### PR TITLE
Prohibit BusSlaveFactory to assign reads to the same bit more than once

### DIFF
--- a/tester/src/main/scala/spinal/tester/PlayDev.scala
+++ b/tester/src/main/scala/spinal/tester/PlayDev.scala
@@ -3,7 +3,7 @@ package spinal.tester
 import spinal.core._
 import spinal.core.internals._
 import spinal.lib._
-import spinal.lib.bus.amba3.apb.{Apb3, Apb3Gpio, Apb3SlaveFactory}
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config, Apb3Gpio, Apb3SlaveFactory}
 import spinal.lib.bus.amba4.axi.{Axi4Config, Axi4Shared}
 import spinal.lib.bus.amba4.axilite.{AxiLite4, AxiLite4SpecRenamer}
 import spinal.lib.com.i2c._
@@ -1305,4 +1305,28 @@ object PlayNamingImprovment extends App{
 
 }
 
+object PlayDevBusSlaveFactoryDoubleRead{
+  class TestTopLevelDut extends Component {
 
+    val io = new Bundle {
+      val bus = slave(Apb3(Apb3Config(32, 32, 1, false)))
+      val dummy_r_0 = in Bits (16 bits)
+      val dummy_r_1 = in Bits (16 bits)
+      val dummy_w_0 = out Bits (16 bits)
+      val dummy_w_1 = out Bits (16 bits)
+    }
+
+    val factory = new Apb3SlaveFactory(io.bus, selId = 0)
+
+    factory.read(io.dummy_r_0, 0x03, 0)
+    factory.read(io.dummy_r_1, 0x03, 16)
+    factory.drive(io.dummy_w_0, 0x00, 0)
+    factory.drive(io.dummy_w_1, 0x00, 8)
+
+  }
+
+  def main(args: Array[String]) {
+    val config = SpinalConfig()
+    config.generateVerilog(new TestTopLevelDut())
+  }
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryDoubleRead.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryDoubleRead.scala
@@ -1,0 +1,45 @@
+package spinal.tester.scalatest
+
+import org.scalatest.{FunSuite, Assertions}
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb._
+
+
+object TestTopLevel {
+
+  class TestTopLevelDut extends Component {
+
+    val io = new Bundle {
+      val bus = slave(Apb3(Apb3Config(32, 32, 1, false)))
+      val dummy_r_0 = in Bits (32 bits)
+      val dummy_r_1 = in Bits (16 bits)
+    }
+
+    val factory = new Apb3SlaveFactory(io.bus, selId = 0)
+
+    factory.read(io.dummy_r_0, 0x00, 0)
+    factory.read(io.dummy_r_1, 0x00, 8)
+
+  }
+
+}
+
+class BusSlaveFactoryDoubleReadTester extends FunSuite {
+
+  test("BusSlaveFactoryDoubleRead") {
+
+    val caught = Assertions.intercept[spinal.core.SpinalExit](
+      SpinalConfig(
+        targetDirectory = "/dev",
+        netlistFileName = "null"
+      ).generateVhdl(
+        new TestTopLevel.TestTopLevelDut()
+      )
+    )
+
+    assert(caught.toString.contains("HIERARCHY VIOLATION"),
+      "SpinalHDL compilation did not throw a HIERARCHY VIOLATION where there should have been one!")
+  }
+}
+

--- a/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryDoubleRead.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryDoubleRead.scala
@@ -8,11 +8,11 @@ import spinal.lib.bus.amba3.apb._
 
 object TestTopLevel {
 
-  class TestTopLevelDut extends Component {
+  class DoubleReadDut extends Component {
 
     val io = new Bundle {
       val bus = slave(Apb3(Apb3Config(32, 32, 1, false)))
-      val dummy_r_0 = in Bits (32 bits)
+      val dummy_r_0 = in Bits (16 bits)
       val dummy_r_1 = in Bits (16 bits)
     }
 
@@ -23,23 +23,42 @@ object TestTopLevel {
 
   }
 
+  class DoubleWriteDut extends Component {
+
+    val io = new Bundle {
+      val bus = slave(Apb3(Apb3Config(32, 32, 1, false)))
+      val dummy_w_0 = out Bits (16 bits)
+      val dummy_w_1 = out Bits (16 bits)
+    }
+
+    val factory = new Apb3SlaveFactory(io.bus, selId = 0)
+
+    factory.drive(io.dummy_w_0, 0x00, 0)
+    factory.drive(io.dummy_w_1, 0x00, 8)
+
+  }
+
 }
 
 class BusSlaveFactoryDoubleReadTester extends FunSuite {
 
   test("BusSlaveFactoryDoubleRead") {
 
-    val caught = Assertions.intercept[spinal.core.SpinalExit](
-      SpinalConfig(
-        targetDirectory = "/dev",
-        netlistFileName = "null"
-      ).generateVhdl(
-        new TestTopLevel.TestTopLevelDut()
+    val caught = Assertions.intercept[java.lang.AssertionError](
+      SpinalConfig().generateVhdl(
+        new TestTopLevel.DoubleReadDut()
       )
     )
 
-    assert(caught.toString.contains("HIERARCHY VIOLATION"),
-      "SpinalHDL compilation did not throw a HIERARCHY VIOLATION where there should have been one!")
+    assert(caught.toString.contains("DOUBLE-READ-ERROR"),
+      "SpinalHDL compilation did not throw a DOUBLE-READ-ERROR where there should have been one!")
+  }
+
+  test("BusSlaveFactoryDoubleWrite") {
+    // test that no error is thrown on double write access
+    SpinalConfig().generateVhdl(
+      new TestTopLevel.DoubleWriteDut()
+    )
   }
 }
 


### PR DESCRIPTION
This small PR fixes issue #130.

An additional check in BusSlaveFactoryDelayed is implemented to assert that on any read command, no bit on the bus read line is assigned multiple times.

There is also a unit test for this case.