### PR TITLE
Disable output colorizing when running in a non-interactive shell

### DIFF
--- a/core/src/main/scala/spinal/core/Misc.scala
+++ b/core/src/main/scala/spinal/core/Misc.scala
@@ -314,7 +314,10 @@ object SpinalExit {
 }
 object SpinalLog{
   def tag(name: String, color: String): String =
-    s"[${color}${name}${Console.RESET}]"
+    if (System.console != null)
+      s"[${color}${name}${Console.RESET}]"
+    else
+      s"[${name}]"
 }
 
 object SpinalInfoPhase {


### PR DESCRIPTION
Prevent seeing strange chars in files and non-interactive consoles ```[[33mRuntime[0m]``` -> ```[Runtime]```