### PR TITLE
changes for output assigns

### DIFF
--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -140,6 +140,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         transformationPhases           : ArrayBuffer[Phase] = ArrayBuffer[Phase](),
                         memBlackBoxers                 : ArrayBuffer[Phase] = ArrayBuffer[Phase] (/*new PhaseMemBlackBoxerDefault(blackboxNothing)*/),
                         rtlHeader                      : String = null,
+                        removeOutputAssigns            : Boolean = false,
                         private [core] var _withEnumString : Boolean = true
 ){
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitter.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitter.scala
@@ -69,6 +69,8 @@ abstract class ComponentEmitter {
   val outputsToBufferize = mutable.LinkedHashSet[BaseType]() //Check if there is a reference to an output pin (read self outputed signal)
   val subComponentInputToNotBufferize = mutable.HashSet[Any]()
   val openSubIo = mutable.HashSet[BaseType]()
+  
+  val subComponentOutputToNotBufferize = mutable.HashSet[Any]()
 
   def getOrDefault[X,Y](map: java.util.concurrent.ConcurrentHashMap[X,Y], key: X, default: Y) = map.get(key) match {
     case null => default
@@ -100,6 +102,7 @@ abstract class ComponentEmitter {
     else
       null
   }
+
 
   def elaborate() = {
     val asyncStatement = ArrayBuffer[LeafStatement]()
@@ -294,6 +297,7 @@ abstract class ComponentEmitter {
         }
       }
     }
+
 
     //Fill multiplexersPerSelect
     component.dslBody.walkStatements(s => {

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -109,6 +109,7 @@ class ComponentEmitterVhdl(
     declarations ++= s"  signal $name : ${emitDataType(io)};\n"
     referencesOverrides(io) = name
   }
+  
 
   def emitArchitecture(): Unit = {
     for(mem <- mems){


### PR DESCRIPTION
This is a *hopeful* solution to https://github.com/SpinalHDL/SpinalHDL/issues/251 that I raised.

ComponentEmitterVerilog.scala
-----------------------------
- Added a check where if an output of a subcomponent was connect to an output of the current component it would set the referencesOverrides() to the component port. This removes the need for the additional assign statement.
- subcomponent outputs that are only used internally to the current component should still produce a wire as expected.
- Added formatting to the portMap in emitEntity. Before adding to the portMaps, it will figure up the spacing.

Spinal.scala
------------
- Added a config parameter called 'removeOutputAssigns'. Defaults to false, keeping the original
  functionality where outputs are set through assigns.


Here is an example of the input Spinal and corresponding output Verilogs
```scala
class MyBB extends BlackBox {
  val thisin  = in Bool
  val thisout = out Bool
}

class MyBottom extends MrvnComponent{
  val somein = in Bool
  val somein2 = in Bool
  val someout = out Bool
  val someout2 = out Bool
  
  someout  := somein & somein2
  someout2 := somein | somein2
  
  val bb = new MyBB
  bb.thisin := somein
}

class MyTop extends MrvnComponent{
  val in1 = in Bool
  val in2 = in Bool
  val in3 = in Bool
  
  val out1 = out Bool
  val out2 = out Bool
  val out3 = out Bool
  val out4 = out Bool

  val bot1 = new MyBottom
  val bot2 = new MyBottom
  
  bot1.somein   := in1
  bot1.somein2  := in2
  out1 := bot1.someout
  
  bot2.somein   := in2
  bot2.somein2  := in3
  out2 := bot2.someout
  
  out3 := bot1.someout2 ^ bot2.someout2
  
  out4 := bot1.someout2
}
```

**Normal/Default - removeOutputAssigns=false**
```verilog
module MyBottom (
      input    somein,
      input    somein2,
      output   someout,
      output   someout2);
  wire  bb_thisout;
  MyBB bb ( 
    .thisin  ( somein     ),
    .thisout ( bb_thisout ) 
  );
  assign someout = (somein && somein2);
  assign someout2 = (somein || somein2);
endmodule


//MyBottom_1_ remplaced by MyBottom

module MyTop (
      input    in1,
      input    in2,
      input    in3,
      output   out1,
      output   out2,
      output   out3,
      output   out4);
  wire  bot1_someout;
  wire  bot1_someout2;
  wire  bot2_someout;
  wire  bot2_someout2;
  MyBottom bot1 ( 
    .somein   ( in1           ),
    .somein2  ( in2           ),
    .someout  ( bot1_someout  ),
    .someout2 ( bot1_someout2 ) 
  );
  MyBottom bot2 ( 
    .somein   ( in2           ),
    .somein2  ( in3           ),
    .someout  ( bot2_someout  ),
    .someout2 ( bot2_someout2 ) 
  );
  assign out1 = bot1_someout;
  assign out2 = bot2_someout;
  assign out3 = (bot1_someout2 ^ bot2_someout2);
  assign out4 = bot1_someout2;
endmodule
```
**removeOutputAssigns=true**
```verilog
module MyBottom (
      input    somein,
      input    somein2,
      output   someout,
      output   someout2);
  wire  bb_thisout;
  MyBB bb ( 
    .thisin  ( somein     ),
    .thisout ( bb_thisout ) 
  );
  assign someout = (somein && somein2);
  assign someout2 = (somein || somein2);
endmodule


//MyBottom_1_ remplaced by MyBottom

module MyTop (
      input    in1,
      input    in2,
      input    in3,
      output   out1,
      output   out2,
      output   out3,
      output   out4);
  wire  bot2_someout2;
  MyBottom bot1 ( 
    .somein   ( in1  ),
    .somein2  ( in2  ),
    .someout  ( out1 ),
    .someout2 ( out4 ) 
  );
  MyBottom bot2 ( 
    .somein   ( in2           ),
    .somein2  ( in3           ),
    .someout  ( out2          ),
    .someout2 ( bot2_someout2 ) 
  );
  assign out3 = (out4 ^ bot2_someout2);
endmodule
```

Fixes #251 