### PR TITLE
RFC: Remove randBoot() for Cadence toolchain

### DIFF
--- a/lib/src/main/scala/spinal/lib/Flow.scala
+++ b/lib/src/main/scala/spinal/lib/Flow.scala
@@ -192,6 +192,6 @@ class FlowCCByToggle[T <: Data](dataType: T, inputClock: ClockDomain, outputCloc
     inputArea.target init(False)
     outputArea.hit init(False)
   }else{
-    inputArea.target.randBoot()
+    inputArea.target
   }
 }

--- a/lib/src/main/scala/spinal/lib/com/jtag/JtagTap.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/JtagTap.scala
@@ -41,7 +41,7 @@ object JtagState extends SpinalEnum {
 class JtagFsm(jtag: Jtag) extends Area {
   import JtagState._
   val stateNext = JtagState()
-  val state = RegNext(stateNext) randBoot()
+  val state = RegNext(stateNext)
   stateNext := state.mux(
     default    -> (jtag.tms ? RESET     | IDLE),           //RESET
     IDLE       -> (jtag.tms ? DR_SELECT | IDLE),


### PR DESCRIPTION
randBoot() generates warnings in Cadence's frontend because initial values without a reset are not allowed. The easiest way is to remove the function calls, but maybe there is a better way to handle this!