### PR TITLE
Blackbox io ports fix

### DIFF
--- a/core/src/main/scala/spinal/core/BlackBox.scala
+++ b/core/src/main/scala/spinal/core/BlackBox.scala
@@ -154,6 +154,21 @@ abstract class BlackBox extends Component with SpinalTagReady {
 
   /** Replace std_logic by std_ulogic */
   def replaceStdLogicByStdULogic = this.addTag(uLogic)
+
+  /** Keep all in/out signals */
+  def keepAllIo() : this.type = {
+    val io = reflectIo
+    if(io != null) {
+      io.keep()
+    }
+    this
+  }
+
+  /** Initialization class delay */
+  override def delayedInit(body: => Unit) = {
+    super.delayedInit(body)
+    keepAllIo()
+  }
 }
 
 

--- a/core/src/main/scala/spinal/core/PhaseVhdl.scala
+++ b/core/src/main/scala/spinal/core/PhaseVhdl.scala
@@ -1698,6 +1698,8 @@ class PhaseVhdl(pc : PhaseContext) extends PhaseMisc with VhdlBase {
           val bind = component.kindsOutputsToBindings.getOrElse(data, null)
           if (bind != null) {
             ret ++= addULogicCast(data, emitReference(data), emitReference(bind), data.dir)
+          } else {
+            ret ++= addULogicCast(data, emitReference(data), s"open", data.dir)
           }
         }
         else if (data.isInput)


### PR DESCRIPTION
Keep all io signals for Blackbox - they should not be optimized away
Map unused out ports in VHDL generation to "open".
Probably same fix should be done for Verilog backend