### PR TITLE
Rise/Fall -> Rose/Fell

### DIFF
--- a/core/src/main/scala/spinal/core/Formal.scala
+++ b/core/src/main/scala/spinal/core/Formal.scala
@@ -6,8 +6,8 @@ object Formal {
   def past[T <: Data](that : T, delay : Int) : T = that.formalPast(delay)
   def past[T <: Data](that : T) : T = past(that, 1)
 
-  def rise(that : Bool) : Bool = that.wrapUnaryOperator(new Operator.Formal.Rise)
-  def fall(that : Bool) : Bool = that.wrapUnaryOperator(new Operator.Formal.Fall)
+  def rose(that : Bool) : Bool = that.wrapUnaryOperator(new Operator.Formal.Rose)
+  def fell(that : Bool) : Bool = that.wrapUnaryOperator(new Operator.Formal.Fell)
   def changed[T <: BaseType](that : T) : Bool = that.wrapUnaryWithBool(new Operator.Formal.Changed)
   def stable[T <: BaseType](that : T) : Bool = that.wrapUnaryWithBool(new Operator.Formal.Stable)
   def initstate() : Bool = {

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -1364,9 +1364,9 @@ end
     case  e: BitVectorRangedAccessFloating            => accessBitVectorFloating(e)
 
     case e : Operator.Formal.Past                     => s"$$past(${emitExpression(e.source)}, ${e.delay})"
-    case e : Operator.Formal.Rise                     => s"$$rise(${emitExpression(e.source)})"
-    case e : Operator.Formal.Fall                     => s"$$rise(${emitExpression(e.source)})"
-    case e : Operator.Formal.Changed                  => s"$$changed(${emitExpression(e.source)})"
+    case e : Operator.Formal.Rose                     => s"$$rose(${emitExpression(e.source)})"
+    case e : Operator.Formal.Fell                     => s"$$fell(${emitExpression(e.source)})"
+    case e : Operator.Formal.Changed                  => s"!$$stable(${emitExpression(e.source)})"
     case e : Operator.Formal.Stable                   => s"$$stable(${emitExpression(e.source)})"
     case e : Operator.Formal.InitState                => s"$$initstate()"
   }

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -315,13 +315,13 @@ object Operator {
     }
 
 
-    class Rise extends UnaryOperator{
-      override def opName: String = "$rise(Bool)"
+    class Rose extends UnaryOperator{
+      override def opName: String = "$rose(Bool)"
       override def getTypeObject: Any = TypeBool
     }
 
-    class Fall extends UnaryOperator{
-      override def opName: String = "$rise(Bool)"
+    class Fell extends UnaryOperator{
+      override def opName: String = "$fell(Bool)"
       override def getTypeObject: Any = TypeBool
     }
 
@@ -329,13 +329,13 @@ object Operator {
 
     class Changed extends UnaryOperator{
       override def getTypeObject = TypeBool
-      override def opName: String = "$changed(...)"
+      override def opName: String = "!$stable(...)"
     }
 
 
     class Stable extends UnaryOperator{
       override def getTypeObject = TypeBool
-      override def opName: String = "$changed(...)"
+      override def opName: String = "$stable(...)"
     }
 
     class InitState extends Expression{

--- a/tester/src/main/scala/spinal/tester/PlayDev.scala
+++ b/tester/src/main/scala/spinal/tester/PlayDev.scala
@@ -1203,8 +1203,8 @@ object PlayAssertFormal extends App {
     GenerationFlags.formal{
       import spinal.core.Formal._
 //      val a = past(B"1010")
-      val b = rise(False)
-      val c = fall(False)
+      val b = rose(False)
+      val c = fell(False)
       val d = changed(False)
       val f = stable(False)
       val g = initstate()


### PR DESCRIPTION
Resubmit of earlier patch (that might have had integration issues).

Change Rise/Fall -> Rose/Fell and $rise/$fall -> $rose/$fell to mimic the SystemVerilog names. $rise/$fall is essentially syntax error.

Also changed $changed to !$stable because $changed is not a support SystemVerilog name either.

Tom
