### PR TITLE
Add DDR2 support for NexysA7

### DIFF
--- a/lib/src/main/scala/spinal/lib/memory/sdram/SdramLayout.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/SdramLayout.scala
@@ -21,6 +21,15 @@ object SdramGeneration{
     burstLength = 1,
     dataRate = 1
   )
+  val DDR2 = new SdramGeneration(
+    RESETn = true,//should be false!
+    ODT = true,
+    DQS = true,
+    FAW = true,
+    CCD = 2,
+    burstLength = 8,
+    dataRate = 2
+  )
   val DDR3 = new SdramGeneration(
     RESETn = true,
     ODT = true,

--- a/lib/src/main/scala/spinal/lib/memory/sdram/sdr/SdramDevices.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/sdr/SdramDevices.scala
@@ -79,6 +79,16 @@ object W9825G6JH6 {
 }
 
 
+object MT47H64M16HR{
+  def layout = SdramLayout(
+    generation = DDR2,
+    bankWidth = 3,
+    columnWidth = 10,
+    rowWidth = 13,
+    dataWidth = 16
+  )
+}
+
 
 object MT41K128M16JT{
   def layout = SdramLayout(


### PR DESCRIPTION
Please note that RESETn should be false for DDR2, since there is no reset pin. But I could not compile it. So I am leaving it true for now and connecting DDR reset pin to SW[0] on NexysA7 board.