### PR TITLE
little fix

### DIFF
--- a/core/src/main/scala/spinal/core/Bits.scala
+++ b/core/src/main/scala/spinal/core/Bits.scala
@@ -191,7 +191,12 @@ class Bits extends BitVector with DataPrimitives[Bits] with BitwiseOp[Bits]{
     * @return (data10bits(8 downto 4), data10bits(3 downto 0))
     */
   def splitAt(n: Int): (Bits,Bits) = {
-    (this(this.high downto n), this(n - 1 downto 0))
+    require(n>=0)
+    if(n==0){
+      (this, Bits(0 bits))
+    } else {
+      (this(this.high downto n), this(n - 1 downto 0))
+    }
   }
 
   /**

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -1223,7 +1223,7 @@ end
 
   def emitBitVectorLiteral(e: BitVectorLiteral): String = {
     if(e.getWidth > 4){
-      s"${e.getWidth}'h${e.hexString(e.getWidth,true)}"
+      s"${e.getWidth}'h${e.hexString(e.getWidth,false)}"
     } else {
       s"(${e.getWidth}'b${e.getBitsStringOn(e.getWidth,'x')})"
     }


### PR DESCRIPTION
1. `Bits.splitAt(0)` fix 
2. negative constant hexString align instead true as false
```scala 
val a = SInt(6 bits)
a := -3    //assign a = 6'hfd align will lead EDA warning 
``` 
now  `a := -3` got `assign a = 6'h3d` not `assign a = 6'hfd` 
