### PR TITLE
Remove trailing white-spaces from the Verilog emitter

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -71,7 +71,7 @@ class ComponentEmitterVerilog(
       val dir        = s"${emitDirection(baseType)}"
       val section    = s"${emitType(baseType)}"
       val name       = s"${baseType.getName()}"
-      val comma      = if(baseType == component.getOrdredNodeIo.last) " " else ","
+      val comma      = if(baseType == component.getOrdredNodeIo.last) "" else ","
       val EDAcomment = s"${emitCommentAttributes(baseType.instanceAttributes)}"  //like "/* verilator public */"
 
       if(outputsToBufferize.contains(baseType) || baseType.isInput){
@@ -226,7 +226,7 @@ class ComponentEmitterVerilog(
         val genericFlat = bb.genericElements
 
         if (genericFlat.nonEmpty) {
-          logics ++= s"#( \n"
+          logics ++= s"#(\n"
           for (e <- genericFlat) {
             e match {
               case (name: String, bt: BaseType) => logics ++= s"    .${name}(${emitExpression(bt.getTag(classOf[GenericValue]).get.e)}),\n"
@@ -266,7 +266,7 @@ class ComponentEmitterVerilog(
 //        if (logic.toString.length() > maxNameLengthCon) maxNameLengthCon = logic.toString.length()
 //      }
 
-      logics ++= s"${child.getName()} ( \n"
+      logics ++= s"${child.getName()} (\n"
 
       val instports: String = child.getOrdredNodeIo.map{ data =>
         val portAlign  = s"%-${maxNameLength}s".format(emitReferenceNoOverrides(data))


### PR DESCRIPTION
The current Verilog emitter adds unnecessary white-spaces to following locations:
- after the last port declaration
- after the opening parenthesis of sub-module

```verilog
module MyModule (
  input               io_a,
  input               io_b,
  output              io_c //<- Trailing whitespace here
);

  assign io_c = (io_a && io_b);

endmodule

module MyTopLevel (
  input               io_cond0,
  input               io_cond1,
  output              io_flag //<- Trailing whitespace here
);
  wire                module_1__io_c;

  MyModule module_1_ ( //<- Trailing whitespace here
    .io_a    (io_cond0        ), //i
    .io_b    (io_cond1        ), //i
    .io_c    (module_1__io_c  )  //o
  );
  assign io_flag = module_1__io_c;

endmodule
```
Sometimes it is necessary to inspect at the generated Verilog code, and my editor highlights trailing white-spaces. So, this pull request remove unnecessary white-spaces, as mentioned above.

I understand this is more of a cosmetic problem than a bug but I hope that you will accept this PR.