### PR TITLE
added alignment check to apb3 decoder

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba3/apb/Apb3Decoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/apb/Apb3Decoder.scala
@@ -58,6 +58,10 @@ class Apb3Decoder(inputConfig: Apb3Config, decodings: Seq[SizeMapping]) extends 
   assert(inputConfig.selWidth == 1, "Apb3Decoder: input sel width must be equal to 1")
   assert(!SizeMapping.verifyOverlapping(decodings), "Apb3Decoder: overlapping found")
 
+  for(mapping <- decodings) {
+    assert(mapping.base % mapping.size == 0, f"Mapping at 0x${mapping.base}%x is not aligned to its size (0x${mapping.size}%x bytes)")
+  }
+
   val io = new Bundle {
     val input  = slave(Apb3(inputConfig))
     val output = master(Apb3(Apb3Decoder.getOutputConfig(inputConfig,decodings)))


### PR DESCRIPTION
If a mapping is not aligned to it's size, the address generated by the processor will not match the address given to the hardware unit. Ensure all mappings are aligned to at least their own size to prevent this. 