### PR TITLE
QSysify emitters for AXI4, AXI4 Lite and Interrupt Sender

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
@@ -55,10 +55,10 @@ case class Axi4Config(addressWidth : Int,
                       wUserWidth   : Int = -1,
                       bUserWidth   : Int = -1,
                       
-                      readIssuingCapability     : Int = 1,
-                      writeIssuingCapability    : Int = 1,
-                      combinedIssuingCapability : Int = 1,
-                      readDataReorderingDepth   : Int = 1) {
+                      readIssuingCapability     : Int = -1,
+                      writeIssuingCapability    : Int = -1,
+                      combinedIssuingCapability : Int = -1,
+                      readDataReorderingDepth   : Int = -1) {
 
 
   def useArUser = arUserWidth >= 0

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
@@ -49,11 +49,16 @@ case class Axi4Config(addressWidth : Int,
                       useResp      : Boolean = true,
                       useProt      : Boolean = true,
                       useStrb      : Boolean = true,
-                      arUserWidth   : Int = -1,
-                      awUserWidth   : Int = -1,
+                      arUserWidth  : Int = -1,
+                      awUserWidth  : Int = -1,
                       rUserWidth   : Int = -1,
                       wUserWidth   : Int = -1,
-                      bUserWidth   : Int = -1) {
+                      bUserWidth   : Int = -1,
+                      
+                      readIssuingCapability     : Int = 1,
+                      writeIssuingCapability    : Int = 1,
+                      combinedIssuingCapability : Int = 1,
+                      readDataReorderingDepth   : Int = 1) {
 
 
   def useArUser = arUserWidth >= 0
@@ -66,6 +71,11 @@ case class Axi4Config(addressWidth : Int,
 
   if(useId)
     require(idWidth >= 0,"You need to set idWidth")
+
+  require(combinedIssuingCapability >= scala.math.max(readIssuingCapability, writeIssuingCapability),
+    "Inconsistent combined issuing capability")
+  require(readDataReorderingDepth <= readIssuingCapability,
+    "Inconsistent read data reordering depth")
 
   def addressType = UInt(addressWidth bits)
   def dataType = Bits(dataWidth bits)

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axilite/AxiLite4.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axilite/AxiLite4.scala
@@ -82,10 +82,17 @@ object AxiLite4 {
   * @param dataWidth    Width of the data bus
   */
 case class AxiLite4Config(addressWidth : Int,
-                          dataWidth    : Int){
+                          dataWidth    : Int,
+                          
+                          readIssuingCapability     : Int = 1,
+                          writeIssuingCapability    : Int = 1,
+                          combinedIssuingCapability : Int = 1,
+                          readDataReorderingDepth   : Int = 1){
   def bytePerWord = dataWidth/8
   def addressType = UInt(addressWidth bits)
   def dataType = Bits(dataWidth bits)
+
+  require(dataWidth == 32 || dataWidth == 64, "Data width must be 32 or 64")
 }
 
 

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axilite/AxiLite4.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axilite/AxiLite4.scala
@@ -84,10 +84,10 @@ object AxiLite4 {
 case class AxiLite4Config(addressWidth : Int,
                           dataWidth    : Int,
                           
-                          readIssuingCapability     : Int = 1,
-                          writeIssuingCapability    : Int = 1,
-                          combinedIssuingCapability : Int = 1,
-                          readDataReorderingDepth   : Int = 1){
+                          readIssuingCapability     : Int = -1,
+                          writeIssuingCapability    : Int = -1,
+                          combinedIssuingCapability : Int = -1,
+                          readDataReorderingDepth   : Int = -1){
   def bytePerWord = dataWidth/8
   def addressType = UInt(addressWidth bits)
   def dataType = Bits(dataWidth bits)

--- a/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
+++ b/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
@@ -3,6 +3,7 @@ package spinal.lib.eda.altera
 import spinal.core._
 import spinal.lib.bus.amba3.apb.Apb3
 import spinal.lib.bus.avalon.AvalonMM
+import spinal.lib.bus.amba4.axi.Axi4
 
 import scala.collection.mutable
 import scala.collection.mutable.StringBuilder
@@ -12,6 +13,7 @@ object QSysify{
     val tool = new QSysify
     tool.interfaceEmiters += new AvalonEmitter()
     tool.interfaceEmiters += new ApbEmitter()
+    tool.interfaceEmiters += new Axi4Emitter()
     tool.interfaceEmiters += new ClockDomainEmitter()
     tool.interfaceEmiters += new ResetEmitterEmitter()
     tool.interfaceEmiters += new InterruptReceiverEmitter()
@@ -459,5 +461,115 @@ class InterruptSenderEmitter extends QSysifyInterfaceEmiter{
 |add_interface_port $interfaceName $name irq Output ${i.getBitsWidth}
 |""".stripMargin
     true
+  }
+}
+
+class Axi4Emitter extends QSysifyInterfaceEmiter{
+  override def emit(i: Data,builder : StringBuilder): Boolean = i match {
+    case e: Axi4 =>{
+      import e.config._
+      val isMaster = e.isMasterInterface
+      val (masterPinDir,slavePinDir,startEnd) = if(isMaster) ("Output", "Input","start") else ("Input","Output","end")
+      val name = e.getName()
+      val clockDomainTag = e.getTag(classOf[ClockDomainTag])
+      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You shoud apply the ClockDomainTag to the inferface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
+      val clockName = clockDomainTag.get.clockDomain.clock.getName()
+      val resetName = clockDomainTag.get.clockDomain.reset.getName()
+      builder ++= s"""
+|#
+|# connection point $name
+|#
+|add_interface $name axi4 $startEnd
+|
+|set_interface_property $name associatedClock $clockName
+|set_interface_property $name associatedReset $resetName
+|
+|set_interface_property $name ENABLED true
+|set_interface_property $name EXPORT_OF ""
+|set_interface_property $name PORT_NAME_MAP ""
+|set_interface_property $name SVD_ADDRESS_GROUP ""
+""".stripMargin
+
+      if(isMaster) builder ++= s"""
+|set_interface_property $name readIssuingCapability ${readIssuingCapability}
+|set_interface_property $name writeIssuingCapability ${writeIssuingCapability}
+|set_interface_property $name combinedIssuingCapability ${combinedIssuingCapability}
+""".stripMargin
+      else builder ++= s"""
+|set_interface_property $name readAcceptanceCapability ${readIssuingCapability}
+|set_interface_property $name writeAcceptanceCapability ${writeIssuingCapability}
+|set_interface_property $name combinedAcceptanceCapability ${combinedIssuingCapability}
+|set_interface_property $name readDataReorderingDepth ${readDataReorderingDepth}
+""".stripMargin
+
+      // emit AR
+      builder ++= s"""
+|add_interface_port $name ${e.ar.valid.getName()} arvalid ${masterPinDir} 1
+|add_interface_port $name ${e.ar.ready.getName()} arready ${slavePinDir} 1
+|add_interface_port $name ${e.ar.payload.addr.getName()} araddr ${masterPinDir} ${addressWidth}
+""".stripMargin
+
+      if(useId) builder ++= s"add_interface_port $name ${e.ar.payload.id.getName()} arid ${masterPinDir} ${idWidth}\n"
+      if(useLen) builder ++= s"add_interface_port $name ${e.ar.payload.len.getName()} arlen ${masterPinDir} 8\n"
+      if(useSize) builder ++= s"add_interface_port $name ${e.ar.payload.size.getName()} arsize ${masterPinDir} 3\n"
+      if(useBurst) builder ++= s"add_interface_port $name ${e.ar.payload.burst.getName()} arburst ${masterPinDir} 2\n"
+      if(useLock) builder ++= s"add_interface_port $name ${e.ar.payload.lock.getName()} arlock ${masterPinDir} 2\n"
+      if(useCache) builder ++= s"add_interface_port $name ${e.ar.payload.cache.getName()} arcache ${masterPinDir} 4\n"
+      if(useProt) builder ++= s"add_interface_port $name ${e.ar.payload.prot.getName()} arprot ${masterPinDir} 3\n"
+      if(useArUser) builder ++= s"add_interface_port $name ${e.b.payload.user.getName()} aruser ${slavePinDir} ${arUserWidth}\n"
+      
+      // emit AW
+      builder ++= s"""
+|add_interface_port $name ${e.aw.valid.getName()} awvalid ${masterPinDir} 1
+|add_interface_port $name ${e.aw.ready.getName()} awready ${slavePinDir} 1
+|add_interface_port $name ${e.aw.payload.addr.getName()} awaddr ${masterPinDir} ${addressWidth}
+""".stripMargin
+
+      if(useId) builder ++= s"add_interface_port $name ${e.aw.payload.id.getName()} awid ${masterPinDir} ${idWidth}\n"
+      if(useLen) builder ++= s"add_interface_port $name ${e.aw.payload.len.getName()} awlen ${masterPinDir} 8\n"
+      if(useSize) builder ++= s"add_interface_port $name ${e.aw.payload.size.getName()} awsize ${masterPinDir} 3\n"
+      if(useBurst) builder ++= s"add_interface_port $name ${e.aw.payload.burst.getName()} awburst ${masterPinDir} 2\n"
+      if(useLock) builder ++= s"add_interface_port $name ${e.aw.payload.lock.getName()} awlock ${masterPinDir} 2\n"
+      if(useCache) builder ++= s"add_interface_port $name ${e.aw.payload.cache.getName()} awcache ${masterPinDir} 4\n"
+      if(useProt) builder ++= s"add_interface_port $name ${e.aw.payload.prot.getName()} awprot ${masterPinDir} 3\n"
+      if(useAwUser) builder ++= s"add_interface_port $name ${e.b.payload.user.getName()} awuser ${slavePinDir} ${awUserWidth}\n"
+      
+      // emit R
+      builder ++= s"""
+|add_interface_port $name ${e.r.valid.getName()} rvalid ${slavePinDir} 1
+|add_interface_port $name ${e.r.ready.getName()} rready ${masterPinDir} 1
+|add_interface_port $name ${e.r.payload.data.getName()} rdata ${slavePinDir} ${dataWidth}
+""".stripMargin
+
+      if(useId) builder ++= s"add_interface_port $name ${e.r.payload.id.getName()} rid ${slavePinDir} ${idWidth}\n"
+      if(useLast) builder ++= s"add_interface_port $name ${e.r.payload.last.getName()} rlast ${slavePinDir} 1\n"
+      if(useResp) builder ++= s"add_interface_port $name ${e.r.payload.resp.getName()} rresp ${slavePinDir} 2\n"
+      if(useRUser) builder ++= s"add_interface_port $name ${e.b.payload.user.getName()} ruser ${slavePinDir} ${rUserWidth}\n"
+
+      // emit W
+      builder ++= s"""
+|add_interface_port $name ${e.w.valid.getName()} wvalid ${masterPinDir} 1
+|add_interface_port $name ${e.w.ready.getName()} wready ${slavePinDir} 1
+|add_interface_port $name ${e.w.payload.data.getName()} wdata ${masterPinDir} ${dataWidth}
+""".stripMargin
+
+      if(useLast) builder ++= s"add_interface_port $name ${e.w.payload.last.getName()} wlast ${masterPinDir} 1\n"
+      if(useStrb) builder ++= s"add_interface_port $name ${e.w.payload.strb.getName()} wstrb ${masterPinDir} ${dataWidth/8}\n"
+      if(useWUser) builder ++= s"add_interface_port $name ${e.b.payload.user.getName()} wuser ${slavePinDir} ${wUserWidth}\n"
+
+      // emit B
+      builder ++= s"""
+|add_interface_port $name ${e.b.valid.getName()} bvalid ${slavePinDir} 1
+|add_interface_port $name ${e.b.ready.getName()} bready ${masterPinDir} 1
+""".stripMargin
+
+      if(useId) builder ++= s"add_interface_port $name ${e.b.payload.id.getName()} bid ${slavePinDir} ${idWidth}\n"
+      if(useResp) builder ++= s"add_interface_port $name ${e.b.payload.resp.getName()} bresp ${slavePinDir} 2\n"
+      if(useBUser) builder ++= s"add_interface_port $name ${e.b.payload.user.getName()} buser ${slavePinDir} ${bUserWidth}\n"
+
+
+      true
+      }
+    case _ => false
   }
 }

--- a/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
+++ b/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
@@ -492,17 +492,24 @@ class Axi4Emitter extends QSysifyInterfaceEmiter{
 |set_interface_property $name SVD_ADDRESS_GROUP ""
 """.stripMargin
 
-      if(isMaster) builder ++= s"""
-|set_interface_property $name readIssuingCapability ${readIssuingCapability}
-|set_interface_property $name writeIssuingCapability ${writeIssuingCapability}
-|set_interface_property $name combinedIssuingCapability ${combinedIssuingCapability}
-""".stripMargin
-      else builder ++= s"""
-|set_interface_property $name readAcceptanceCapability ${readIssuingCapability}
-|set_interface_property $name writeAcceptanceCapability ${writeIssuingCapability}
-|set_interface_property $name combinedAcceptanceCapability ${combinedIssuingCapability}
-|set_interface_property $name readDataReorderingDepth ${readDataReorderingDepth}
-""".stripMargin
+      if(isMaster) {
+        if(readIssuingCapability > -1)
+          builder ++= s"set_interface_property $name readIssuingCapability ${readIssuingCapability}\n"
+        if(writeIssuingCapability > -1)
+          builder ++= s"set_interface_property $name writeIssuingCapability ${writeIssuingCapability}\n"
+        if(combinedIssuingCapability > -1)
+          builder ++= s"set_interface_property $name combinedIssuingCapability ${combinedIssuingCapability}\n"
+      }
+      else {
+        if(readIssuingCapability > -1)
+          builder ++= s"set_interface_property $name readAcceptanceCapability ${readIssuingCapability}\n"
+        if(writeIssuingCapability > -1)
+          builder ++= s"set_interface_property $name writeAcceptanceCapability ${writeIssuingCapability}\n"
+        if(combinedIssuingCapability > -1)
+          builder ++= s"set_interface_property $name combinedAcceptanceCapability ${combinedIssuingCapability}\n"
+        if(readDataReorderingDepth > -1)
+          builder ++= s"set_interface_property $name readDataReorderingDepth ${readDataReorderingDepth}\n"
+      }
 
       // emit AR
       builder ++= s"""
@@ -602,17 +609,24 @@ class AxiLite4Emitter extends QSysifyInterfaceEmiter{
 |set_interface_property $name SVD_ADDRESS_GROUP ""
 """.stripMargin
 
-      if(isMaster) builder ++= s"""
-|set_interface_property $name readIssuingCapability ${readIssuingCapability}
-|set_interface_property $name writeIssuingCapability ${writeIssuingCapability}
-|set_interface_property $name combinedIssuingCapability ${combinedIssuingCapability}
-""".stripMargin
-      else builder ++= s"""
-|set_interface_property $name readAcceptanceCapability ${readIssuingCapability}
-|set_interface_property $name writeAcceptanceCapability ${writeIssuingCapability}
-|set_interface_property $name combinedAcceptanceCapability ${combinedIssuingCapability}
-|set_interface_property $name readDataReorderingDepth ${readDataReorderingDepth}
-""".stripMargin
+      if(isMaster) {
+        if(readIssuingCapability > -1)
+          builder ++= s"set_interface_property $name readIssuingCapability ${readIssuingCapability}\n"
+        if(writeIssuingCapability > -1)
+          builder ++= s"set_interface_property $name writeIssuingCapability ${writeIssuingCapability}\n"
+        if(combinedIssuingCapability > -1)
+          builder ++= s"set_interface_property $name combinedIssuingCapability ${combinedIssuingCapability}\n"
+      }
+      else {
+        if(readIssuingCapability > -1)
+          builder ++= s"set_interface_property $name readAcceptanceCapability ${readIssuingCapability}\n"
+        if(writeIssuingCapability > -1)
+          builder ++= s"set_interface_property $name writeAcceptanceCapability ${writeIssuingCapability}\n"
+        if(combinedIssuingCapability > -1)
+          builder ++= s"set_interface_property $name combinedAcceptanceCapability ${combinedIssuingCapability}\n"
+        if(readDataReorderingDepth > -1)
+          builder ++= s"set_interface_property $name readDataReorderingDepth ${readDataReorderingDepth}\n"
+      }
 
       // emit AR
       builder ++= s"""


### PR DESCRIPTION
Configs for AXI4 and AXI4 had to be extended:
max number of pending reads/writes and reorder FIFO depth

I also added a check for AXI4 Lite data width. The spec only allows 32 and 64 bit.