### PR TITLE
fix: pass TRAVIS envvar to docker container

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -227,7 +227,7 @@ case "$1" in
     compileTest
   ;;
   "-c")
-    docker run --rm -itv $(pwd):/src -w /src spinalhdl/dev ./travis.sh -t
+    docker run --rm -ite TRAVIS="$TRAVIS" -v $(pwd):/src -w /src spinalhdl/dev ./travis.sh -t
   ;;
   "-d")
     deploy


### PR DESCRIPTION
It is possible to use some bash functions in Travis to divide the output into collapsable groups. See, for example, this build of GHDL: https://travis-ci.org/ghdl/ghdl/jobs/498072196. Precisely, these functions were added to this repo in #195 (see https://github.com/SpinalHDL/SpinalHDL/blob/dev/travis.sh#L32-L68) but they are not actually being used because envvar TRAVIS does not exist inside the container where the script is executed. See: https://travis-ci.org/SpinalHDL/SpinalHDL/jobs/498262317

This PR just shares the envvar from the host, which fixes the issue: https://travis-ci.com/1138-4EB/SpinalHDL/jobs/180718038

However, as you can see in the last log, `[SBT] test` is not properly collapsed. This is because `sbt -J-Xss2m test` generates lots of output, and the log is longer than the maximum size shown in Travis. This makes it difficult to see step/blocks executed after test, which is required when tests fail.

@Dolu1990, would it be possible to make `test` check if envvar `TRAVIS` exists and add travis block comments accordingly? See, for example, `[GHDL - test] sanity`, `[GHDL - test] gna` and `[GHDL - test] vests` in the first link above. If you feel like implementing it, we can leave this PR open and work on top of it. Otherwise we can just merge this and open a new issue for future work.

**EDIT**

The minimum requirement would be to start each block with `echo "travis_fold:start:$LABEL"` and finish it with `echo "travis_fold:end:$LABEL"`.