### PR TITLE
Add support for Nameable members inside Scala containers

### DIFF
--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -491,7 +491,7 @@ trait Nameable extends OwnableRef with ContextUser{
   }
 
   def reflectNames(): Unit = {
-    Misc.reflect(this, (name, obj) => {
+    def reflectName(name: String, obj: Any): Unit = {
       obj match {
         case component: Component =>
           if (component.parent == this.component) {
@@ -514,9 +514,19 @@ trait Nameable extends OwnableRef with ContextUser{
               }
             }
           }
+        case it: Iterable[Any] =>
+          it.zipWithIndex.foreach {case (subObj, i) =>
+            reflectName(s"${name}_$i", subObj)
+
+            if (subObj.isInstanceOf[Nameable]) {
+              subObj.asInstanceOf[Nameable].reflectNames()
+            }
+          }
         case _ =>
       }
-    })
+    }
+
+    Misc.reflect(this, reflectName)
   }
 
 }


### PR DESCRIPTION
This patch adds support for storing `Nameable` objects inside Scala containers. The members of the container are given a name in the same way `Vec` gives a name to its members.

I would like to get some feedback, especially on the call to `subObj.asInstanceOf[Nameable].reflectNames()`. This is done to support `Area`s inside containers but I'm not sure if its ok to call this for all `Nameable`s.