### PR TITLE
AsyncMemoryBusFactory fix for writeMemWordAligned

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/simple/AsyncMemoryBusFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/simple/AsyncMemoryBusFactory.scala
@@ -37,6 +37,8 @@ class AsyncMemoryBusFactory(bus: AsyncMemoryBus, incAddress: Int = 0) extends Bu
 
   def build(): Unit = {
 
+    super.doNonStopWrite(bus.writeData)
+    
     val askWrite = (bus.valid & !bus.rwn).allowPruning()
     val doWrite  = (bus.valid & !bus.rwn & bus.ready).allowPruning()
     val askRead  = (bus.valid & bus.rwn).allowPruning()


### PR DESCRIPTION
One line was missing thus preventing BusSlaveFactory.readSyncMemWordAligned() from working