### PR TITLE
Fixed calculation of SDRAM capacity

### DIFF
--- a/lib/src/main/scala/spinal/lib/memory/sdram/Sdram.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/Sdram.scala
@@ -13,7 +13,7 @@ case class SdramLayout( bankWidth : Int,
   def byteAddressWidth = bankWidth + columnWidth + rowWidth + log2Up(bytePerWord)
   def chipAddressWidth = Math.max(columnWidth,rowWidth)
   def bankCount = 1 << bankWidth
-  def capacity = BigInt(byteAddressWidth) << chipAddressWidth
+  def capacity = BigInt(1) << byteAddressWidth
 }
 
 case class SdramTimings(


### PR DESCRIPTION
I am quite sure the calculation is wrong. This should fix it, at least it fixes the tests on miniSpartan6+.