### PR TITLE
Fix wishbone decoder

### DIFF
--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneArbiterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneArbiterTester.scala
@@ -21,7 +21,7 @@ class WishboneArbiterComponent(config : WishboneConfig,size: Int) extends Compon
 
 class SpinalSimWishboneArbiterTester extends FunSuite{
   def testArbiter(config : WishboneConfig,size: Int,description : String = ""): Unit = {
-    val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneArbiterComponent(config,size))
+    val fixture = SimConfig.allOptimisation.withWave.compile(rtl = new WishboneArbiterComponent(config,size))
     fixture.doSim(description){ dut =>
       dut.clockDomain.forkStimulus(period=10)
       dut.io.busIN.foreach{ bus =>
@@ -78,22 +78,32 @@ class SpinalSimWishboneArbiterTester extends FunSuite{
   }
 
   test("classicWishboneArbiter"){
-    val size = 100
+    val size = 20
     val config = WishboneConfig(32,8)
-    testArbiter(config,20,"classicWishboneArbiter")
+    testArbiter(config,size,"classicWishboneArbiter")
   }
 
 
   test("pipelinedWishboneArbiter"){
-    val size = 100
+    val size = 20
     val config = WishboneConfig(32,8).pipelined
-    testArbiter(config,20,"pipelinedWishboneArbiter")
+    testArbiter(config,size,"pipelinedWishboneArbiter")
   }
 
   test("classicWishboneArbiterSEL"){
-    val size = 100
+    val size = 20
     val config = WishboneConfig(32,8,selWidth = 2,useERR = true,useLOCK = true)
-    testArbiter(config,20,"classicWishboneArbiterSEL")
+    testArbiter(config,size,"classicWishboneArbiterSEL")
+  }
+
+  test("WishboneArbiterBug"){
+    val size = 2
+    val config = WishboneConfig(addressWidth=32,
+                                dataWidth=8,
+                                // selWidth=2,
+                                useRTY=true)
+                                // useERR=true)
+    testArbiter(config,size,"WishboneArbiterBug")
   }
   // test("pipelinedWishboneDecoder"){
   //   val size = 100

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
@@ -22,7 +22,7 @@ class WishboneDecoderComponent(config : WishboneConfig,decodings : Seq[SizeMappi
 
 class SpinalSimWishboneDecoderTester extends FunSuite{
   def testDecoder(config : WishboneConfig,decodings : Seq[SizeMapping],description : String = ""): Unit = {
-    val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneDecoderComponent(config,decodings))
+    val fixture = SimConfig.allOptimisation.withWave.compile(rtl = new WishboneDecoderComponent(config,decodings))
     fixture.doSim(description){ dut =>
       dut.clockDomain.forkStimulus(period=10)
       dut.io.busIN.CYC #= false
@@ -87,5 +87,12 @@ class SpinalSimWishboneDecoderTester extends FunSuite{
     val config = WishboneConfig(32,8).pipelined
     val decodings = for(i <- 1 to 20) yield SizeMapping(i*size,size-1)
     testDecoder(config,decodings,"pipelinedWishboneDecoder")
+  }
+
+  test("DecoderSelectorBug"){
+    val size = 2
+    val config = WishboneConfig(32,16)
+    val decodings = List(SizeMapping(0x2000,12 Bytes),SizeMapping(0x1000, 12 Bytes))
+    testDecoder(config,decodings,"DecoderSelectorBug")
   }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
@@ -9,6 +9,7 @@ import spinal.lib.bus.misc._
 import spinal.lib.bus.wishbone._
 import spinal.lib.wishbone.sim._
 import spinal.lib.sim._
+import scala.util.Random
 
 class WishboneDecoderComponent(config : WishboneConfig,decodings : Seq[SizeMapping]) extends Component{
   val io = new Bundle{
@@ -39,10 +40,9 @@ class SpinalSimWishboneDecoderTester extends FunSuite{
       SimTimeout(1000*10000)
       val sco = ScoreboardInOrder[WishboneTransaction]()
       val dri = new WishboneDriver(dut.io.busIN, dut.clockDomain)
-      val maxAddr = 2099
 
       val seq = WishboneSequencer{
-        WishboneTransaction().randomizeAddress(maxAddr).randomizeData(200)
+        WishboneTransaction().randomAdressInRange(Random.shuffle(decodings).head).randomizeData(Math.pow(2,config.dataWidth).toInt-1)
       }
 
       val monIN = WishboneMonitor(dut.io.busIN, dut.clockDomain){ bus =>
@@ -90,7 +90,6 @@ class SpinalSimWishboneDecoderTester extends FunSuite{
   }
 
   test("DecoderSelectorBug"){
-    val size = 2
     val config = WishboneConfig(32,16)
     val decodings = List(SizeMapping(0x2000,12 Bytes),SizeMapping(0x1000, 12 Bytes))
     testDecoder(config,decodings,"DecoderSelectorBug")

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimInterconTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimInterconTester.scala
@@ -121,4 +121,12 @@ class SpinalSimWishboneSimInterconTester extends FunSuite{
     testIntercon(config,decodings,masters,"pipelinedWishboneDecoder")
   }
 
+  test("InterconSelectorBug"){
+    val masters = 1
+    val slaves = 2
+    val config = WishboneConfig(32,16)
+    val decodings = List(SizeMapping(0x2000,12 Bytes),SizeMapping(0x1000, 12 Bytes))
+    testIntercon(config,decodings,masters,"InterconSelectorBug")
+  }
+
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimInterconTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimInterconTester.scala
@@ -122,7 +122,7 @@ class SpinalSimWishboneSimInterconTester extends FunSuite{
   }
 
   test("InterconSelectorBug"){
-    val masters = 1
+    val masters = 2
     val slaves = 2
     val config = WishboneConfig(32,16)
     val decodings = List(SizeMapping(0x2000,12 Bytes),SizeMapping(0x1000, 12 Bytes))


### PR DESCRIPTION
This PR will fix a bug in the wishbone decoder logic

The wishbone arbiter (and consequently the intercon) will suffer from the same problem.

TODO:
- [x] Add to the decoder unitest the case slave number == 2
- [x] Fix bug in the decoder logic
- [x] Add to the arbiter unitest the case master number == 2
- [x] Fix bug in the arbiter logic
