### PR TITLE
Change coding style of Verilog to case(1) with parallel_case #145

### DIFF
--- a/core/src/main/scala/spinal/core/Enum.scala
+++ b/core/src/main/scala/spinal/core/Enum.scala
@@ -318,7 +318,7 @@ object binarySequential extends SpinalEnumEncoding{
 
 /**
   * Binary One hot encoding
-  * @example{{{ 000, 010, 100 }}}
+  * @example{{{ 001, 010, 100 }}}
   */
 object binaryOneHot extends SpinalEnumEncoding{
   override def getWidth(enum: SpinalEnum): Int = enum.elements.length


### PR DESCRIPTION
This allows the special case of a binaryOneHot encoding to be encoded with best synthesis results

- [ ] compiled
- [ ] tested