### PR TITLE
Fix sbt supershell in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       # See 'project/Version.scala'
       scala: 2.11.12
       jdk: openjdk9
-      sbt_args: -no-colors -J-Xss2m --supershell=false
+      sbt_args: --supershell=false -no-colors -J-Xss2m
       script:
         - sbt -jvm-opts travis/jvmopts.compile compile
         - sbt -jvm-opts travis/jvmopts.test test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       # See 'project/Version.scala'
       scala: 2.11.12
       jdk: openjdk9
-      sbt_args: -no-colors -J-Xss2m
+      sbt_args: -no-colors -J-Xss2m --supershell=false
       script:
         - sbt -jvm-opts travis/jvmopts.compile compile
         - sbt -jvm-opts travis/jvmopts.test test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       # See 'project/Version.scala'
       scala: 2.11.12
       jdk: openjdk9
-      sbt_args: --supershell=false -no-colors -J-Xss2m
+      sbt_args: -Dsbt.supershell=false -no-colors -J-Xss2m
       script:
         - sbt -jvm-opts travis/jvmopts.compile compile
         - sbt -jvm-opts travis/jvmopts.test test

--- a/travis.sh
+++ b/travis.sh
@@ -176,7 +176,7 @@ beforeInstall () {
 
 compileTest () {
   travis_start "compile" "SBT" "compile"
-  sbt -J-Xss2m compile
+  sbt -J-Xss2m --supershell=false compile
   travis_finish "compile"
 
   travis_start "cocotb" "SBT" "cocotb VPI"
@@ -188,7 +188,7 @@ compileTest () {
   travis_finish "cocotb"
 
   travis_start "test" "SBT" "test"
-  sbt -J-Xss2m test
+  sbt -J-Xss2m --supershell=false test
   travis_finish "test"
 }
 

--- a/travis.sh
+++ b/travis.sh
@@ -176,7 +176,7 @@ beforeInstall () {
 
 compileTest () {
   travis_start "compile" "SBT" "compile"
-  sbt --supershell=false -J-Xss2m compile
+  sbt -Dsbt.supershell=false -J-Xss2m compile
   travis_finish "compile"
 
   travis_start "cocotb" "SBT" "cocotb VPI"
@@ -188,7 +188,7 @@ compileTest () {
   travis_finish "cocotb"
 
   travis_start "test" "SBT" "test"
-  sbt --supershell=false -J-Xss2m test
+  sbt -Dsbt.supershell=false -J-Xss2m test
   travis_finish "test"
 }
 

--- a/travis.sh
+++ b/travis.sh
@@ -176,7 +176,7 @@ beforeInstall () {
 
 compileTest () {
   travis_start "compile" "SBT" "compile"
-  sbt -J-Xss2m --supershell=false compile
+  sbt --supershell=false -J-Xss2m compile
   travis_finish "compile"
 
   travis_start "cocotb" "SBT" "cocotb VPI"
@@ -188,7 +188,7 @@ compileTest () {
   travis_finish "cocotb"
 
   travis_start "test" "SBT" "test"
-  sbt -J-Xss2m --supershell=false test
+  sbt --supershell=false -J-Xss2m test
   travis_finish "test"
 }
 


### PR DESCRIPTION
Add "supershell=false" flag like suggested in #252.
I noted that the output is more clear and without unnecessary spaces.
Like you can see in here: https://travis-ci.com/wifasoi/SpinalHDL/jobs/280481629

@Dolu1990 if ok with you I'll merge to dev (or should i merge it to master?)

This will fix #252 