### PR TITLE
SimGHDL Fixes/improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ project/plugins/project/
 .settings
 .bloop
 .metals
-
+*.swp
+*.swo
 .idea
 out
 
@@ -46,7 +47,9 @@ log.txt
 *.out
 *.o
 *.bin
+*.exe
 *.so
+*.dll
 *.vpi
 *.vpl
 

--- a/sim/src/main/resources/SharedMemIface.cpp
+++ b/sim/src/main/resources/SharedMemIface.cpp
@@ -52,9 +52,9 @@ std::vector<int8_t> SharedMemIface::read(int64_t handle){
 }
 
 int64_t SharedMemIface::read64(int64_t handle){
-    int64_t ret = 0ul;
+    int64_t ret = 0;
     this->read(handle, this->data_buffer);
-    size_t copy_size = std::min(8ul, this->data_buffer.size());
+    size_t copy_size = std::min((size_t)8, this->data_buffer.size());
     size_t start_orig = this->data_buffer.size()-1;
     for(uint8_t i = 0; i < copy_size; i++) {
         ((int8_t*) &ret)[i] = this->data_buffer[start_orig - i];
@@ -63,9 +63,9 @@ int64_t SharedMemIface::read64(int64_t handle){
 }
 
 int32_t SharedMemIface::read32(int64_t handle){
-    int32_t ret = 0ul;
+    int32_t ret = 0;
     this->read(handle, this->data_buffer);
-    size_t copy_size = std::min(4ul, this->data_buffer.size());
+    size_t copy_size = std::min((size_t)4, this->data_buffer.size());
     size_t start_orig = this->data_buffer.size()-1;
     for(uint8_t i = 0; i < copy_size; i++) {
         ((int8_t*) &ret)[i] = this->data_buffer[start_orig - i];

--- a/sim/src/main/resources/SharedMemIface.hpp
+++ b/sim/src/main/resources/SharedMemIface.hpp
@@ -25,7 +25,10 @@ class SharedMemIface {
     void close();
     bool is_closed(){ return this->closed; };
     void check_ready();
-    void set_crashed(int64_t ret_code_){ this->ret_code.store(ret_code_); };
+    void set_crashed(int64_t ret_code_){ 
+        this->ret_code.store(ret_code_, std::memory_order_relaxed); 
+    };
+    
     virtual ~SharedMemIface();
 
     private:

--- a/sim/src/main/resources/SharedStruct.hpp
+++ b/sim/src/main/resources/SharedStruct.hpp
@@ -79,6 +79,7 @@ class SharedStruct {
 
         ProcStatus check_not_ready() {
             ProcStatus status = this->proc_status.load();
+            #ifndef NO_SPINLOCK_YIELD_OPTIMIZATION
             for(uint32_t spin_count = 0; status == ProcStatus::ready; ++spin_count) {
 
                 if (spin_count < SPINLOCK_MAX_ACQUIRE_SPINS) {
@@ -89,6 +90,9 @@ class SharedStruct {
                 }
                 status = this->proc_status.load();
             }
+            #else
+            while(status == ProcStatus::ready) status = this->proc_status.load();
+            #endif
             return status;
         }
 

--- a/sim/src/main/resources/SharedStruct.hpp
+++ b/sim/src/main/resources/SharedStruct.hpp
@@ -4,11 +4,17 @@
 #include<boost/interprocess/sync/scoped_lock.hpp>
 #include<boost/interprocess/sync/interprocess_condition.hpp>
 #include<boost/interprocess/containers/vector.hpp>
+#include<immintrin.h> //_mm_pause 
 #include<exception>
 #include<atomic>
+#include<thread>
 #include<iostream>
 #include<string>
 #include<cstdint>
+
+#ifndef SPINLOCK_MAX_ACQUIRE_SPINS
+#define SPINLOCK_MAX_ACQUIRE_SPINS 500
+#endif
 
 using namespace boost::interprocess;
 
@@ -18,13 +24,13 @@ typedef vector<uint8_t, ShmemAllocator> SharedVector;
 class VpiException: public std::exception
 {
     public:
-    VpiException(const char* msg_): exception(), msg(msg_) {};
-    virtual const char* what() const throw(){
-        return msg.c_str();
-    };
+        VpiException(const char* msg_): exception(), msg(msg_) {};
+        virtual const char* what() const throw(){
+            return msg.c_str();
+        };
 
     private:
-    std::string msg;
+        std::string msg;
 };
 
 enum class ProcStatus : int8_t {
@@ -42,39 +48,54 @@ enum class ProcStatus : int8_t {
 
 class SharedStruct {
     public:
-    SharedStruct(const ShmemAllocator alloc_inst_) : 
-        alloc_inst(alloc_inst_),
-        proc_status(ProcStatus::init),  
-        sleep_cycles(0), 
-        seed(12345),
-        handle(0),
-        data(alloc_inst){}
+        SharedStruct(const ShmemAllocator alloc_inst_) : 
+            alloc_inst(alloc_inst_),
+            proc_status(ProcStatus::init),  
+            sleep_cycles(0), 
+            seed(12345),
+            handle(0),
+            data(alloc_inst){}
 
-    virtual ~SharedStruct(){}
+        virtual ~SharedStruct(){}
 
-    void check_ready(){
-        ProcStatus status = this->proc_status.load();
-        while(status != ProcStatus::ready) {
-            if (status == ProcStatus::error) {
-               throw VpiException((const char*) this->data.data()); 
+// unused
+//        void check_ready(){
+//            ProcStatus status = this->proc_status.load();
+//            for(uint32_t spin_count = 0; status != ProcStatus::ready; ++spin_count) {
+//                if (status == ProcStatus::error) {
+//                    throw VpiException((const char*) this->data.data()); 
+//                }
+//
+//                if (spin_count < SPINLOCK_MAX_ACQUIRE_SPINS) {
+//                    _mm_pause();
+//                } else {
+//                    std::this_thread::yield();
+//                    spin_count = 0;
+//                }
+//
+//                status = this->proc_status.load();
+//            }
+//        }
+
+        ProcStatus check_not_ready() {
+            ProcStatus status = this->proc_status.load();
+            for(uint32_t spin_count = 0; status == ProcStatus::ready; ++spin_count) {
+
+                if (spin_count < SPINLOCK_MAX_ACQUIRE_SPINS) {
+                    _mm_pause();
+                } else {
+                    std::this_thread::yield();
+                    spin_count = 0;
+                }
+                status = this->proc_status.load();
             }
-            status = this->proc_status.load();
+            return status;
         }
-    }
-    
-    ProcStatus check_not_ready() {
-    ProcStatus status = this->proc_status.load();
-    while(status == ProcStatus::ready) {
-            status = this->proc_status.load();
-        }
-        
-    return status;
-    }
 
-    const ShmemAllocator alloc_inst;
-    std::atomic<ProcStatus> proc_status;
-    std::atomic<uint64_t> sleep_cycles;
-    std::atomic<uint64_t> seed;
-    std::atomic<size_t> handle;
-    SharedVector data; 
+        const ShmemAllocator alloc_inst;
+        std::atomic<ProcStatus> proc_status;
+        std::atomic<uint64_t> sleep_cycles;
+        std::atomic<uint64_t> seed;
+        std::atomic<size_t> handle;
+        SharedVector data; 
 };

--- a/sim/src/main/resources/VpiPlugin.cpp
+++ b/sim/src/main/resources/VpiPlugin.cpp
@@ -126,6 +126,8 @@ bool print_net_in_module(vpiHandle module_handle, stringstream &msg_ss){
             if (net_full_name.compare(net_full_name2)){
                 assert(0);
             }
+
+            vpi_free_object(net_handle);
         }
     } else {
         cout << "   No handles." << endl;
@@ -161,11 +163,13 @@ bool print_signals_cmd(){
             if(check_error()) return true;
             while (module_handle) {
                 if(print_net_in_module(module_handle, msg_ss)) return true;
+                vpi_free_object(module_handle);
                 module_handle = vpi_scan(module_iterator);
                 if(check_error()) return true;
             }
         }
 
+        vpi_free_object(top_mod_handle);
         top_mod_handle = vpi_scan(top_mod_iterator);
         if(check_error()) return true;
     }
@@ -201,6 +205,7 @@ bool randomize_in_module(vpiHandle module_handle, mt19937& mt_rand){
                           NULL, 
                           vpiNoDelay);
             if(check_error()) return true;
+            vpi_free_object(net_handle);
         }
     } 
     
@@ -231,11 +236,13 @@ bool randomize_cmd(){
             if(check_error()) return true;
             while (module_handle) {
                 if(randomize_in_module(module_handle, mt_rand)) return true;
+                vpi_free_object(module_handle);
                 module_handle = vpi_scan(module_iterator);
                 if(check_error()) return true;
             }
         }
 
+        vpi_free_object(top_mod_handle);
         top_mod_handle = vpi_scan(top_mod_iterator);
         if(check_error()) return true;
     }

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -28,7 +28,7 @@ case class VpiBackendConfig(
   var CFLAGS: String         = "-std=c++11 -Wall -Wextra -pedantic -O2 -Wno-strict-aliasing", 
   var LDFLAGS: String        = "-lpthread ", 
   var useCache: Boolean      = false,
-  var logSimProcess: Boolean = true
+  var logSimProcess: Boolean = false
 )
 
 abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
@@ -40,7 +40,7 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
   val workspaceName   = config.workspaceName   
   val wavePath        = config.wavePath        
   val waveFormat      = config.waveFormat      
-  val analyzeFlags    = config.analyzeFlags    
+  val analyzeFlags    = config.analyzeFlags
   var runFlags        = config.runFlags        
   val sharedMemSize   = config.sharedMemSize   
   val CC              = config.CC

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -28,7 +28,7 @@ case class VpiBackendConfig(
   var CFLAGS: String         = "-std=c++11 -Wall -Wextra -pedantic -O2 -Wno-strict-aliasing", 
   var LDFLAGS: String        = "-lpthread ", 
   var useCache: Boolean      = false,
-  var logSimProcess: Boolean = false
+  var logSimProcess: Boolean = true
 )
 
 abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {

--- a/sim/src/test/scala/spinal/sim/TestGhdl.scala
+++ b/sim/src/test/scala/spinal/sim/TestGhdl.scala
@@ -295,18 +295,24 @@ object TestGhdl9 extends App{
 
 object TestGhdl10 extends App {
   val config = new GhdlBackendConfig()
-  config.rtlSourcesPaths += "toplevel.vhd"
-  config.toplevelName = "toplevel"
+  config.rtlSourcesPaths += "adder.vhd"
+  config.toplevelName = "adder"
   config.pluginsPath = "simulation_plugins"
   config.workspacePath = "yolo"
   config.workspaceName = "yolo"
   config.wavePath = "test.vcd"
-  config.waveFormat = WaveFormat.VCD
-
+  config.waveFormat = WaveFormat.NONE
   val (ghdlbackend, _) = new GhdlBackend(config).instanciate
-   for(i <- 0l to 1024l){
-    ghdlbackend.randomize(i)
+  val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
+  val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
+  val sum = ghdlbackend.get_signal_handle("adder.sum")
+
+   for(i <- 0l to 1000000l){
+    ghdlbackend.randomize(i) 
     ghdlbackend.sleep(1)
+    ghdlbackend.write32(nibble1, 1)
+    ghdlbackend.write32(nibble1, 2)
+    ghdlbackend.read32(sum)
   }
   ghdlbackend.close
   println("Finished TestGhdl10")

--- a/sim/src/test/scala/spinal/sim/TestGhdl.scala
+++ b/sim/src/test/scala/spinal/sim/TestGhdl.scala
@@ -437,10 +437,9 @@ object TestGhdl15 extends App{
   config.useCache = true
 
   val backendFactory = new GhdlBackend(config)
- 
   val runningSims = (0 to 7).map { i =>
     Future {
-      val (ghdlbackend, _) = backendFactory.instanciate()
+    val (ghdlbackend, _) = backendFactory.instanciate()
       val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
       val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
       val sum = ghdlbackend.get_signal_handle("adder.sum")
@@ -460,4 +459,102 @@ object TestGhdl15 extends App{
 
   runningSims.foreach { res => println(Await.result(res, Duration.Inf))}
   println("Finished TestGhdl15")
+}
+
+object TestGhdl16 extends App{
+  val config = new GhdlBackendConfig()
+  config.rtlSourcesPaths += "adder.vhd"
+  config.toplevelName = "adder"
+  config.pluginsPath = "simulation_plugins"
+  config.workspacePath = "yolo"
+  config.workspaceName = "yolo"
+  config.waveFormat = WaveFormat.NONE
+  config.useCache = false
+
+  val backendFactory = new GhdlBackend(config)
+ 
+  val ghdlbackends = (0 to 7).map { i =>
+    val (ghdlbend, _) = backendFactory.instanciate()
+    ghdlbend
+  }.toArray
+
+  val startAt = System.nanoTime 
+  val runningSims = (0 to 7).map { i =>
+    Future {
+      val ghdlbackend = ghdlbackends(i)
+      val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
+      val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
+      val sum = ghdlbackend.get_signal_handle("adder.sum")
+      
+      for(j <- 0 to 1000000) {
+        ghdlbackend.write32(nibble1, i)
+        ghdlbackend.write32(nibble2, i+1)
+        ghdlbackend.eval
+      }
+
+      val ret = Seq(i.toString, 
+                "+", 
+                (i+1).toString,
+                "=",
+                ghdlbackend.read32(sum).toString).mkString(" ")
+      ghdlbackend.close
+      ret
+    }
+  }.toArray
+
+
+  runningSims.foreach { res => println(Await.result(res, Duration.Inf))}
+  val endAt = System.nanoTime
+  println(((endAt - startAt) * 1e-6).toString + " ms")
+  println("Finished TestGhdl16")
+}
+
+
+object TestGhdl17 extends App{
+  val config = new GhdlBackendConfig()
+  config.rtlSourcesPaths += "adder.vhd"
+  config.toplevelName = "adder"
+  config.pluginsPath = "simulation_plugins"
+  config.workspacePath = "yolo"
+  config.workspaceName = "yolo"
+  config.waveFormat = WaveFormat.NONE
+  config.useCache = false
+  config.CFLAGS += " -DNO_SPINLOCK_YIELD_OPTIMIZATION "
+
+  val backendFactory = new GhdlBackend(config)
+
+  val ghdlbackends = (0 to 7).map { i =>
+    val (ghdlbend, _) = backendFactory.instanciate()
+    ghdlbend
+  }.toArray
+ 
+  val startAt = System.nanoTime 
+  val runningSims = (0 to 7).map { i =>
+    Future {
+      val ghdlbackend = ghdlbackends(i)
+      val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
+      val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
+      val sum = ghdlbackend.get_signal_handle("adder.sum")
+      
+      for(j <- 0 to 1000000) {
+        ghdlbackend.write32(nibble1, i)
+        ghdlbackend.write32(nibble2, i+1)
+        ghdlbackend.eval
+      }
+
+      val ret = Seq(i.toString, 
+                "+", 
+                (i+1).toString,
+                "=",
+                ghdlbackend.read32(sum).toString).mkString(" ")
+      ghdlbackend.close
+      ret
+    }
+  }.toArray
+
+
+  runningSims.foreach { res => println(Await.result(res, Duration.Inf))}
+  val endAt = System.nanoTime
+  println(((endAt - startAt) * 1e-6).toString + " ms")
+  println("Finished TestGhdl17")
 }

--- a/tester/src/main/scala/spinal/tester/code/PlaySim.scala
+++ b/tester/src/main/scala/spinal/tester/code/PlaySim.scala
@@ -209,4 +209,46 @@ object PlaySimGhdl3 extends App{
   tb()
 }
 
+object PlaySimGhdl4 extends App{
+  class toplevel extends Component {
+    val io = new Bundle {
+      val a, b, c = in UInt (8 bits)
+      val result = out UInt (8 bits)
+      val comb   = out UInt (8 bits)
+    }
+    io.result := RegNext(io.a + io.b - io.c) init (0)
+    io.comb := io.a + io.b + io.c
+  }
+
+  SimConfig.withGhdl.doSim(new toplevel){ dut =>
+    dut.clockDomain.forkStimulus(period = 10)
+    dut.clockDomain.forkSimSpeedPrinter(0.2)
+
+
+    var model = -1
+    var times = 0
+    dut.clockDomain.onSamplings{
+//      println(simTime())
+//      if(times > 10) {
+//        simFailure("Rawr at ")
+        assert(dut.io.result.toInt == model || model == -1)
+        model = ((dut.io.a.toInt + dut.io.b.toInt - dut.io.c.toInt) & 0xFF)
+//      }
+      dut.io.a #= Random.nextInt(256)
+      dut.io.b #= Random.nextInt(256)
+      dut.io.c #= Random.nextInt(256)
+      times += 1
+    }
+
+
+//    sleep(1000)
+    for(repeat <- 0 until 4) {
+      val startAt = System.nanoTime
+      waitUntil(times == 2000000)
+      times = 0
+      val endAt = System.nanoTime
+      System.out.println((endAt - startAt) * 1e-6 + " ms")
+    }
+  }
+}
 

--- a/tester/src/main/scala/spinal/tester/code/PlaySim.scala
+++ b/tester/src/main/scala/spinal/tester/code/PlaySim.scala
@@ -171,40 +171,43 @@ object PlaySimGhdl3 extends App{
   val compiled = SimConfig.withWave.withGhdl.compile(new toplevel)
   def tb(){
     compiled.doSim { dut =>
-//      dut.clockDomain.forkStimulus(period = 10)
-//      dut.clockDomain.forkSimSpeedPrinter(0.2)
+      dut.clockDomain.forkStimulus(period = 10)
+      dut.clockDomain.forkSimSpeedPrinter(0.2)
 
-      sleep(1000)
-              dut.io.a #= Random.nextInt(256)
-      sleep(1000)
+//      sleep(1000)
+//              dut.io.a #= Random.nextInt(256)
+//      sleep(1000)
 
-//      var model = -1
-//      var times = 0
-//      dut.clockDomain.onSamplings {
-//        //      println(simTime())
-//        //      if(times > 10) {
-//        //        simFailure("Rawr at ")
-//        assert(dut.io.result.toInt == model || model == -1)
-//        model = ((dut.io.a.toInt + dut.io.b.toInt - dut.io.c.toInt) & 0xFF)
-//        //      }
-//        dut.io.a #= Random.nextInt(256)
-//        dut.io.b #= Random.nextInt(256)
-//        dut.io.c #= Random.nextInt(256)
-//        times += 1
-//      }
-//
-//
-//      //    sleep(1000)
-//      for (repeat <- 0 until 4) {
-//        val startAt = System.nanoTime
-//        waitUntil(times == 2000)
-//        times = 0
-//        val endAt = System.nanoTime
-//        System.out.println((endAt - startAt) * 1e-6 + " ms")
-//      }
+      var model = -1
+      var times = 0
+      dut.clockDomain.onSamplings {
+        //      println(simTime())
+        //      if(times > 10) {
+        //        simFailure("Rawr at ")
+        assert(dut.io.result.toInt == model || model == -1)
+        model = ((dut.io.a.toInt + dut.io.b.toInt - dut.io.c.toInt) & 0xFF)
+        //      }
+        dut.io.a #= Random.nextInt(256)
+        dut.io.b #= Random.nextInt(256)
+        dut.io.c #= Random.nextInt(256)
+        times += 1
+      }
+
+
+      //    sleep(1000)
+      for (repeat <- 0 until 4) {
+        val startAt = System.nanoTime
+        waitUntil(times == 2000)
+        times = 0
+        val endAt = System.nanoTime
+        System.out.println((endAt - startAt) * 1e-6 + " ms")
+      }
     }
   }
 
+  tb()
+  tb()
+  tb()
   tb()
   tb()
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
@@ -30,8 +30,8 @@ object SpinalSimMiscTester{
 
 object SpinalSimTester{
   def apply()(body :  => SpinalSimConfig => Unit): Unit = {
-//    body(SimConfig.withVerilator)
-    body(SimConfig.withGhdl)
+    body(SimConfig.withVerilator)
+//    body(SimConfig.withGhdl)
   }
 }
 


### PR DESCRIPTION
In this pull request the following changes were done:

- Improved spinlock performances when many simulations are run at the same time. This was accomplished adding a yield directive that pass the thread control to the os if the lock is spinning for too long. A cache line optimization was added too based on https://probablydance.com/2019/12/30/measuring-mutexes-spinlocks-and-how-bad-the-linux-scheduler-really-is/ . Since I am not an expert I am unsure if the way I did that is the best one. Still I can get >30% performance improvement on TestGHDL16 vs TestGHDL17
- Fixed a memory leak on vpi_iterate and vpi_scan.
- Added windows support. Please note that since ghdl-mcode doesn't work on 64bit Windows platform, the code was tested only on ghdl-llvm.

Please note that https://github.com/ghdl/ghdl/issues/1233 fixed a memory leak on GHDL. Therefore some tests may show a memory leak if an older version of GHDL is used

This PR is part of issue #146 