### PR TITLE
Add support for multiple Data arguments for forkSensitive(trigger)

### DIFF
--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -138,32 +138,24 @@ package object sim {
     }
   }
 
-  def forkSensitive(trigger : => Any)(block : => Unit): Unit = {
-    trigger match {
-      case bt: BaseType => {
-        var valueLast = bt.toBigInt
-        forkSensitive {
-          val valueNew = bt.toBigInt
-          if (valueNew != valueLast) block
-          valueLast = valueNew
-        }
+  def forkSensitive(triggers: Data*)(block: => Unit): Unit = {
+    def value(data: Data) = data.flatten.map(_.toBigInt)
+    def currentTriggerValue = triggers.flatMap(value)
+
+    forkSensitive(currentTriggerValue)(block)
+  }
+
+  def forkSensitive(trigger: => Any)(block: => Unit): Unit = {
+    var lastValue = trigger
+
+    forkSensitive {
+      val newValue = trigger
+
+      if (newValue != lastValue) {
+        block
       }
-      case data: Data => {
-        var valueLast = data.flatten.map(_.toBigInt)
-        forkSensitive {
-          val valueNew = data.flatten.map(_.toBigInt)
-          if (valueNew != valueLast) block
-          valueLast = valueNew
-        }
-      }
-      case _ => {
-        var valueLast = trigger
-        forkSensitive {
-          val valueNew = trigger
-          if (valueNew != valueLast) block
-          valueLast = valueNew
-        }
-      }
+
+      lastValue = newValue
     }
   }
 


### PR DESCRIPTION
`forkSensitive(trigger)` can now be called using `Data` varargs like this: `forkSensitive(data1, data2, ...)`.

This commit also refactors `forkSensitive(trigger)` a bit to avoid code duplication.