### PR TITLE
FSM boot state should be first state in enum

### DIFF
--- a/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
+++ b/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
@@ -188,7 +188,11 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated{
 //  override def goto(state: SpinalEnumElement[StateMachineEnum]): Unit = ??? //stateNext := state
 
   override def add(state: State): Int = {
-    states += state
+    if (state.isInstanceOf[StateBoot]) {
+      states.+=:(state)
+    } else {
+      states += state
+    }
     states.length-1
   }
   override def add(stateMachine : StateMachineAccessor) : Unit = {


### PR DESCRIPTION
FSM boot state should be first state in enum for optimal synthesis on devices.
Without this fix initial FSM state was: StateReg and StateNext = first enum element which is not boot state, but state created first in Scala code (it can be even not the Entry state).
This change fix synthesis warnings at least for Spartan 6 FPGAs.
This also fix post-synthesis, post-map and post-PAR simulations.
