### PR TITLE
BusSlaveFactory Rework

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba3/apb/Apb3SlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/apb/Apb3SlaveFactory.scala
@@ -28,19 +28,34 @@ class Apb3SlaveFactory(bus: Apb3, selId: Int) extends BusSlaveFactoryDelayed{
         when(doWrite){
           for(element <- jobs) element match{
             case element: BusSlaveFactoryWrite   => element.that.assignFromBits(bus.PWDATA(element.bitOffset, element.that.getBitsWidth bits))
-            case element: BusSlaveFactoryOnWrite => element.doThat()
+            case element: BusSlaveFactoryOnWriteAtAddress => element.doThat()
             case _ =>
           }
         }
         when(doRead){
           for(element <- jobs) element match{
             case element: BusSlaveFactoryRead   => bus.PRDATA(element.bitOffset, element.that.getBitsWidth bits) := element.that.asBits
-            case element: BusSlaveFactoryOnRead => element.doThat()
+            case element: BusSlaveFactoryOnReadAtAddress => element.doThat()
             case _ =>
           }
         }
       }
     }
+
+    when(doWrite){
+      for(jobs <- elements) jobs match{
+        case element: BusSlaveFactoryOnWrite => element.doThat()
+        case _ =>
+      }
+    }
+
+    when(doRead){
+      for(jobs <- elements) jobs match{
+        case element: BusSlaveFactoryOnRead => element.doThat()
+        case _ =>
+      }
+    }
+
   }
 
   override def busDataWidth: Int = bus.config.dataWidth

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axilite/AxiLite4SlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axilite/AxiLite4SlaveFactory.scala
@@ -36,7 +36,7 @@ class AxiLite4SlaveFactory(bus : AxiLite4) extends BusSlaveFactoryDelayed{
           //TODO writeRsp.resp := OKAY
           for (element <- jobs) element match {
             case element: BusSlaveFactoryWrite   =>  element.that.assignFromBits(bus.writeData.data(element.bitOffset, element.that.getBitsWidth bits))
-            case element: BusSlaveFactoryOnWrite => element.doThat()
+            case element: BusSlaveFactoryOnWriteAtAddress => element.doThat()
             case _ =>
           }
         }
@@ -49,7 +49,7 @@ class AxiLite4SlaveFactory(bus : AxiLite4) extends BusSlaveFactoryDelayed{
         }
         when(readOccur) {
           for (element <- jobs) element match {
-            case element: BusSlaveFactoryOnRead => element.doThat()
+            case element: BusSlaveFactoryOnReadAtAddress => element.doThat()
             case _ =>
           }
         }

--- a/lib/src/main/scala/spinal/lib/bus/avalon/AvalonMMSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/AvalonMMSlaveFactory.scala
@@ -44,7 +44,7 @@ class AvalonMMSlaveFactory(bus: AvalonMM) extends BusSlaveFactoryDelayed{
         when(bus.write){
           for(element <- jobs) element match{
             case element: BusSlaveFactoryWrite   => element.that.assignFromBits(bus.writeData(element.bitOffset, element.that.getBitsWidth bits))
-            case element: BusSlaveFactoryOnWrite => element.doThat()
+            case element: BusSlaveFactoryOnWriteAtAddress => element.doThat()
             case _ =>
           }
         }
@@ -52,7 +52,7 @@ class AvalonMMSlaveFactory(bus: AvalonMM) extends BusSlaveFactoryDelayed{
         when(bus.read){
           for(element <- jobs) element match{
             case element: BusSlaveFactoryRead   => readAtCmd.payload(element.bitOffset, element.that.getBitsWidth bits) := element.that.asBits
-            case element: BusSlaveFactoryOnRead => element.doThat()
+            case element: BusSlaveFactoryOnReadAtAddress => element.doThat()
             case _ =>
           }
         }

--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -336,7 +336,7 @@ trait BusSlaveFactory extends Area{
   }
 
   /**
-    * Read that and consume the transaction when a read happen at address.
+    * Read that (that is bigger than the busWidth) and consume the transaction when a read happen at address.
     * @note in order to avoid to read wrong data read first the address which contains the
     *       valid signal.
     *       Little : payload - valid at address 0x00
@@ -358,7 +358,22 @@ trait BusSlaveFactory extends Area{
     }else{
       readMultiWord(that.valid ## that.payload, address)
     }
+  }
 
+
+  /**
+    * Read that and consume the transaction when a read happen at address.
+    */
+  def readStreamNonBlocking[T <: Data](that: Stream[T],
+                                       address: BigInt,
+                                       validBitOffset: Int,
+                                       payloadBitOffset: Int): Unit = {
+    that.ready := False
+    onRead(address){
+      that.ready := True
+    }
+    read(that.valid,   address, validBitOffset)
+    read(that.payload, address, payloadBitOffset)
   }
 
 

--- a/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
@@ -118,8 +118,8 @@ class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
 
     //manage interrupts
     val interruptCtrl = new Area {
-      val writeIntEnable = busCtrlWrapped.createReadWrite(Bool, address = 4, 0) init(False)
-      val readIntEnable  = busCtrlWrapped.createReadWrite(Bool, address = 4, 1) init(False)
+      val writeIntEnable = busCtrlWrapped.createReadAndWrite(Bool, address = 4, 0) init(False)
+      val readIntEnable  = busCtrlWrapped.createReadAndWrite(Bool, address = 4, 1) init(False)
       val readInt   = readIntEnable  &  read.stream.valid
       val writeInt  = writeIntEnable & !write.stream.valid
       val interrupt = readInt || writeInt

--- a/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
@@ -107,10 +107,10 @@ class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
       val (stream, fifoOccupancy) = io.read.toStream.queueWithOccupancy(config.rxFifoDepth)
       busCtrl.busDataWidth match {
         case 16 =>
-          busCtrlWrapped.readStreamNonBlocking(stream, address = 0, validBitOffset = 15, payloadBitOffset = 0)
+          busCtrlWrapped.readStreamNonBlocking(stream, address = 0)
           busCtrlWrapped.read(fifoOccupancy,address = 6, 8)
         case 32 =>
-          busCtrlWrapped.readStreamNonBlocking(stream, address = 0, validBitOffset = 16, payloadBitOffset = 0)
+          busCtrlWrapped.readStreamNonBlocking(stream, address = 0)
           busCtrlWrapped.read(fifoOccupancy,address = 4, 24)
       }
       def genCTS(freeThreshold : Int) = RegNext(fifoOccupancy <= config.rxFifoDepth - freeThreshold) init(False)  // freeThreshold => how many remaining space should be in the fifo before allowing transfer

--- a/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
@@ -107,10 +107,10 @@ class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
       val (stream, fifoOccupancy) = io.read.toStream.queueWithOccupancy(config.rxFifoDepth)
       busCtrl.busDataWidth match {
         case 16 =>
-          busCtrlWrapped.readStreamNonBlocking(stream, address = 0)
+          busCtrlWrapped.readStreamNonBlocking(stream, address = 0, validBitOffset = 15, payloadBitOffset = 0)
           busCtrlWrapped.read(fifoOccupancy,address = 6, 8)
         case 32 =>
-          busCtrlWrapped.readStreamNonBlocking(stream, address = 0)
+          busCtrlWrapped.readStreamNonBlocking(stream, address = 0, validBitOffset = 16, payloadBitOffset = 0)
           busCtrlWrapped.read(fifoOccupancy,address = 4, 24)
       }
       def genCTS(freeThreshold : Int) = RegNext(fifoOccupancy <= config.rxFifoDepth - freeThreshold) init(False)  // freeThreshold => how many remaining space should be in the fifo before allowing transfer

--- a/lib/src/main/scala/spinal/lib/graphic/vga/Axi4VgaCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/graphic/vga/Axi4VgaCtrl.scala
@@ -53,7 +53,7 @@ case class Axi4VgaCtrl(g : Axi4VgaCtrlGenerics) extends Component{
 
   val apbCtrl = Apb3SlaveFactory(io.apb)
 
-  val run = apbCtrl.createReadWrite(Bool,0x00) init(False)
+  val run = apbCtrl.createReadAndWrite(Bool,0x00) init(False)
 
 
   val dma  = VideoDma(dmaGenerics)

--- a/lib/src/main/scala/spinal/lib/misc/Timer.scala
+++ b/lib/src/main/scala/spinal/lib/misc/Timer.scala
@@ -28,8 +28,8 @@ case class Timer(width : Int) extends Component{
   def driveFrom(busCtrl : BusSlaveFactory,baseAddress : BigInt)
                (ticks : Seq[Bool],clears : Seq[Bool]) = new Area {
     //Address 0 => clear/tick masks + bus
-    val ticksEnable  = busCtrl.createReadWrite(Bits(ticks.length bits) ,baseAddress + 0,0) init(0)
-    val clearsEnable = busCtrl.createReadWrite(Bits(clears.length bits),baseAddress + 0,16) init(0)
+    val ticksEnable  = busCtrl.createReadAndWrite(Bits(ticks.length bits) ,baseAddress + 0,0) init(0)
+    val clearsEnable = busCtrl.createReadAndWrite(Bits(clears.length bits),baseAddress + 0,16) init(0)
     val busClearing  = False
 
     //Address 4 => read/write limit (+ auto clear)

--- a/tester/src/main/scala/spinal/tester/code/Play2.scala
+++ b/tester/src/main/scala/spinal/tester/code/Play2.scala
@@ -1310,7 +1310,7 @@ object PlayI2CHALTest{
 
     busCtrl.driveAndRead(masterI2C.io.config,    0x00)
     busCtrl.createAndDriveFlow(I2CMasteHALCmd(masterI2CGeneric), 0x04).toStream >-> masterI2C.io.cmd
-    busCtrl.readStreamNonBlocking(masterStreamRSP, address = 0x0C, validBitOffset=0, payloadBitOffset=1)
+    busCtrl.readStreamNonBlocking(masterStreamRSP, address = 0x0C)
     busCtrl.readAndWrite (masterStatusCMD, 0x08)
     //  busCtrl.readAndWrite (masterStatusRSP, 0x0C)
 

--- a/tester/src/main/scala/spinal/tester/code/Play2.scala
+++ b/tester/src/main/scala/spinal/tester/code/Play2.scala
@@ -1310,7 +1310,7 @@ object PlayI2CHALTest{
 
     busCtrl.driveAndRead(masterI2C.io.config,    0x00)
     busCtrl.createAndDriveFlow(I2CMasteHALCmd(masterI2CGeneric), 0x04).toStream >-> masterI2C.io.cmd
-    busCtrl.readStreamNonBlocking(masterStreamRSP, address = 0x0C)
+    busCtrl.readStreamNonBlocking(masterStreamRSP, address = 0x0C, validBitOffset=0, payloadBitOffset=1)
     busCtrl.readAndWrite (masterStatusCMD, 0x08)
     //  busCtrl.readAndWrite (masterStatusRSP, 0x0C)
 

--- a/tester/src/main/scala/spinal/tester/code/Play3.scala
+++ b/tester/src/main/scala/spinal/tester/code/Play3.scala
@@ -996,7 +996,7 @@ object PlayPatch{
               baseAddress : BigInt)
              (width     : Int = 16,
               lowActive : Bool = False): Bits ={
-      val leds = busCtrl.createReadWrite(Bits(width bits),baseAddress) init(0)
+      val leds = busCtrl.createReadAndWrite(Bits(width bits),baseAddress) init(0)
       return lowActive ? ~leds | leds
     }
   }

--- a/tester/src/main/scala/spinal/tester/code/Presentation.scala
+++ b/tester/src/main/scala/spinal/tester/code/Presentation.scala
@@ -1484,7 +1484,7 @@ object c666{
     // Take uartCtrl.io.read, convert it into a Stream, then connect it to the input of a FIFO of 64 elements
     // Then make the output of the FIFO readable at the address 12 by using a non blocking protocol
     // (bit 0 => data valid, bits 8 downto 1 => data)
-    busCtrl.readStreamNonBlocking(uartCtrl.io.read.toStream.queue(rxFifoDepth),address = 12,validBitOffset = 31,payloadBitOffset = 0)
+    busCtrl.readStreamNonBlocking(uartCtrl.io.read.toStream.queue(rxFifoDepth),address = 12)
   }
 
 
@@ -1556,7 +1556,7 @@ object c666{
     // Then make the output of the FIFO readable at the address 12 by using a non blocking protocol
     // (bit 31 => data valid, bits 7 downto 0 => data)
     val readStream = uartCtrl.io.read.toStream.queue(rxFifoDepth)
-    busCtrl.readStreamNonBlocking(readStream,address = 12,validBitOffset = 31,payloadBitOffset = 0)
+    busCtrl.readStreamNonBlocking(readStream,address = 12)
   }
 }
 
@@ -1581,7 +1581,7 @@ object c6669{
     //Make writeBusy register
     busCtrl.read(uartCtrl.io.write.valid,address = 8)
     //Make read register
-    busCtrl.readStreamNonBlocking(uartCtrl.io.read.toStream.queue(rxFifoDepth),address = 12,validBitOffset = 31,payloadBitOffset = 0)
+    busCtrl.readStreamNonBlocking(uartCtrl.io.read.toStream.queue(rxFifoDepth),address = 12)
   }
 }
 

--- a/tester/src/main/scala/spinal/tester/code/Presentation.scala
+++ b/tester/src/main/scala/spinal/tester/code/Presentation.scala
@@ -478,9 +478,9 @@ object C11 {
     .probe(somewhere.signalC)
     .build
 
-//    val uartCtrl = new UartCtrl()
-//    uartCtrl.io.read >> logicAnalyser.io.slavePort
-//    uartCtrl.io.write << logicAnalyser.io.masterPort
+  //    val uartCtrl = new UartCtrl()
+  //    uartCtrl.io.read >> logicAnalyser.io.slavePort
+  //    uartCtrl.io.write << logicAnalyser.io.masterPort
 }
 
 object C12 {
@@ -867,41 +867,41 @@ object t8_a {
     // some logic ..
   }
 
-//  class ApbUartCtrl(apbConfig: Apb3Config) extends Component {
-//    val io = new Bundle {
-//      val bus = slave(new Apb3(apbConfig))
-//      val uart = master(Uart())
-//    }
-//    val busCtrl = new Apb3SlaveController(io.bus) //This is a APB3 slave controller builder tool
-//
-//    val config = busCtrl.writeOnlyRegOf(UartCtrlConfig(), 0x10) //Create a write only configuration register at address 0x10
-//    val writeStream = busCtrl.writeStreamOf(Bits(8 bit), 0x20)
-//    val readStream = busCtrl.readStreamOf(Bits(8 bit), 0x30)
-//
-//    val uartCtrl = new UartCtrl()
-//    uartCtrl.io.config := config
-//    uartCtrl.io.write <-< writeStream //Pipelined connection
-//    uartCtrl.io.read.toStream.queue(16) >> readStream  //Queued connection
-//    uartCtrl.io.uart <> io.uart
-//  }
+  //  class ApbUartCtrl(apbConfig: Apb3Config) extends Component {
+  //    val io = new Bundle {
+  //      val bus = slave(new Apb3(apbConfig))
+  //      val uart = master(Uart())
+  //    }
+  //    val busCtrl = new Apb3SlaveController(io.bus) //This is a APB3 slave controller builder tool
+  //
+  //    val config = busCtrl.writeOnlyRegOf(UartCtrlConfig(), 0x10) //Create a write only configuration register at address 0x10
+  //    val writeStream = busCtrl.writeStreamOf(Bits(8 bit), 0x20)
+  //    val readStream = busCtrl.readStreamOf(Bits(8 bit), 0x30)
+  //
+  //    val uartCtrl = new UartCtrl()
+  //    uartCtrl.io.config := config
+  //    uartCtrl.io.write <-< writeStream //Pipelined connection
+  //    uartCtrl.io.read.toStream.queue(16) >> readStream  //Queued connection
+  //    uartCtrl.io.uart <> io.uart
+  //  }
 }
 
 
 object t8_B2 {
-//
-//  class ApbUartCtrl(apbConfig: Apb3Config) extends Component {
-//    val io = new Bundle {
-//      val apb = slave(new Apb3(apbConfig))
-//      val uart = master(Uart())
-//    }
-//    val uartCtrl = new UartCtrl()
-//    uartCtrl.io.uart <> io.uart
-//
-//    val busCtrl = new Apb3SlaveController(io.apb)
-//    busCtrl.writeOnlyRegOf(uartCtrl.io.config, 0x10)
-//    busCtrl.writeStream(uartCtrl.io.write, 0x20)
-//    busCtrl.readStream(uartCtrl.io.read.toStream.queue(16), 0x30)
-//  }
+  //
+  //  class ApbUartCtrl(apbConfig: Apb3Config) extends Component {
+  //    val io = new Bundle {
+  //      val apb = slave(new Apb3(apbConfig))
+  //      val uart = master(Uart())
+  //    }
+  //    val uartCtrl = new UartCtrl()
+  //    uartCtrl.io.uart <> io.uart
+  //
+  //    val busCtrl = new Apb3SlaveController(io.apb)
+  //    busCtrl.writeOnlyRegOf(uartCtrl.io.config, 0x10)
+  //    busCtrl.writeStream(uartCtrl.io.write, 0x20)
+  //    busCtrl.readStream(uartCtrl.io.read.toStream.queue(16), 0x30)
+  //  }
 
 }
 
@@ -978,7 +978,7 @@ object t12 {
 
 object t13 {
   val normalVec = Vec(UInt(4 bit), 10)
-//  val variableVec = Vec(UInt(5 bit), UInt(9 bit), UInt(16 bit))
+  //  val variableVec = Vec(UInt(5 bit), UInt(9 bit), UInt(16 bit))
 
   val containZero = normalVec.sContains(0)
   val existOne = normalVec.sExist(_ === 1)
@@ -1086,9 +1086,9 @@ import spinal.core._
 class AND_Gate extends Component {
 
   /**
-   * This is the component definition that corresponds to
-   * the VHDL entity of the component
-   */
+    * This is the component definition that corresponds to
+    * the VHDL entity of the component
+    */
   val io = new Bundle {
     val a = in Bool
     val b = in Bool
@@ -1175,8 +1175,8 @@ object RgbToGray{
     def coef(value : UInt,by : Float) : UInt = (value * U((255*by).toInt,8 bits) >> 8)
     val gray = RegNext(
       coef(io.r,0.3f) +
-      coef(io.g,0.4f) +
-      coef(io.b,0.3f)
+        coef(io.g,0.4f) +
+        coef(io.b,0.3f)
     )
 
     val address = CounterFreeRun(stateCount = 1 << 16)
@@ -1207,8 +1207,8 @@ object RgbToGray2{
 
   //Calculate the gray level
   val gray = coefMul(r,0.3f) +
-             coefMul(g,0.4f) +
-             coefMul(b,0.3f)
+    coefMul(g,0.4f) +
+    coefMul(b,0.3f)
 
 
   class RgbToGray extends Component{
@@ -1226,8 +1226,8 @@ object RgbToGray2{
 
     val gray = RegNext(
       coef(io.r,0.3f) +
-      coef(io.g,0.4f) +
-      coef(io.b,0.3f)
+        coef(io.g,0.4f) +
+        coef(io.b,0.3f)
     )
 
     val address = Reg(UInt(8 bits)) init(0)
@@ -1484,7 +1484,7 @@ object c666{
     // Take uartCtrl.io.read, convert it into a Stream, then connect it to the input of a FIFO of 64 elements
     // Then make the output of the FIFO readable at the address 12 by using a non blocking protocol
     // (bit 0 => data valid, bits 8 downto 1 => data)
-    busCtrl.readStreamNonBlocking(uartCtrl.io.read.toStream.queue(rxFifoDepth),address = 12)
+    busCtrl.readStreamNonBlocking(uartCtrl.io.read.toStream.queue(rxFifoDepth),address = 12,validBitOffset = 31,payloadBitOffset = 0)
   }
 
 
@@ -1556,7 +1556,7 @@ object c666{
     // Then make the output of the FIFO readable at the address 12 by using a non blocking protocol
     // (bit 31 => data valid, bits 7 downto 0 => data)
     val readStream = uartCtrl.io.read.toStream.queue(rxFifoDepth)
-    busCtrl.readStreamNonBlocking(readStream,address = 12)
+    busCtrl.readStreamNonBlocking(readStream,address = 12,validBitOffset = 31,payloadBitOffset = 0)
   }
 }
 
@@ -1581,7 +1581,7 @@ object c6669{
     //Make writeBusy register
     busCtrl.read(uartCtrl.io.write.valid,address = 8)
     //Make read register
-    busCtrl.readStreamNonBlocking(uartCtrl.io.read.toStream.queue(rxFifoDepth),address = 12)
+    busCtrl.readStreamNonBlocking(uartCtrl.io.read.toStream.queue(rxFifoDepth),address = 12,validBitOffset = 31,payloadBitOffset = 0)
   }
 }
 
@@ -1645,18 +1645,18 @@ object c9482 {
 
 
 object CheatSheet{
-//  object myEnum extends SpinalEnum([encoding]){
-//    val IDLE, STATE1 = newElement()
-//  }
-object State extends SpinalEnum{
+  //  object myEnum extends SpinalEnum([encoding]){
+  //    val IDLE, STATE1 = newElement()
+  //  }
+  object State extends SpinalEnum{
 
     val IDLE, S0,S1,S2 = newElement()
   }
 
-//  val myBool = Bool(4 < 2 )
+  //  val myBool = Bool(4 < 2 )
   val myBool = True
   val myUInt = U(13, 32 bits)
-//  val myBits = B"8'hA3" // h,d,b,x,o
+  //  val myBits = B"8'hA3" // h,d,b,x,o
   val myBits = B"0110"
   val itMatch = myBits === M"00--10--"
 
@@ -1865,8 +1865,8 @@ object PlayRgbToGray34{
 
   //Calculate the gray level
   val gray = coefMul(r, 0.3f) +
-             coefMul(g, 0.4f) +
-             coefMul(b, 0.3f)
+    coefMul(g, 0.4f) +
+    coefMul(b, 0.3f)
 }
 
 
@@ -1923,7 +1923,7 @@ object TrololOOP{
 object SementicAA{
   val inc, clear = Bool
   val counter = Reg(UInt(8 bits))
-  
+
   when(inc){
     counter := counter + 1
   }


### PR DESCRIPTION
- Fix issue on write/read multiword dataRange
- Add new functions (onWrite, onRead, createReadOnly, createReadAndWrite, driveAndReadMultiWord, createReadMultiWord)
- Remove onReadCondition and onWriteCondition
- readStreamNonBlock and driveFlow support payload that are bigger than the bus data length 