### PR TITLE
formatting Verilog 

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -773,8 +773,10 @@ class ComponentEmitterVerilog(
   def emitBaseTypeSignal(baseType: BaseType, name: String): String = {
     val syntax  = s"${emitSyntaxAttributes(baseType.instanceAttributes)}"
     val net     = if(signalNeedProcess(baseType)) "reg" else "wire"
+    val siginit = s"${getBaseTypeSignalInitialisation(baseType)}"
+    val comment = s"${emitCommentAttributes(baseType.instanceAttributes)}"
     val section = emitType(baseType)
-    s"${theme.maintab}${syntax}${expressionAlign(net, section, name)}${getBaseTypeSignalInitialisation(baseType)}${emitCommentAttributes(baseType.instanceAttributes)};\n"
+    s"${theme.maintab}${syntax}${expressionAlign(net, section, name)}${siginit}${comment};\n"
 //    s"  ${}${if(signalNeedProcess(baseType)) s"reg " else "wire "}${emitType(baseType)} ${name}${getBaseTypeSignalInitialisation(baseType)}${emitCommentAttributes(baseType.instanceAttributes)};\n"
   }
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -28,7 +28,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
-
 class ComponentEmitterVerilog(
   val c                              : Component,
   systemVerilog                      : Boolean,
@@ -52,39 +51,38 @@ class ComponentEmitterVerilog(
   val portMaps     = ArrayBuffer[String]()
   val declarations = new StringBuilder()
   val logics       = new StringBuilder()
-
   def getTrace() = new ComponentEmitterTrace(declarations :: logics :: Nil, portMaps)
 
   def result: String = {
-    val ret = new StringBuilder()
-    var first = true
-
-    ret ++= s"module ${component.definitionName} ("
-
-    for(portMap <- portMaps){
-      if(first){
-        ret ++= s"\n    $portMap"
-        first = false
-      } else {
-        ret ++= s",\n    $portMap"
-      }
-    }
-
-    ret ++= s");\n"
-    ret ++= declarations
-    ret ++= logics
-    ret ++= s"endmodule\n"
-    ret ++= s"\n"
-    ret.toString()
+    val ports = portMaps.map{ portMap => s"${theme.porttab}${portMap}\n"}.mkString + s");"
+    s"""
+      |module ${component.definitionName} (
+      |${ports}
+      |${declarations}
+      |${logics}
+      |endmodule
+      |""".stripMargin
   }
 
   def emitEntity(): Unit = {
-    component.getOrdredNodeIo.foreach(baseType =>
-      if(outputsToBufferize.contains(baseType) || baseType.isInput)
-        portMaps += s"  ${emitSyntaxAttributes(baseType.instanceAttributes)}${emitDirection(baseType)} ${emitType(baseType)} ${baseType.getName()}${emitCommentAttributes(baseType.instanceAttributes)}"
-      else
-        portMaps += s"  ${emitSyntaxAttributes(baseType.instanceAttributes)}${emitDirection(baseType)} ${if(signalNeedProcess(baseType) && !outputsToBufferize.contains(baseType)) "reg " else ""}${emitType(baseType)} ${baseType.getName()}${if(outputsToBufferize.contains(baseType)) "" else getBaseTypeSignalInitialisation(baseType)}${emitCommentAttributes(baseType.instanceAttributes)}"
-    )
+    component.getOrdredNodeIo.foreach{baseType =>
+      val syntax     = s"${emitSyntaxAttributes(baseType.instanceAttributes)}"
+      val dir        = s"${emitDirection(baseType)}"
+      val section    = s"${emitType(baseType)}"
+      val name       = s"${baseType.getName()}"
+      val comma      = if(baseType == component.getOrdredNodeIo.last) " " else ","
+      val EDAcomment = s"${emitCommentAttributes(baseType.instanceAttributes)}"  //like "/* verilator public */"
+
+      if(outputsToBufferize.contains(baseType) || baseType.isInput){
+        portMaps += f"${syntax}${dir}%6s ${""}%3s ${section}%-8s ${name}${EDAcomment}${comma}"
+//        portMaps += s"${emitSyntaxAttributes(baseType.instanceAttributes)}${emitDirection(baseType)} ${emitType(baseType)} ${baseType.getName()}${emitCommentAttributes(baseType.instanceAttributes)}"
+      } else {
+        val siginit = if(outputsToBufferize.contains(baseType)) "" else getBaseTypeSignalInitialisation(baseType)
+        val isReg   = if(signalNeedProcess(baseType)) "reg" else ""
+        portMaps += f"${syntax}${dir}%6s ${isReg}%3s ${section}%-8s ${name}${siginit}${EDAcomment}${comma}"
+//        portMaps += s"${emitSyntaxAttributes(baseType.instanceAttributes)}${emitDirection(baseType)} ${if(signalNeedProcess(baseType) && !outputsToBufferize.contains(baseType)) "reg " else ""}${emitType(baseType)} ${baseType.getName()}${if(outputsToBufferize.contains(baseType)) "" else getBaseTypeSignalInitialisation(baseType)}${emitCommentAttributes(baseType.instanceAttributes)}"
+      }
+    }
   }
 
   override def wrapSubInput(io: BaseType): Unit = {
@@ -130,7 +128,8 @@ class ComponentEmitterVerilog(
       expressionToWrap += select._1
       for(mux <- muxes) {
         val name = component.localNamingScope.allocateName(anonymSignalPrefix)
-        declarations ++= s"  reg ${emitType(mux)} $name;\n"
+        declarations ++= theme.maintab + expressionAlign("reg",emitType(mux), name) + ";\n"
+//        declarations ++= s"  reg ${emitType(mux)} $name;\n"
         wrappedExpressionToName(mux) = name
         //        expressionToWrap ++= mux.inputs
       }
@@ -239,24 +238,49 @@ class ComponentEmitterVerilog(
       }
 
       //Fixing the spacing
-      var maxNameLength = 0
-      for(data <- child.getOrdredNodeIo) {
-        if (emitReferenceNoOverrides(data).toString.length() > maxNameLength) maxNameLength = emitReferenceNoOverrides(data).toString.length()
+      def wireWithSection(data: BaseType): String = {
+        if(openSubIo.contains(data)) ""
+        else {
+          val wireName = emitReference(data, false)
+          val section = if(data.getBitsWidth == 1) "" else  s"[${data.getBitsWidth - 1}:0]"
+          wireName + section
+        }
       }
-      var maxNameLengthCon = 0
-      for(data <- child.getOrdredNodeIo) {
-        val logic = if(openSubIo.contains(data)) "" else emitReference(data, false)
-        if (logic.toString.length() > maxNameLengthCon) maxNameLengthCon = logic.toString.length()
-      }
+
+      val maxNameLength: Int = child.getOrdredNodeIo
+        .map(data => emitReferenceNoOverrides(data).length())
+        .max
+
+      val maxNameLengthCon: Int = child.getOrdredNodeIo
+        .map(data => wireWithSection(data).length())
+        .max
+
+//      var maxNameLength = 0
+//      for(data <- child.getOrdredNodeIo) {
+//        if (emitReferenceNoOverrides(data).toString.length() > maxNameLength) maxNameLength = emitReferenceNoOverrides(data).toString.length()
+//      }
+//      var maxNameLengthCon = 0
+//      for(data <- child.getOrdredNodeIo) {
+//        val logic = if(openSubIo.contains(data)) "" else emitReference(data, false)
+//        if (logic.toString.length() > maxNameLengthCon) maxNameLengthCon = logic.toString.length()
+//      }
 
       logics ++= s"${child.getName()} ( \n"
-      for (data <- child.getOrdredNodeIo) {
-        val logic = if(openSubIo.contains(data)) "" else emitReference(data, false)
-        //logics ++= s"    .${emitReferenceNoOverrides(data)}($logic),\n"
-        logics ++= s"    .%-${maxNameLength}s ( %-${maxNameLengthCon}s ),\n".format(emitReferenceNoOverrides(data), logic) 
-      }
-      logics.setCharAt(logics.size - 2, ' ')
 
+      val instports: String = child.getOrdredNodeIo.map{ data =>
+        val portAlign  = s"%-${maxNameLength}s".format(emitReferenceNoOverrides(data))
+        val wireAlign  = s"%-${maxNameLengthCon}s".format(wireWithSection(data))
+        val comma      = if (data == child.getOrdredNodeIo.last) " " else ","
+        val dirtag: String = data.dir match{
+          case spinal.core.in  | spinal.core.inWithNull  => "i"
+          case spinal.core.out | spinal.core.outWithNull => "o"
+          case spinal.core.inout                         => "~"
+          case _  => SpinalError("Not founded IO type")
+        }
+        s"    .${portAlign}    (${wireAlign}  )${comma} //${dirtag}\n"
+      }.mkString
+
+      logics ++= instports
       logics ++= s"  );"
       logics ++= s"\n"
     }
@@ -747,11 +771,18 @@ class ComponentEmitterVerilog(
   def emitExpressionNoWrappeForFirstOne(that: Expression): String = dispatchExpression(that)
 
   def emitBaseTypeSignal(baseType: BaseType, name: String): String = {
-    s"  ${emitSyntaxAttributes(baseType.instanceAttributes)}${if(signalNeedProcess(baseType)) "reg " else "wire "}${emitType(baseType)} ${name}${getBaseTypeSignalInitialisation(baseType)}${emitCommentAttributes(baseType.instanceAttributes)};\n"
+    val syntax  = s"${emitSyntaxAttributes(baseType.instanceAttributes)}"
+    val net     = if(signalNeedProcess(baseType)) "reg" else "wire"
+    val section = emitType(baseType)
+    s"${theme.maintab}${syntax}${expressionAlign(net, section, name)}${getBaseTypeSignalInitialisation(baseType)}${emitCommentAttributes(baseType.instanceAttributes)};\n"
+//    s"  ${}${if(signalNeedProcess(baseType)) s"reg " else "wire "}${emitType(baseType)} ${name}${getBaseTypeSignalInitialisation(baseType)}${emitCommentAttributes(baseType.instanceAttributes)};\n"
   }
 
   def emitBaseTypeWrap(baseType: BaseType, name: String): String = {
-    s"  ${if(signalNeedProcess(baseType)) "reg " else "wire "}${emitType(baseType)} ${name};\n"
+    val net = if(signalNeedProcess(baseType)) "reg" else "wire"
+    val section = emitType(baseType)
+    s"${theme.maintab}${expressionAlign(net, section, name)};\n"
+//    s"  ${if(signalNeedProcess(baseType)) "reg " else "wire "}${emitType(baseType)} ${name};\n"
   }
 
   def getBaseTypeSignalInitialisation(signal: BaseType): String = {
@@ -1193,7 +1224,11 @@ end
   }
 
   def emitBitVectorLiteral(e: BitVectorLiteral): String = {
-    s"(${e.getWidth}'b${e.getBitsStringOn(e.getWidth,'x')})"
+    if(e.getWidth > 4){
+      s"${e.getWidth}'h${e.hexString(e.getWidth,true)}"
+    } else {
+      s"(${e.getWidth}'b${e.getBitsStringOn(e.getWidth,'x')})"
+    }
   }
 
   def emitEnumLiteralWrap(e: EnumLiteral[_  <: SpinalEnum]): String = {

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -242,7 +242,8 @@ class ComponentEmitterVerilog(
         if(openSubIo.contains(data)) ""
         else {
           val wireName = emitReference(data, false)
-          val section = if(data.getBitsWidth == 1) "" else  s"[${data.getBitsWidth - 1}:0]"
+          val section  = s"${emitType(data)}"
+//          val section = if(data.getBitsWidth == 1) "" else  s"[${data.getBitsWidth - 1}:0]"
           wireName + section
         }
       }

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -238,23 +238,18 @@ class ComponentEmitterVerilog(
       }
 
       //Fixing the spacing
-      def wireWithSection(data: BaseType): String = {
+      def netsWithSection(data: BaseType): String = {
         if(openSubIo.contains(data)) ""
         else {
           val wireName = emitReference(data, false)
-          val section  = s"${emitType(data)}"
-//          val section = if(data.getBitsWidth == 1) "" else  s"[${data.getBitsWidth - 1}:0]"
+          val section = if(data.getBitsWidth == 1) "" else  s"[${data.getBitsWidth - 1}:0]"
           wireName + section
         }
       }
 
-      val maxNameLength: Int = child.getOrdredNodeIo
-        .map(data => emitReferenceNoOverrides(data).length())
-        .max
+      val maxNameLength: Int = if(child.getOrdredNodeIo.isEmpty) 0 else child.getOrdredNodeIo.map(data => emitReferenceNoOverrides(data).length()).max
 
-      val maxNameLengthCon: Int = child.getOrdredNodeIo
-        .map(data => wireWithSection(data).length())
-        .max
+      val maxNameLengthCon: Int = if(child.getOrdredNodeIo.isEmpty) 0 else child.getOrdredNodeIo.map(data => netsWithSection(data).length()).max
 
 //      var maxNameLength = 0
 //      for(data <- child.getOrdredNodeIo) {
@@ -270,7 +265,7 @@ class ComponentEmitterVerilog(
 
       val instports: String = child.getOrdredNodeIo.map{ data =>
         val portAlign  = s"%-${maxNameLength}s".format(emitReferenceNoOverrides(data))
-        val wireAlign  = s"%-${maxNameLengthCon}s".format(wireWithSection(data))
+        val wireAlign  = s"%-${maxNameLengthCon}s".format(netsWithSection(data))
         val comma      = if (data == child.getOrdredNodeIo.last) " " else ","
         val dirtag: String = data.dir match{
           case spinal.core.in  | spinal.core.inWithNull  => "i"

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -2252,6 +2252,13 @@ abstract class BitVectorLiteral() extends Literal with WidthProvider {
     makeIt(isSignedKind && value < 0)
   }
 
+  def hexString(bitCount: Int, aligin: Boolean = false):String = {
+    val hexCount = scala.math.ceil(bitCount/4.0).toInt
+    val alignCount = if (aligin) (hexCount * 4) else bitCount
+    val unsignedValue = if(value >= 0) value else ((BigInt(1) << alignCount) + value)
+    if(value == 0) "0" else s"%${hexCount}s".format(unsignedValue.toString(16)).replace(' ','0')
+  }
+
 
   def minimalValueBitWidth: Int = {
     val pureWidth = value.bitLength + (if(isSignedKind && value != 0) 1 else 0)

--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -91,7 +91,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
       componentBuilderVerilog.result
     } else {
       emitedComponentRef.put(component, oldComponent)
-      val str =  s"\n//${component.definitionName} remplaced by ${oldComponent.definitionName}\n\n"
+      val str =  s"\n//${component.definitionName} replaced by ${oldComponent.definitionName}"
       component.definitionName = oldComponent.definitionName
       str
     }

--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -91,7 +91,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
       componentBuilderVerilog.result
     } else {
       emitedComponentRef.put(component, oldComponent)
-      val str =  s"\n//${component.definitionName} replaced by ${oldComponent.definitionName}"
+      val str =  s"//${component.definitionName} replaced by ${oldComponent.definitionName}\n"
       component.definitionName = oldComponent.definitionName
       str
     }

--- a/core/src/main/scala/spinal/core/internals/VerilogBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VerilogBase.scala
@@ -22,15 +22,40 @@ package spinal.core.internals
 
 import spinal.core._
 
+trait VerilogTheme{
+  def tab      = "  "
+  def porttab  = ""
+  def maintab  = ""
+}
+
+class Tab2 extends VerilogTheme {
+  override def tab      = "  "
+  override def porttab  = "  "
+  override def maintab  = "  "
+}
+
+class Tab4 extends VerilogTheme {
+  override def tab      = "    "
+  override def porttab  = ""
+  override def maintab  = ""
+}
+
 
 trait VerilogBase extends VhdlVerilogBase{
+  val theme = new Tab2 //TODO add into SpinalConfig
+
+  def expressionAlign(net: String, section: String, name: String) = {
+    f"$net%-10s $section%-8s $name"
+  }
 
   def emitExpressionWrap(e: Expression, name: String): String = {
-    s"  wire ${emitType(e)} ${name};\n"
+//    s"  wire ${emitType(e)} ${name};\n"
+    theme.maintab + expressionAlign("wire", emitType(e), name) + ";\n"
   }
 
   def emitExpressionWrap(e: Expression, name: String, nature: String): String = {
-    s"  $nature ${emitType(e)} ${name};\n"
+//    s"  $nature ${emitType(e)} ${name};\n"
+    theme.maintab + expressionAlign(nature, emitType(e), name) + ";\n"
   }
 
   def emitClockEdge(clock: String, edgeKind: EdgeKind): String = {


### PR DESCRIPTION
**1. impove Instance format, which discuss at #257**
add bit section and io direction tag
```verilog
  CordicCore uCore ( 
    .io_din_valid         (uRotated_io_dout_valid               ), //i
    .io_din_payload_X     (uRotated_io_dout_payload_iq_I[11:0]  ), //i
    .io_din_payload_Y     (uRotated_io_dout_payload_iq_Q[11:0]  ), //i
    .io_din_payload_Z     (uRotated_io_dout_payload_theta[9:0]  ), //i
    .io_dout_valid        (uCore_io_dout_valid                  ), //o
    .io_dout_payload_X    (uCore_io_dout_payload_X[11:0]        ), //o
    .io_dout_payload_Y    (uCore_io_dout_payload_Y[11:0]        ), //o
    .io_dout_payload_Z    (uCore_io_dout_payload_Z[9:0]         ), //o
    .clk                  (clk                                  ), //i
    .resetn               (resetn                               )  //i
  );  
```
**2. aligin Module port and declaration** 
```verilog
module CordicExp (
  input               io_din_valid,
  input      [11:0]   io_din_payload_I,
  input      [11:0]   io_din_payload_Q,
  input      [11:0]   io_theta,
  output reg          io_dout_valid,
  output reg [11:0]   io_dout_payload_I,
  output reg [11:0]   io_dout_payload_Q,
  input               clk,
  input               resetn 
);
  wire       [19:0]   t_1_;
  wire       [19:0]   t_2_;
  wire                uRotated_io_dout_valid;
  wire       [11:0]   uRotated_io_dout_payload_iq_I;
  wire       [11:0]   uRotated_io_dout_payload_iq_Q;
  wire       [9:0]    uRotated_io_dout_payload_theta;
  wire                uCore_io_dout_valid;
  reg                 xAn_valid;
  reg        [11:0]   xAn_payload_I;
  reg        [11:0]   xAn_payload_Q;  
```
**3. generat constant as hex when width bigger than 4 bits**
```verilog 
assign  a = 16'h3fff
assign  b = 12'h324
assign  c = 3'b101
assign  d = 16'h0
```