### PR TITLE
lib: misc: mtimer: Add MachineTimer

### DIFF
--- a/lib/src/main/scala/spinal/lib/misc/mtimer/MachineTimer.scala
+++ b/lib/src/main/scala/spinal/lib/misc/mtimer/MachineTimer.scala
@@ -1,0 +1,52 @@
+package spinal.lib.misc.mtimer
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc._
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.avalon._
+import spinal.lib.bus.wishbone._
+
+
+object MachineTimer {
+  class Core[T <: spinal.core.Data with IMasterSlave](
+    p: MachineTimerCtrl.Parameter,
+    busType: HardType[T],
+    factory: T => BusSlaveFactory
+  ) extends Component {
+    val io = new Bundle {
+      val bus = slave(busType())
+      val interrupt = out(Bool)
+    }
+
+    val ctrl = MachineTimerCtrl(factory(io.bus), p)
+    io.interrupt := ctrl.io.interrupt
+  }
+}
+
+case class Apb3MachineTimer(
+  parameter: MachineTimerCtrl.Parameter,
+  busConfig: Apb3Config = Apb3Config(12, 32)
+) extends MachineTimer.Core[Apb3] (
+  parameter,
+  Apb3(busConfig),
+  Apb3SlaveFactory(_)
+) { val dummy = 0 }
+
+case class WishboneMachineTimer(
+  parameter: MachineTimerCtrl.Parameter,
+  busConfig: WishboneConfig = WishboneConfig(12, 32)
+) extends MachineTimer.Core[Wishbone] (
+  parameter,
+  Wishbone(busConfig),
+  WishboneSlaveFactory(_)
+) { val dummy = 0 }
+
+case class AvalonMMMachineTimer(
+  parameter: MachineTimerCtrl.Parameter,
+  busConfig: AvalonMMConfig = AvalonMMConfig.fixed(12, 32, 1)
+) extends MachineTimer.Core[AvalonMM] (
+  parameter,
+  AvalonMM(busConfig),
+  AvalonMMSlaveFactory(_)
+) { val dummy = 0 }

--- a/lib/src/main/scala/spinal/lib/misc/mtimer/MachineTimerCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/misc/mtimer/MachineTimerCtrl.scala
@@ -1,0 +1,40 @@
+package spinal.lib.misc.mtimer
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+
+
+object MachineTimerCtrl {
+  def apply(busCtrl: BusSlaveFactory, p: Parameter = Parameter.default) = MachineTimerCtrl(busCtrl, p)
+
+  case class Parameter(
+    width: Int
+  ) {
+    assert(width > 32, "MachineTimer needs two compare registers. Timer width should be more than 32.")
+  }
+  object Parameter {
+    def default = Parameter(64)
+    def lightweight = Parameter(40)
+  }
+
+  case class Io(p: Parameter) extends Bundle {
+    val interrupt = out(Bool)
+  }
+
+  case class MachineTimerCtrl(
+    busCtrl: BusSlaveFactory,
+    p: Parameter
+  ) extends Area {
+    val io = Io(p)
+
+    val counter = Reg(UInt(p.width bits)) init(0)
+    val compare = Reg(UInt(p.width bits))
+    val hit = RegNext(!(counter - compare).msb)
+    counter := counter + 1
+    io.interrupt := hit
+
+    busCtrl.readMultiWord(counter, 0x0)
+    busCtrl.writeMultiWord(compare, 0x8)
+  }
+}


### PR DESCRIPTION
Some points I would like to have feedback to:
* I removed the 'Ctrl' from the bus components and only added it to the controller itself. I'm not sure if you need this suffix for bus components in e.g. SoC-files. I also wrote-out the shortcut for Ctrl...
* Added a 'connection' case class:
`case class MachineTimerControllerConnection(parameter: MachineTimerParameter) extends Bundle {
    val counter = out UInt(64 bits)
    val clear = in Bool
}
...
val io = new Bundle {
    val storage = in(MachineTimerControllerStorage(parameter))
    val connection = MachineTimerControllerConnection(parameter)
    val interrupt = out Bool
  }
`