### PR TITLE
Various Bugfixes and improvements to VPI/GHDL backend

### DIFF
--- a/sim/src/main/java/spinal/sim/vpi/JNISharedMemIfaceJNI.java
+++ b/sim/src/main/java/spinal/sim/vpi/JNISharedMemIfaceJNI.java
@@ -39,5 +39,6 @@ public class JNISharedMemIfaceJNI {
   public final static native void SharedMemIface_eval(long jarg1, SharedMemIface jarg1_);
   public final static native void SharedMemIface_randomize(long jarg1, SharedMemIface jarg1_, long jarg2);
   public final static native void SharedMemIface_close(long jarg1, SharedMemIface jarg1_);
+  public final static native void SharedMemIface_check_ready(long jarg1, SharedMemIface jarg1_);
   public final static native boolean SharedMemIface_is_closed(long jarg1, SharedMemIface jarg1_);
 }

--- a/sim/src/main/java/spinal/sim/vpi/JNISharedMemIfaceJNI.java
+++ b/sim/src/main/java/spinal/sim/vpi/JNISharedMemIfaceJNI.java
@@ -40,5 +40,6 @@ public class JNISharedMemIfaceJNI {
   public final static native void SharedMemIface_randomize(long jarg1, SharedMemIface jarg1_, long jarg2);
   public final static native void SharedMemIface_close(long jarg1, SharedMemIface jarg1_);
   public final static native void SharedMemIface_check_ready(long jarg1, SharedMemIface jarg1_);
+  public final static native void SharedMemIface_set_crashed(long jarg1, SharedMemIface jarg1_, long jarg2);
   public final static native boolean SharedMemIface_is_closed(long jarg1, SharedMemIface jarg1_);
 }

--- a/sim/src/main/java/spinal/sim/vpi/SharedMemIface.java
+++ b/sim/src/main/java/spinal/sim/vpi/SharedMemIface.java
@@ -96,6 +96,10 @@ public class SharedMemIface {
     JNISharedMemIfaceJNI.SharedMemIface_check_ready(swigCPtr, this);
   }
 
+  public void set_crashed(long ret_code_) {
+    JNISharedMemIfaceJNI.SharedMemIface_set_crashed(swigCPtr, this, ret_code_);
+  }
+
   public boolean is_closed() {
     return JNISharedMemIfaceJNI.SharedMemIface_is_closed(swigCPtr, this);
   }

--- a/sim/src/main/java/spinal/sim/vpi/SharedMemIface.java
+++ b/sim/src/main/java/spinal/sim/vpi/SharedMemIface.java
@@ -92,6 +92,10 @@ public class SharedMemIface {
     JNISharedMemIfaceJNI.SharedMemIface_close(swigCPtr, this);
   }
 
+  public void check_ready() {
+    JNISharedMemIfaceJNI.SharedMemIface_check_ready(swigCPtr, this);
+  }
+
   public boolean is_closed() {
     return JNISharedMemIfaceJNI.SharedMemIface_is_closed(swigCPtr, this);
   }

--- a/sim/src/main/resources/SharedMemIface.hpp
+++ b/sim/src/main/resources/SharedMemIface.hpp
@@ -2,6 +2,7 @@
 #include"SharedStruct.hpp"
 #include<string>
 #include<vector>
+#include<atomic>
 
 using namespace std;
 
@@ -24,6 +25,7 @@ class SharedMemIface {
     void close();
     bool is_closed(){ return this->closed; };
     void check_ready();
+    void set_crashed(int64_t ret_code_){ this->ret_code.store(ret_code_); };
     virtual ~SharedMemIface();
 
     private:
@@ -32,6 +34,7 @@ class SharedMemIface {
     SharedStruct* shared_struct; 
     string shmem_name;
     size_t shmem_size;
+    std::atomic<int64_t> ret_code;
     std::vector<int8_t> data_buffer;
     std::string error_string;
 };

--- a/sim/src/main/resources/SharedMemIface.hpp
+++ b/sim/src/main/resources/SharedMemIface.hpp
@@ -23,10 +23,10 @@ class SharedMemIface {
     void randomize(int64_t seed);
     void close();
     bool is_closed(){ return this->closed; };
+    void check_ready();
     virtual ~SharedMemIface();
 
     private:
-    void check_ready();
     bool closed;
     managed_shared_memory segment;
     SharedStruct* shared_struct; 

--- a/sim/src/main/resources/SharedMemIface.i
+++ b/sim/src/main/resources/SharedMemIface.i
@@ -44,6 +44,7 @@ public:
     void eval();
     void randomize(int64_t seed);
     void close();
+    void check_ready();
     bool is_closed();
 };
 

--- a/sim/src/main/resources/SharedMemIface.i
+++ b/sim/src/main/resources/SharedMemIface.i
@@ -45,6 +45,7 @@ public:
     void randomize(int64_t seed);
     void close();
     void check_ready();
+    void set_crashed(int64_t ret_code_);
     bool is_closed();
 };
 

--- a/sim/src/main/resources/SharedMemIface_wrap.cxx
+++ b/sim/src/main/resources/SharedMemIface_wrap.cxx
@@ -1030,6 +1030,30 @@ SWIGEXPORT void JNICALL Java_spinal_sim_vpi_JNISharedMemIfaceJNI_SharedMemIface_
 }
 
 
+SWIGEXPORT void JNICALL Java_spinal_sim_vpi_JNISharedMemIfaceJNI_SharedMemIface_1check_1ready(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+  SharedMemIface *arg1 = (SharedMemIface *) 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(SharedMemIface **)&jarg1; 
+  {
+    try {
+      (arg1)->check_ready();
+    } catch (VpiException &e) {
+      jclass clazz = jenv->FindClass("spinal/sim/VpiException");
+      jenv->ThrowNew(clazz, e.what());
+      return ;
+    } catch (std::exception &e) {
+      jclass clazz = jenv->FindClass("java/lang/Exception");
+      jenv->ThrowNew(clazz, e.what());
+      return ;
+    }
+    
+  }
+}
+
+
 SWIGEXPORT jboolean JNICALL Java_spinal_sim_vpi_JNISharedMemIfaceJNI_SharedMemIface_1is_1closed(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jboolean jresult = 0 ;
   SharedMemIface *arg1 = (SharedMemIface *) 0 ;

--- a/sim/src/main/resources/SharedMemIface_wrap.cxx
+++ b/sim/src/main/resources/SharedMemIface_wrap.cxx
@@ -1054,6 +1054,32 @@ SWIGEXPORT void JNICALL Java_spinal_sim_vpi_JNISharedMemIfaceJNI_SharedMemIface_
 }
 
 
+SWIGEXPORT void JNICALL Java_spinal_sim_vpi_JNISharedMemIfaceJNI_SharedMemIface_1set_1crashed(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2) {
+  SharedMemIface *arg1 = (SharedMemIface *) 0 ;
+  int64_t arg2 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(SharedMemIface **)&jarg1; 
+  arg2 = (int64_t)jarg2; 
+  {
+    try {
+      (arg1)->set_crashed(arg2);
+    } catch (VpiException &e) {
+      jclass clazz = jenv->FindClass("spinal/sim/VpiException");
+      jenv->ThrowNew(clazz, e.what());
+      return ;
+    } catch (std::exception &e) {
+      jclass clazz = jenv->FindClass("java/lang/Exception");
+      jenv->ThrowNew(clazz, e.what());
+      return ;
+    }
+    
+  }
+}
+
+
 SWIGEXPORT jboolean JNICALL Java_spinal_sim_vpi_JNISharedMemIfaceJNI_SharedMemIface_1is_1closed(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jboolean jresult = 0 ;
   SharedMemIface *arg1 = (SharedMemIface *) 0 ;

--- a/sim/src/main/resources/VpiPlugin.cpp
+++ b/sim/src/main/resources/VpiPlugin.cpp
@@ -88,6 +88,7 @@ void entry_point_cb() {
     ifstream shmem_file(SHMEM_FILENAME);
     string shmem_name;
     getline(shmem_file, shmem_name);
+    cout << "Shared memory key : " << shmem_name << endl;
     segment = managed_shared_memory(open_only, shmem_name.c_str());
     auto ret_struct = segment.find<SharedStruct>("SharedStruct");
     shared_struct = ret_struct.first; 

--- a/sim/src/main/scala/spinal/sim/Signal.scala
+++ b/sim/src/main/scala/spinal/sim/Signal.scala
@@ -134,10 +134,10 @@ class SIntDataType(width : Int) extends BitVectorDataType(width){
 }
 
 class Signal(val path : Seq[String],val dataType : DataType) {
-  var id : Long = -1
-  var validId = false
+  var id : Int = -1
   override def toString = s"${path.mkString("/")} : $dataType"
-  def toVPIAddress = path.mkString(".")
+  def toVpiAddress = path.mkString(".")
+  val hash = toVpiAddress.hashCode()
 }
 
 

--- a/sim/src/main/scala/spinal/sim/SimVerilator.scala
+++ b/sim/src/main/scala/spinal/sim/SimVerilator.scala
@@ -6,23 +6,23 @@ object SimVerilator{
 
 class SimVerilator(backend : VerilatorBackend, handle : Long) extends SimRaw(){
   override def getInt(signal : Signal) : Int = {
-    assert(signal.id.toInt != -1, "You can't access this signal in the simulation, as it isn't public")
-    signal.dataType.raw64ToInt(backend.nativeInstance.getU64(handle, signal.id.toInt), signal : Signal)
+    assert(signal.id != -1, "You can't access this signal in the simulation, as it isn't public")
+    signal.dataType.raw64ToInt(backend.nativeInstance.getU64(handle, signal.id), signal : Signal)
   }
   override def getLong(signal : Signal) : Long = {
-    assert(signal.id.toInt != -1, "You can't access this signal in the simulation, as it isn't public")
-    signal.dataType.raw64ToLong(backend.nativeInstance.getU64(handle, signal.id.toInt), signal : Signal)
+    assert(signal.id != -1, "You can't access this signal in the simulation, as it isn't public")
+    signal.dataType.raw64ToLong(backend.nativeInstance.getU64(handle, signal.id), signal : Signal)
   }
   override def setLong(signal : Signal, value : Long) : Unit = {
-    assert(signal.id.toInt != -1, "You can't access this signal in the simulation, as it isn't public")
-    backend.nativeInstance.setU64(handle, signal.id.toInt, signal.dataType.longToRaw64(value, signal : Signal))
+    assert(signal.id != -1, "You can't access this signal in the simulation, as it isn't public")
+    backend.nativeInstance.setU64(handle, signal.id, signal.dataType.longToRaw64(value, signal : Signal))
   }
 
   override def getBigInt(signal: Signal) = {
     if(signal.dataType.width < 64 || (signal.dataType.width == 64 && signal.dataType.isInstanceOf[SIntDataType])) {
       getLong(signal)
     } else if(signal.dataType.width == 64){
-      val rawValue = backend.nativeInstance.getU64(handle, signal.id.toInt)
+      val rawValue = backend.nativeInstance.getU64(handle, signal.id)
       if(rawValue >= 0 ) {
         BigInt(rawValue)
       }else{
@@ -31,11 +31,11 @@ class SimVerilator(backend : VerilatorBackend, handle : Long) extends SimRaw(){
     } else {
       if(signal.dataType.isInstanceOf[SIntDataType]){
         val array = new Array[Byte]((signal.dataType.width+31)/32*4)
-        backend.nativeInstance.getAU8(handle, signal.id.toInt, array)
+        backend.nativeInstance.getAU8(handle, signal.id, array)
         BigInt(array)
       }else{
         val array = new Array[Byte]((signal.dataType.width+31)/32*4 + 1)
-        backend.nativeInstance.getAU8(handle, signal.id.toInt, array)
+        backend.nativeInstance.getAU8(handle, signal.id, array)
         array(0) = 0
         BigInt(array)
       }
@@ -47,14 +47,14 @@ class SimVerilator(backend : VerilatorBackend, handle : Long) extends SimRaw(){
     if(valueBitLength <= 63) {
       setLong(signal, value.toLong)
     } else if(valueBitLength == 64 && signal.dataType.width == 64) {
-      assert(signal.id.toInt != -1, "You can't access this signal in the simulation, as it isn't public")
+      assert(signal.id != -1, "You can't access this signal in the simulation, as it isn't public")
       val valueLong = value.toLong
       signal.dataType.checkIs64(valueLong, signal : Signal)
-      backend.nativeInstance.setU64(handle, signal.id.toInt, valueLong)
+      backend.nativeInstance.setU64(handle, signal.id, valueLong)
     } else {
       signal.dataType.checkBigIntRange(value, signal)
       val array = value.toByteArray
-      backend.nativeInstance.setAU8(handle, signal.id.toInt, array, array.length)
+      backend.nativeInstance.setAU8(handle, signal.id, array, array.length)
     }
   }
 

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -13,26 +13,41 @@ import scala.sys.process._
 
 import spinal.sim.vpi._
 
-class VpiBackendConfig {
-  val rtlSourcesPaths        = ArrayBuffer[String]()
-  var toplevelName: String   = null
-  var pluginsPath: String    = "simulation_plugins"
-  var workspacePath: String  = null
-  var workspaceName: String  = null
-  var wavePath: String       = null
-  var waveFormat: WaveFormat = WaveFormat.NONE
-  var analyzeFlags: String   = ""
-  var runFlags: String       = ""
-  var sharedMemSize          = 65536
-  var CC: String             = "g++" 
-  var CFLAGS: String         = "-std=c++11 -Wall -Wextra -pedantic -O2 -Wno-strict-aliasing" 
-  var LDFLAGS: String        = "-lrt -lpthread " 
-  var useCache: Boolean      = false
-}
+case class VpiBackendConfig(
+  val rtlSourcesPaths: ArrayBuffer[String] = ArrayBuffer[String](),
+  var toplevelName: String     = null,
+  var pluginsPath: String      = "simulation_plugins",
+  var workspacePath: String    = null,
+  var workspaceName: String    = null,
+  var wavePath: String         = null,
+  var waveFormat: WaveFormat   = WaveFormat.NONE,
+  var analyzeFlags: String     = "",
+  var runFlags: String         = "",
+  var sharedMemSize: Int       = 65536,
+  var CC: String               = "g++",
+  var CFLAGS: String           = "-std=c++11 -Wall -Wextra -pedantic -O2 -Wno-strict-aliasing", 
+  var LDFLAGS: String          = "-lrt -lpthread ", 
+  var useCache: Boolean        = false,
+  var logGhdlProcess: Boolean  = false
+)
 
 abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
-  import config._
   import Backend._
+  val rtlSourcesPaths = config.rtlSourcesPaths 
+  val toplevelName    = config.toplevelName    
+  val pluginsPath     = config.pluginsPath     
+  val workspacePath   = config.workspacePath   
+  val workspaceName   = config.workspaceName   
+  val wavePath        = config.wavePath        
+  val waveFormat      = config.waveFormat      
+  val analyzeFlags    = config.analyzeFlags    
+  var runFlags        = config.runFlags        
+  val sharedMemSize   = config.sharedMemSize   
+  val CC              = config.CC
+  var CFLAGS          = config.CFLAGS
+  var LDFLAGS         = config.LDFLAGS
+  val useCache        = config.useCache              
+  val logGhdlProcess  = config.logGhdlProcess
 
   val sharedExtension = if(isWindows) "dll" else (if(isMac) "dylib" else "so")
   val sharedMemIfaceName = "shared_mem_iface." + sharedExtension
@@ -46,59 +61,62 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
   val jdk = System.getProperty("java.home").replace("/jre","").replace("\\jre","")
 
   CFLAGS += s" -I$jdk/include -I$jdk/include/${(if(isWindows) "win32" 
-                                                else (if (isMac) "darwin" 
-                                                      else "linux"))}"
+  else (if (isMac) "darwin" 
+  else "linux"))}"
 
   class Logger extends ProcessLogger { 
-    override def err(s: => String): Unit = {if(!s.startsWith("ar: creating ")) println(s)}
-    override def out(s: => String): Unit = {}
+    override def err(s: => String): Unit = { if(logGhdlProcess) println(s) }
+    override def out(s: => String): Unit = { if(logGhdlProcess) println(s) }
     override def buffer[T](f: => T) = f
   }
 
-  if(!(Files.exists(Paths.get(sharedMemIfacePath)) && useCache)) {
-    List("/SharedMemIface.cpp", 
-         "/SharedMemIface.hpp", 
-         "/SharedMemIface_wrap.cxx", 
-         "/SharedStruct.hpp").foreach { filename =>
-           val cppSourceFile = new PrintWriter(new File(pluginsPath + "/" + filename))
-           val stream = getClass.getResourceAsStream(filename)
-           cppSourceFile.write(scala.io.Source.fromInputStream(stream).mkString) 
-           cppSourceFile.close
-         }
-
-         assert(Process(Seq(CC, 
-           "-c", 
-           CFLAGS, 
-           "SharedMemIface.cpp", 
-           "-o",
-           "SharedMemIface.o").mkString(" "), 
-         new File(pluginsPath)).! (new Logger()) == 0, 
-       "Compilation of SharedMemIface.cpp failed")
-
-         assert(Process(Seq(CC, 
-           "-c", 
-           CFLAGS, 
-           "SharedMemIface_wrap.cxx", 
-           "-o",
-           "SharedMemIface_wrap.o").mkString(" "), 
-         new File(pluginsPath)).! (new Logger()) == 0, 
-       "Compilation of SharedMemIface_wrap.cxx failed")
-
-         assert(Process(Seq(CC, 
-           CFLAGS, 
-           "SharedMemIface.o", 
-           "SharedMemIface_wrap.o",
-           LDFLAGS, 
-           "-o",
-           sharedMemIfaceName).mkString(" "),
-
-         new File(pluginsPath)).! (new Logger()) == 0, 
-       "Compilation of SharedMemIface." + sharedExtension + " failed")
-  }
-
   val pwd = new File(".").getAbsolutePath().mkString
-  System.load(pwd + "/" + sharedMemIfacePath)
 
+  VpiBackend.synchronized {
+    if(!(Files.exists(Paths.get(sharedMemIfacePath)) && useCache)) {
+      List("/SharedMemIface.cpp", 
+        "/SharedMemIface.hpp", 
+        "/SharedMemIface_wrap.cxx", 
+        "/SharedStruct.hpp").foreach { filename =>
+          val cppSourceFile = new PrintWriter(new File(pluginsPath + "/" + filename))
+          val stream = getClass.getResourceAsStream(filename)
+          cppSourceFile.write(scala.io.Source.fromInputStream(stream).mkString) 
+          cppSourceFile.close
+        }
+
+        assert(Process(Seq(CC, 
+          "-c", 
+          CFLAGS, 
+          "SharedMemIface.cpp", 
+          "-o",
+          "SharedMemIface.o").mkString(" "), 
+        new File(pluginsPath)).! (new Logger()) == 0, 
+      "Compilation of SharedMemIface.cpp failed")
+
+        assert(Process(Seq(CC, 
+          "-c", 
+          CFLAGS, 
+          "SharedMemIface_wrap.cxx", 
+          "-o",
+          "SharedMemIface_wrap.o").mkString(" "), 
+        new File(pluginsPath)).! (new Logger()) == 0, 
+      "Compilation of SharedMemIface_wrap.cxx failed")
+
+        assert(Process(Seq(CC, 
+          CFLAGS, 
+          "SharedMemIface.o", 
+          "SharedMemIface_wrap.o",
+          LDFLAGS, 
+          "-o",
+          sharedMemIfaceName).mkString(" "),
+
+        new File(pluginsPath)).! (new Logger()) == 0, 
+      "Compilation of SharedMemIface." + sharedExtension + " failed")
+    }
+
+    System.load(pwd + "/" + sharedMemIfacePath)
+  }
+ 
   def clean() {
     FileUtils.deleteQuietly(new File(s"${workspacePath}/${workspaceName}"))
     FileUtils.cleanDirectory(new File(pluginsPath))
@@ -108,26 +126,31 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
   def analyzeRTL()
   def runSimulation() : Thread
   def instanciate() : (SharedMemIface, Thread) = {
-    compileVPI()
-    analyzeRTL()
-    val shmemKey = Seq("SpinalHDL",
-                       runIface.toString,
-                       uniqueId.toString,
-                       hashCode().toString, 
-                       System.currentTimeMillis().toString,
-                       scala.util.Random.nextLong().toString).mkString("_")
+    VpiBackend.synchronized {  
+        compileVPI()
+        analyzeRTL()      
+        val shmemKey = Seq("SpinalHDL",
+                           runIface.toString,
+                           uniqueId.toString,
+                           hashCode().toString, 
+                           pwd.hashCode().toString,
+                           System.currentTimeMillis().toString,
+                           scala.util.Random.nextLong().toString).mkString("_")
 
-    runIface += 1
+      runIface += 1
 
-    val sharedMemIface = new SharedMemIface(shmemKey, sharedMemSize)
-    var shmemFile = new PrintWriter(new File(workspacePath + "/shmem_name"))
-    shmemFile.write(shmemKey) 
-    shmemFile.close
-    val thread = runSimulation()
-    (sharedMemIface, thread)
+      val sharedMemIface = new SharedMemIface(shmemKey, sharedMemSize)
+      var shmemFile = new PrintWriter(new File(workspacePath + "/shmem_name"))
+      shmemFile.write(shmemKey) 
+      shmemFile.close
+      val thread = runSimulation()
+      sharedMemIface.check_ready
+      (sharedMemIface, thread)
+    }
   }
 }
 
+object VpiBackend {}
 
 class GhdlBackendConfig extends VpiBackendConfig {
   var ghdlPath: String = null
@@ -135,40 +158,39 @@ class GhdlBackendConfig extends VpiBackendConfig {
 }
 
 class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
-  import config._
-  
+  var ghdlPath = config.ghdlPath
+  val elaborationFlags = config.elaborationFlags
+
   val availableFormats = Array(WaveFormat.VCD, WaveFormat.VCDGZ,
-                               WaveFormat.FST, WaveFormat.GHW, 
-                               WaveFormat.DEFAULT, WaveFormat.NONE)
+    WaveFormat.FST, WaveFormat.GHW, 
+    WaveFormat.DEFAULT, WaveFormat.NONE)
 
   val format = if(availableFormats contains waveFormat){
-                waveFormat  
-              } else {
-                println("Wave format " + waveFormat + " not supported by GHDL")
-                WaveFormat.NONE
-              }
+    waveFormat  
+  } else {
+    println("Wave format " + waveFormat + " not supported by GHDL")
+    WaveFormat.NONE
+  }
 
   if(!(Array(WaveFormat.DEFAULT, 
-             WaveFormat.NONE) contains format)) {
-              
-               if(format == WaveFormat.GHW){
-                 runFlags += " --wave=" + wavePath
-               } else {
-                 runFlags += " --" + format.ext + "=" + wavePath
-               }
+    WaveFormat.NONE) contains format)) {
+
+      if(format == WaveFormat.GHW){
+        runFlags += " --wave=" + wavePath
+      } else {
+        runFlags += " --" + format.ext + "=" + wavePath
       }
+    }
 
-
-
-  if(ghdlPath == null) ghdlPath = "ghdl"
-  var vpiModuleName = "vpi_ghdl.vpi"
+    if(ghdlPath == null) ghdlPath = "ghdl"
+    var vpiModuleName = "vpi_ghdl.vpi"
 
   def compileVPI() = {
     val vpiModulePath = pluginsPath + "/" + vpiModuleName
     if(!(Files.exists(Paths.get(vpiModulePath)) && useCache)) {
 
       for(filename <- Array("/VpiPlugin.cpp", 
-                            "/SharedStruct.hpp")) {
+           "/SharedStruct.hpp")) {
              var cppSourceFile = new PrintWriter(new File(pluginsPath + "/" + filename))
              var stream = getClass.getResourceAsStream(filename)
              cppSourceFile.write(scala.io.Source.fromInputStream(stream).mkString) 
@@ -176,57 +198,66 @@ class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
            }
 
            assert(Process(Seq(ghdlPath,
-                              "--vpi-compile",
-                              CC, 
-                              "-c", 
-                              CFLAGS, 
-                              "VpiPlugin.cpp",
-                              "-o",
-                              "VpiPlugin.o").mkString(" "), 
-                            new File(pluginsPath)).! (new Logger()) == 0, 
-                  "Compilation of VpiPlugin.o failed")
+             "--vpi-compile",
+             CC, 
+             "-c", 
+             CFLAGS, 
+             "VpiPlugin.cpp",
+             "-o",
+             "VpiPlugin.o").mkString(" "), 
+           new File(pluginsPath)).! (new Logger()) == 0, 
+         "Compilation of VpiPlugin.o failed")
 
-            assert(Process(Seq(ghdlPath,
-                              "--vpi-link",
-                              CC, 
-                              CFLAGS,
-                              "VpiPlugin.o",
-                              LDFLAGS,
-                              "-o",
-                              vpiModuleName).mkString(" "), 
-                            new File(pluginsPath)).! (new Logger()) == 0, 
-                  s"Compilation of $vpiModuleName failed")
+           assert(Process(Seq(ghdlPath,
+             "--vpi-link",
+             CC, 
+             CFLAGS,
+             "VpiPlugin.o",
+             LDFLAGS,
+             "-o",
+             vpiModuleName).mkString(" "), 
+           new File(pluginsPath)).! (new Logger()) == 0, 
+         s"Compilation of $vpiModuleName failed")
     }
   } 
 
   def analyzeRTL() {
 
     val vhdlSourcePaths = rtlSourcesPaths.filter { s => (s.endsWith(".vhd") || 
-                                                         s.endsWith(".vhdl")) }
-                                         .mkString(" ")
-    
-    assert(Process(Seq(ghdlPath,
-                       "-a",
-                       analyzeFlags,
-                       vhdlSourcePaths).mkString(" "), 
-                     new File(workspacePath)).! (new Logger()) == 0, 
-           s"Analyze step of vhdl files failed") 
+    s.endsWith(".vhdl")) }
+      .mkString(" ")
+
+      assert(Process(Seq(ghdlPath,
+        "-a",
+        analyzeFlags,
+        vhdlSourcePaths).mkString(" "), 
+      new File(workspacePath)).! (new Logger()) == 0, 
+    s"Analyze step of vhdl files failed") 
+
+      assert(Process(Seq(ghdlPath,
+        "-e",
+        elaborationFlags,
+        toplevelName).mkString(" "), 
+      new File(workspacePath)).! (new Logger()) == 0,
+    s"Elaboration of $toplevelName failed")
+
   }
 
   def runSimulation() : Thread = {
     val vpiModulePath = pluginsPath + "/" + vpiModuleName
-      val thread = new Thread(new Runnable {
+    val thread = new Thread(new Runnable {
       def run(): Unit = {
         assert(Process(Seq(ghdlPath,
-                  elaborationFlags,
-                  "--elab-run",
-                  toplevelName,
-                  s"--vpi=${pwd + "/" + vpiModulePath}",
-                  runFlags).mkString(" "), 
-              new File(workspacePath)).! (new Logger()) == 0,
-              s"Simulation of $toplevelName failed")
+          "-r",
+          elaborationFlags,
+          toplevelName,
+          s"--vpi=${pwd + "/" + vpiModulePath}",
+          runFlags).mkString(" "), 
+        new File(workspacePath)).! (new Logger()) == 0,
+      s"Simulation of $toplevelName failed")
       }
-    })
+    }
+    )
 
     thread.setDaemon(true)
     thread.start()

--- a/sim/src/test/scala/spinal/sim/TestGhdl.scala
+++ b/sim/src/test/scala/spinal/sim/TestGhdl.scala
@@ -7,6 +7,9 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 import sys.process._
 import java.lang.RuntimeException
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
 
 object TestGhdl1 extends App{
   val config = new GhdlBackendConfig()
@@ -414,4 +417,41 @@ object TestGhdl14 extends App{
   ghdlbackend3.close
 
   println("Finished TestGhdl14")
+}
+
+object TestGhdl15 extends App{
+  val config = new GhdlBackendConfig()
+  config.rtlSourcesPaths += "adder.vhd"
+  config.toplevelName = "adder"
+  config.pluginsPath = "simulation_plugins"
+  config.workspacePath = "yolo"
+  config.workspaceName = "yolo"
+  config.wavePath = "test.vcd"
+  config.waveFormat = WaveFormat.VCD
+  config.useCache = true
+
+  val backendFactory = new GhdlBackend(config)
+ 
+  val runningSims = (0 to 7).map { i =>
+    Future {
+      val (ghdlbackend, _) = backendFactory.instanciate()
+      val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
+      val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
+      val sum = ghdlbackend.get_signal_handle("adder.sum")
+      ghdlbackend.write32(nibble1, i)
+      ghdlbackend.write32(nibble2, i+1)
+      ghdlbackend.eval
+      val ret = Seq(i.toString, 
+                "+", 
+                (i+1).toString,
+                "=",
+                ghdlbackend.read32(sum).toString).mkString(" ")
+      ghdlbackend.close
+      ret
+    }
+  }.toArray
+
+
+  runningSims.foreach { res => println(Await.result(res, Duration.Inf))}
+  println("Finished TestGhdl15")
 }

--- a/sim/src/test/scala/spinal/sim/TestGhdl.scala
+++ b/sim/src/test/scala/spinal/sim/TestGhdl.scala
@@ -369,3 +369,49 @@ object TestGhdl13 extends App {
   ghdlbackend.close
   println("Finished TestGhdl13")
 }
+
+object TestGhdl14 extends App{
+  val config = new GhdlBackendConfig()
+  config.rtlSourcesPaths += "adder.vhd"
+  config.toplevelName = "adder"
+  config.pluginsPath = "simulation_plugins"
+  config.workspacePath = "yolo"
+  config.workspaceName = "yolo"
+  config.wavePath = "test.vcd"
+  config.waveFormat = WaveFormat.VCD
+
+  val backendFactory = new GhdlBackend(config)
+  var (ghdlbackend, _) = backendFactory.instanciate
+  var nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
+  var nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
+  var sum = ghdlbackend.get_signal_handle("adder.sum")
+  ghdlbackend.write32(nibble1, 3)
+  ghdlbackend.write32(nibble2, 5)
+  ghdlbackend.eval
+  println("3 + 5 = " + ghdlbackend.read32(sum).toString)
+  ghdlbackend.close
+
+  config.wavePath = "test2.vcd"
+  val (ghdlbackend2, _) = backendFactory.instanciate
+  nibble1 = ghdlbackend2.get_signal_handle("adder.nibble1")
+  nibble2 = ghdlbackend2.get_signal_handle("adder.nibble2")
+  sum = ghdlbackend2.get_signal_handle("adder.sum")
+  ghdlbackend2.write32(nibble1, 3)
+  ghdlbackend2.write32(nibble2, 5)
+  ghdlbackend2.eval
+  println("3 + 5 = " + ghdlbackend2.read32(sum).toString)
+  ghdlbackend2.close
+
+  config.wavePath = "test3.vcd"
+  val (ghdlbackend3, _) = backendFactory.instanciate
+  nibble1 = ghdlbackend3.get_signal_handle("adder.nibble1")
+  nibble2 = ghdlbackend3.get_signal_handle("adder.nibble2")
+  sum = ghdlbackend3.get_signal_handle("adder.sum")
+  ghdlbackend3.write32(nibble1, 3)
+  ghdlbackend3.write32(nibble2, 5)
+  ghdlbackend3.eval
+  println("3 + 5 = " + ghdlbackend3.read32(sum).toString)
+  ghdlbackend3.close
+
+  println("Finished TestGhdl14")
+}


### PR DESCRIPTION
- Now the VPI handles are stored internally in SimVpi to avoid getting invalid values in re-run simulations
- Thread locking on VpiBackend creation and .instanciate
- VpiBackend.instanciate waits the simulation to be ready before returning
- Elaboration and run step was splitted in GhdlBackend. Now elaboration is executed in  .analyze
- Added lazy compilation/analyze step to reduce the number of compilations to be done
- Added  spinal.sim.TestGhdl15 to test Parallel execution of GhdlBackend .. passing
- A crashing simulation doesn't hang the JVM anymore

Now spinal.tester.code.PlaySimGhdl3 runs fine :)