### PR TITLE
Performance Improvement: Use post-order traversal in PhaseInferWidth

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -69,6 +69,14 @@ trait ExpressionContainer {
     })
   }
 
+  // Traverse the subtrees first before accessing the parent node
+  def walkExpressionPostorder(func: (Expression) => Unit): Unit = {
+    foreachExpression(e => {
+      e.walkExpressionPostorder(func)
+      func(e)
+    })
+  }
+
   def walkDrivingExpressions(func: (Expression) => Unit): Unit = {
     foreachDrivingExpression(e => {
       func(e)

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -132,6 +132,10 @@ class PhaseContext(val config: SpinalConfig) {
     GraphUtils.walkAllComponents(topLevel, c => c.dslBody.walkStatements(s => s.walkExpression(func)))
   }
 
+  def walkExpressionPostorder(func: Expression => Unit): Unit = {
+    GraphUtils.walkAllComponents(topLevel, c => c.dslBody.walkStatements(s => s.walkExpressionPostorder(func)))
+  }
+
   def walkDeclarations(func: DeclarationStatement => Unit): Unit = {
     walkComponents(c => c.dslBody.walkDeclarations(e => func(e)))
   }
@@ -1144,7 +1148,9 @@ class PhaseInferWidth(pc: PhaseContext) extends PhaseMisc{
       var somethingChange = false
 
       //Infer width on all expressions
-      walkExpression {
+      //Use post-order traversal so that a parent node can get the widths of its children before inferring width,
+      // which could help reducing the number of iterations
+      walkExpressionPostorder {
         case e: DeclarationStatement =>
         case e: Widthable =>
           val hasChange = e.inferWidth


### PR DESCRIPTION
Currently, PhaseInferWidth uses pre-order traversal when accessing the expression tree, which means the parent node will be accessed first without knowing the width of its children. It will lead to many iterations if the expression tree is very large. 

For example, in the following code:

```scala
class TestBits extends Component {
    val io = new Bundle {
        val input  = in  Vec(Bool, 512)
        val output = out Bits(512 bits)
    }

    io.output := io.input.asBits
}
```

The `asBits` method will create an expression tree using `##` operator, of which the depth is 512. Debugging into `PhaseInferWidth` and it can be found that `iterationCounter` is 512 when exiting the loop, which creates a significant impact on performance when elaborating a large design.

I proposed to use post-order traversal instead. This way, a parent node is accessed after its children have width information so that the width inferring of an expression tree can be done in just 1 iteration.

FYI, this patch can help reduce the elaborate time by 10 seconds in my large design.
Before:
```
[info] [Progress] at 0.000 : Elaborate components
[info] [Progress] at 0.012 : PhaseCreateComponent
[info] [Progress] at 1.686 : PhaseDummy
[info] [Progress] at 1.686 : Checks and transforms
[info] [Progress] at 1.760 : PhaseMemBlackBoxingDefault
[info] [Progress] at 2.198 : PhaseApplyIoDefault
[info] [Progress] at 2.350 : PhaseNameNodesByReflection
[info] [Progress] at 2.444 : PhaseCollectAndNameEnum
[info] [Progress] at 2.588 : PhaseCheckIoBundle
[info] [Progress] at 2.873 : PhaseCheckHiearchy
[info] [Progress] at 3.098 : PhaseAnalog
[info] [Progress] at 3.253 : PhaseRemoveUselessStuff
[info] [Progress] at 3.741 : PhaseRemoveIntermediateUnnameds
[info] [Progress] at 4.172 : PhasePullClockDomains
[info] [Progress] at 4.292 : PhaseInferEnumEncodings
[info] [Progress] at 4.506 : PhaseInferWidth
[info] [Progress] at 15.223 : PhaseNormalizeNodeInputs
[info] [Progress] at 15.427 : PhaseSimplifyNodes
[info] [Progress] at 15.637 : PhaseCompletSwitchCases
[info] [Progress] at 15.724 : PhaseRemoveUselessStuff
[info] [Progress] at 16.012 : PhaseRemoveIntermediateUnnameds
[info] [Progress] at 16.285 : PhaseCheck_noLatchNoOverride
[info] [Progress] at 16.550 : PhaseCheck_noRegisterAsLatch
[info] [Progress] at 16.624 : PhaseCheckCombinationalLoops
[info] [Progress] at 16.772 : PhaseCheckCrossClock
[info] [Progress] at 18.539 : PhaseAllocateNames
[info] [Progress] at 19.006 : PhaseDevice
[info] [Progress] at 19.043 : PhaseGetInfoRTL
[info] [Progress] at 19.188 : PhaseDummy
[info] [Progress] at 19.189 : Generate Verilog
[info] [Progress] at 19.224 : PhaseVerilog
[info] [Warning] 20052 signals were pruned. You can call printPruned on the backend report to get more informations.
[info] [Done] at 43.426
```

After:
```

[info] [Progress] at 0.000 : Elaborate components
[info] [Progress] at 0.011 : PhaseCreateComponent
[info] [Progress] at 1.869 : PhaseDummy
[info] [Progress] at 1.869 : Checks and transforms
[info] [Progress] at 1.944 : PhaseMemBlackBoxingDefault
[info] [Progress] at 2.392 : PhaseApplyIoDefault
[info] [Progress] at 2.547 : PhaseNameNodesByReflection
[info] [Progress] at 2.641 : PhaseCollectAndNameEnum
[info] [Progress] at 2.788 : PhaseCheckIoBundle
[info] [Progress] at 3.155 : PhaseCheckHiearchy
[info] [Progress] at 3.380 : PhaseAnalog
[info] [Progress] at 3.538 : PhaseRemoveUselessStuff
[info] [Progress] at 4.027 : PhaseRemoveIntermediateUnnameds
[info] [Progress] at 4.459 : PhasePullClockDomains
[info] [Progress] at 4.570 : PhaseInferEnumEncodings
[info] [Progress] at 4.789 : PhaseInferWidth
[info] [Progress] at 5.707 : PhaseNormalizeNodeInputs
[info] [Progress] at 5.921 : PhaseSimplifyNodes
[info] [Progress] at 6.122 : PhaseCompletSwitchCases
[info] [Progress] at 6.209 : PhaseRemoveUselessStuff
[info] [Progress] at 6.486 : PhaseRemoveIntermediateUnnameds
[info] [Progress] at 6.753 : PhaseCheck_noLatchNoOverride
[info] [Progress] at 7.017 : PhaseCheck_noRegisterAsLatch
[info] [Progress] at 7.092 : PhaseCheckCombinationalLoops
[info] [Progress] at 7.234 : PhaseCheckCrossClock
[info] [Progress] at 9.002 : PhaseAllocateNames
[info] [Progress] at 9.518 : PhaseDevice
[info] [Progress] at 9.554 : PhaseGetInfoRTL
[info] [Progress] at 9.694 : PhaseDummy
[info] [Progress] at 9.694 : Generate Verilog
[info] [Progress] at 9.730 : PhaseVerilog
[info] [Warning] 20052 signals were pruned. You can call printPruned on the backend report to get more informations.
[info] [Done] at 33.560
```