### PR TITLE
Fix AXI4 incr address for INCR and WRAP case SpinalHDL/SpinalHDL#169

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
@@ -237,8 +237,9 @@ object Axi4{
     val area = new Area {
       val result = UInt(address.getWidth bits)
       val highCat = if (address.getWidth > 12) address(address.high downto 12) else U""
-      val sizeValue = (0 to bytePerWord).map(idx => idx === size).asBits.asUInt
-      val base = address(Math.min(12, address.getWidth) - 1 downto 0).resize(12)
+      val sizeValue = (0 to log2Up(bytePerWord)).map(idx => idx === size).asBits.asUInt // U(1) << size
+      val alignMask = (sizeValue - 1).resize(12)
+      val base = address(Math.min(12, address.getWidth) - 1 downto 0).resize(12) & ~alignMask
       val baseIncr = base + sizeValue
       val wrapCaseMax = 3 + log2Up(bytePerWord)
       val wrapCaseWidth = log2Up(wrapCaseMax + 1)


### PR DESCRIPTION
I think that the range for the ```sizeValue``` was off-by-log (instead of off-by-one) XD

Also we could simply describe it as ```U(1) << size``` … is that less efficient than the complicated manual map? I kept it as it was but I’d rather go with the more straight-forward solution of the direct shift.

The ```alignMask``` uses a simple subtraction from the sizeValue but a map could be more efficient?