### PR TITLE
Foldable unit test

### DIFF
--- a/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryDoubleRead.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryDoubleRead.scala
@@ -40,7 +40,7 @@ object TestTopLevel {
 
 }
 
-class BusSlaveFactoryDoubleReadTester extends FunSuite {
+class BusSlaveFactoryDoubleReadTester extends FunSuite with TravisFold {
 
   test("BusSlaveFactoryDoubleRead") {
 

--- a/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
@@ -28,7 +28,7 @@ object CheckTester{
   }
 }
 
-class ChecksTester extends FunSuite  {
+class ChecksTester extends FunSuite with TravisFold  {
   import CheckTester._
 
 

--- a/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
@@ -28,7 +28,7 @@ object CheckTester{
   }
 }
 
-class ChecksTester extends FunSuite with TravisFold  {
+class ChecksTester extends FunSuite with TravisFold {
   import CheckTester._
 
 

--- a/tester/src/test/scala/spinal/tester/scalatest/CommonTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/CommonTester.scala
@@ -8,10 +8,12 @@ trait TravisFold extends FunSuite with BeforeAndAfterAllConfigMap{
   def isTravis: Boolean = sys.env.get("TRAVIS").nonEmpty
   override def beforeAll(configMap: ConfigMap) ={
       if(isTravis) println(s"travis_fold:start:${this.getClass.getSimpleName}")
+      super.beforeAll(configMap)
   }
 
   override def afterAll(configMap: ConfigMap) = {
       if(isTravis) println(s"travis_fold:end:${this.getClass.getSimpleName}")
+      super.afterAll(configMap)
   }
 }
 

--- a/tester/src/test/scala/spinal/tester/scalatest/CommonTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/CommonTester.scala
@@ -2,6 +2,18 @@ package spinal.tester.scalatest
 
 import spinal.core._
 import spinal.lib._
+import org.scalatest._
+
+trait TravisFold extends FunSuite with BeforeAndAfterAllConfigMap{
+  def isTravis: Boolean = sys.env.get("TRAVIS").nonEmpty
+  override def beforeAll(configMap: ConfigMap) ={
+      if(isTravis) println(s"travis_fold:start:${this.getClass.getSimpleName}")
+  }
+
+  override def afterAll(configMap: ConfigMap) = {
+      if(isTravis) println(s"travis_fold:end:${this.getClass.getSimpleName}")
+  }
+}
 
 object CommonTester {
 

--- a/tester/src/test/scala/spinal/tester/scalatest/CommonTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/CommonTester.scala
@@ -7,13 +7,13 @@ import org.scalatest._
 trait TravisFold extends FunSuite with BeforeAndAfterAllConfigMap{
   def isTravis: Boolean = sys.env.get("TRAVIS").nonEmpty
   override def beforeAll(configMap: ConfigMap) ={
-      if(isTravis) println(s"travis_fold:start:${this.getClass.getSimpleName}")
-      super.beforeAll(configMap)
+    if(isTravis) println(s"travis_fold:start:${this.getClass.getSimpleName}")
+    super.beforeAll(configMap)
   }
 
   override def afterAll(configMap: ConfigMap) = {
-      if(isTravis) println(s"travis_fold:end:${this.getClass.getSimpleName}")
-      super.afterAll(configMap)
+    super.afterAll(configMap)
+    if(isTravis) println(s"travis_fold:end:${this.getClass.getSimpleName}")
   }
 }
 

--- a/tester/src/test/scala/spinal/tester/scalatest/CrossClockCheckerTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/CrossClockCheckerTester.scala
@@ -44,7 +44,7 @@ class CrossClockCheckerTesterC extends Component{
 }
 
 
-class CrossClockCheckerTester extends FunSuite{
+class CrossClockCheckerTester extends FunSuite with TravisFold{
   import CheckTester._
 
   test("a") {

--- a/tester/src/test/scala/spinal/tester/scalatest/LibTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/LibTester.scala
@@ -32,7 +32,7 @@ class LibTesterCocotbBoot extends SpinalTesterCocotbBase {
 
 
 
-class CoreMiscTester extends FunSuite{
+class CoreMiscTester extends FunSuite with TravisFold{
   import spinal.core.sim._
   test("SlowArea"){
     SimConfig.withConfig(SpinalConfig(defaultClockDomainFrequency = FixedFrequency(4000 Hz))).compile(new Component{

--- a/tester/src/test/scala/spinal/tester/scalatest/RomTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/RomTester.scala
@@ -126,7 +126,7 @@ class RomTesterCocotbBoot3 extends SpinalTesterCocotbBase {
   }
 }
 
-class SpinalSimRomTester extends FunSuite {
+class SpinalSimRomTester extends FunSuite with TravisFold {
   test("test1"){
     import spinal.core.sim._
     import spinal.sim._

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAccessSubComponents.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAccessSubComponents.scala
@@ -44,7 +44,7 @@ object SpinalSimAccessSubComponents {
 
 }
 
-class SpinalSimAccessSubComponents extends FunSuite{
+class SpinalSimAccessSubComponents extends FunSuite with TravisFold{
   var compiled : SimCompiled[SpinalSimAccessSubComponents.Dut] = null
   test("compile"){
     compiled = SimConfig.withWave.compile{

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimApbI2C.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimApbI2C.scala
@@ -149,7 +149,7 @@ class OpenDrainInterconnect(clockDomain: ClockDomain){
 
 
 
-class SpinalSimApbI2C extends FunSuite {
+class SpinalSimApbI2C extends FunSuite with TravisFold {
 
   case class I2CSlaveModel(sda: OpenDrainSoftConnection, scl: OpenDrainSoftConnection){
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimClockDomainTest.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimClockDomainTest.scala
@@ -59,7 +59,7 @@ object SpinalSimClockDomainTest{
   }
 }
 
-class SpinalSimClockDomainTest extends FunSuite {
+class SpinalSimClockDomainTest extends FunSuite with TravisFold {
   val resetKinds = List(SYNC,ASYNC)
   test("Test1"){
     for(resetKind <- resetKinds) {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
@@ -27,7 +27,7 @@ object SpinalSimMiscTester{
 
 }
 
-class SpinalSimMiscTester extends FunSuite {
+class SpinalSimMiscTester extends FunSuite with TravisFold {
   var compiled : SimCompiled[tester.scalatest.SpinalSimMiscTester.SpinalSimMiscTesterCounter] = null
 
   test("testForkSensitive"){

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMultiThreadingTest.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMultiThreadingTest.scala
@@ -21,7 +21,7 @@ class SpinalSimMultiThreadingDut(offset : Int) extends Component {
   //    io.result := rec(io.a + io.b - io.c, 1000)
 }
 
-class SpinalSimMultiThreadingTest extends FunSuite {
+class SpinalSimMultiThreadingTest extends FunSuite with TravisFold {
 
   test("Test1") {
     var faild = false

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimOneEntryRamTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimOneEntryRamTester.scala
@@ -5,7 +5,7 @@ import spinal.core.sim._
 import spinal.core._
 import spinal.lib._
 
-class SpinalSimOneEntryRamTester extends FunSuite{
+class SpinalSimOneEntryRamTester extends FunSuite with TravisFold{
   test("general"){
     SimConfig.withWave.doSim(new Component{
       val mem = Mem(Bits(8 bits), 1) randBoot()

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPerfTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPerfTester.scala
@@ -23,7 +23,7 @@ object SpinalSimPerfTester {
 
 }
 
-class SpinalSimPerfTester extends FunSuite {
+class SpinalSimPerfTester extends FunSuite with TravisFold {
 
   var compiled: SimCompiled[SpinalSimPerfTester.SpinalSimPerfTesterDut] = null
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPhaseTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPhaseTester.scala
@@ -9,7 +9,7 @@ import spinal.lib.graphic.Rgb
 
 import scala.util.Random
 
-class SpinalSimPhaseTester extends FunSuite{
+class SpinalSimPhaseTester extends FunSuite with TravisFold{
   test("test1"){
 //    val compiled = SimConfig.withWave.compile(StreamFifo(UInt(8 bits),16))
     case class Transaction() extends Bundle {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPlicTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPlicTester.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 
-class SpinalSimPlicTester extends FunSuite {
+class SpinalSimPlicTester extends FunSuite with TravisFold {
   test("test1"){
     //Compile the simulator
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimSpiXdr.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimSpiXdr.scala
@@ -35,7 +35,7 @@ import scala.util.Random
 
 
 
-class SpinalSimSpiXdrMaster extends FunSuite {
+class SpinalSimSpiXdrMaster extends FunSuite with TravisFold {
 
   var compiled : SimCompiled[SpiXdrMasterCtrl.TopLevel] = null
   test("compile"){

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamFifoCCTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamFifoCCTester.scala
@@ -10,7 +10,7 @@ import spinal.tester
 import scala.collection.mutable
 import scala.util.Random
 
-class SpinalSimStreamFifoCCTester extends FunSuite {
+class SpinalSimStreamFifoCCTester extends FunSuite with TravisFold {
 
   def testbench(dut : StreamFifoCC[Bits]): Unit ={
     val queueModel = mutable.Queue[Long]()

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamFifoTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamFifoTester.scala
@@ -12,7 +12,7 @@ import spinal.tester
 import scala.collection.mutable
 import scala.util.Random
 
-class SpinalSimStreamFifoTester extends FunSuite {
+class SpinalSimStreamFifoTester extends FunSuite with TravisFold {
   test("testBits"){
     //Compile the simulator
     val compiled = SimConfig.allOptimisation.compile(

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimVerilatorIoTest.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimVerilatorIoTest.scala
@@ -73,7 +73,7 @@ object SpinalSimVerilatorIoTest{
   }
 }
 
-class SpinalSimVerilatorIoTest extends FunSuite {
+class SpinalSimVerilatorIoTest extends FunSuite with TravisFold {
   var compiled : SimCompiled[SpinalSimVerilatorIoTestTop] = null
   def doTest: Unit ={
     compiled.doSim{ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneAdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneAdapterTester.scala
@@ -23,7 +23,7 @@ class WishboneSimpleBusAdapted( configIn : WishboneConfig,
   val adapter = WishboneAdapter(io.busIN,io.busOUT,allowAddressResize,allowDataResize,allowTagResize)
 }
 
-class SpinalSimWishboneAdapterTester extends FunSuite{
+class SpinalSimWishboneAdapterTester extends FunSuite with TravisFold{
   def testBus(confIN:WishboneConfig,confOUT:WishboneConfig,allowAddressResize: Boolean = false,allowDataResize: Boolean = false,allowTagResize: Boolean = false, description : String = ""): Unit = {
     val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneSimpleBusAdapted(confIN,confOUT))
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneArbiterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneArbiterTester.scala
@@ -19,7 +19,7 @@ class WishboneArbiterComponent(config : WishboneConfig,size: Int) extends Compon
   val arbiter = WishboneArbiter(io.busIN,io.busOUT)
 }
 
-class SpinalSimWishboneArbiterTester extends FunSuite{
+class SpinalSimWishboneArbiterTester extends FunSuite with TravisFold{
   def testArbiter(config : WishboneConfig,size: Int,description : String = ""): Unit = {
     val fixture = SimConfig.allOptimisation.withWave.compile(rtl = new WishboneArbiterComponent(config,size))
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
@@ -21,7 +21,7 @@ class WishboneDecoderComponent(config : WishboneConfig,decodings : Seq[SizeMappi
   val decoder = WishboneDecoder(io.busIN,outs)
 }
 
-class SpinalSimWishboneDecoderTester extends FunSuite{
+class SpinalSimWishboneDecoderTester extends FunSuite with TravisFold{
   def testDecoder(config : WishboneConfig,decodings : Seq[SizeMapping],description : String = ""): Unit = {
     val fixture = SimConfig.allOptimisation.withWave.compile(rtl = new WishboneDecoderComponent(config,decodings))
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimInterconTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimInterconTester.scala
@@ -29,7 +29,7 @@ class WishboneInterconComponent(config : WishboneConfig,n_masters: Int,decodings
   }
 }
 
-class SpinalSimWishboneSimInterconTester extends FunSuite{
+class SpinalSimWishboneSimInterconTester extends FunSuite with TravisFold{
   def testIntercon(config : WishboneConfig,decodings : Seq[SizeMapping],masters: Int,description : String = ""): Unit = {
     val fixture = SimConfig.withWave.allOptimisation.compile(rtl = new WishboneInterconComponent(config,masters,decodings))
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimTester.scala
@@ -18,7 +18,7 @@ class wishbonesimplebus(config : WishboneConfig) extends Component{
   val ff = Reg(Bool)
   io.busmaster <> io.busslave
 }
-class SpinalSimWishboneSimTester extends FunSuite{
+class SpinalSimWishboneSimTester extends FunSuite with TravisFold{
   val compiled = SimConfig.allOptimisation.compile(rtl = new wishbonesimplebus(WishboneConfig(8,8)))
   val compPipe = SimConfig.allOptimisation.compile(rtl = new wishbonesimplebus(WishboneConfig(8,8).pipelined))
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
@@ -18,7 +18,7 @@ class WishboneSimpleSlave(config : WishboneConfig) extends Component{
   val reg = busCtrl.createReadWrite(Bits(busCtrl.busDataWidth bits),10)
 }
 
-class SpinalSimWishboneSlaveFactoryTester extends FunSuite{
+class SpinalSimWishboneSlaveFactoryTester extends FunSuite with TravisFold{
   def testBus(conf:WishboneConfig, description : String = ""): Unit = {
     val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneSimpleSlave(conf))
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Await
 import scala.sys.process._
 
-abstract class SpinalTesterCocotbBase extends FunSuite /* with BeforeAndAfterAll with ParallelTestExecution*/ {
+abstract class SpinalTesterCocotbBase extends FunSuite with TravisFold /* with BeforeAndAfterAll with ParallelTestExecution*/ {
 
   var withWaveform = false
   var spinalMustPass = true

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
@@ -5,7 +5,7 @@ import spinal.core._
 
 import scala.sys.process._
 
-abstract class SpinalTesterGhdlBase extends FunSuite  {
+abstract class SpinalTesterGhdlBase extends FunSuite with TravisFold  {
 
   var withWaveform = false
   var elaborateMustFail = false


### PR DESCRIPTION
Is still not perfect, bet you can check the result here:
https://travis-ci.com/wifasoi/SpinalHDL/jobs/195742247

There are still some u-test that do not behave, so I'll mark this PR as a WIP.

Explanation: (the magic souce is [here](https://github.com/SpinalHDL/SpinalHDL/compare/dev...wifasoi:foldable-utest?expand=1#diff-e2080510c7aa6a0d1ccc828264aab096))
- This PR will print the travis "magic string" to permit each unit test to have a foldable log.
- Each fold will have a name corresponding to the unit-test class name.
- This behavior will trigger only when the TRAVIS env variable is defined (the value doesn't matter)