### PR TITLE
verilog case bin format to hex format

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -652,7 +652,8 @@ class ComponentEmitterVerilog(
 
                 case _ => {
                   def emitIsCond(that: Expression): String = that match {
-                    case e: BitVectorLiteral => s"${e.getWidth}'b${e.getBitsStringOn(e.getWidth, 'x')}"
+                    case e: BitVectorLiteral => emitBitVectorLiteral(e)
+//                    case e: BitVectorLiteral => s"${e.getWidth}'b${e.getBitsStringOn(e.getWidth, 'x')}"
                     case e: BoolLiteral => if (e.value) "1'b1" else "1'b0"
                     case lit: EnumLiteral[_] => emitEnumLiteral(lit.enum, lit.encoding)
                   }
@@ -1118,7 +1119,7 @@ end
     def onEachExpression(e: Expression): Unit = {
       e match {
         case node: SubAccess => applyTo(node.getBitVector)
-        case node: Resize => applyTo(node.input)
+        case node: Resize    => applyTo(node.input)
         case _               =>
       }
     }
@@ -1230,7 +1231,7 @@ end
     if(e.getWidth > 4){
       s"${e.getWidth}'h${e.hexString(e.getWidth,false)}"
     } else {
-      s"(${e.getWidth}'b${e.getBitsStringOn(e.getWidth,'x')})"
+      s"${e.getWidth}'b${e.getBitsStringOn(e.getWidth,'x')}"
     }
   }
 
@@ -1308,16 +1309,16 @@ end
 
     case  e: Operator.UInt.Equal                      => operatorImplAsBinaryOperator("==")(e)
     case  e: Operator.UInt.NotEqual                   => operatorImplAsBinaryOperator("!=")(e)
-    case  e: Operator.UInt.Smaller                    =>  operatorImplAsBinaryOperator("<")(e)
+    case  e: Operator.UInt.Smaller                    => operatorImplAsBinaryOperator("<")(e)
     case  e: Operator.UInt.SmallerOrEqual             => operatorImplAsBinaryOperator("<=")(e)
 
     case  e: Operator.UInt.ShiftRightByInt            => shiftRightByIntImpl(e)
     case  e: Operator.UInt.ShiftLeftByInt             => shiftLeftByIntImpl(e)
     case  e: Operator.UInt.ShiftRightByUInt           => operatorImplAsBinaryOperator(">>>")(e)
     case  e: Operator.UInt.ShiftLeftByUInt            => shiftLeftByUIntImpl(e)
-    case  e: Operator.UInt.ShiftRightByIntFixedWidth  =>  shiftRightByIntFixedWidthImpl(e)
-    case  e: Operator.UInt.ShiftLeftByIntFixedWidth   =>  shiftLeftByIntFixedWidthImpl(e)
-    case  e: Operator.UInt.ShiftLeftByUIntFixedWidth  =>  operatorImplAsBinaryOperator("<<<")(e)
+    case  e: Operator.UInt.ShiftRightByIntFixedWidth  => shiftRightByIntFixedWidthImpl(e)
+    case  e: Operator.UInt.ShiftLeftByIntFixedWidth   => shiftLeftByIntFixedWidthImpl(e)
+    case  e: Operator.UInt.ShiftLeftByUIntFixedWidth  => operatorImplAsBinaryOperator("<<<")(e)
 
     //signed
     case  e: Operator.SInt.Add                        => operatorImplAsBinaryOperatorSigned("+")(e)
@@ -1340,10 +1341,10 @@ end
     case  e: Operator.SInt.ShiftRightByInt            => shiftRightByIntImpl(e)
     case  e: Operator.SInt.ShiftLeftByInt             => shiftLeftByIntImpl(e)
     case  e: Operator.SInt.ShiftRightByUInt           => operatorImplAsBinaryOperatorLeftSigned(">>>")(e)
-    case  e: Operator.SInt.ShiftLeftByUInt            =>  shiftLeftByUIntImplSigned(e)
-    case  e: Operator.SInt.ShiftRightByIntFixedWidth  =>  shiftRightSignedByIntFixedWidthImpl(e)
-    case  e: Operator.SInt.ShiftLeftByIntFixedWidth   =>  shiftLeftByIntFixedWidthImpl(e)
-    case  e: Operator.SInt.ShiftLeftByUIntFixedWidth  =>  operatorImplAsBinaryOperatorLeftSigned("<<<")(e)
+    case  e: Operator.SInt.ShiftLeftByUInt            => shiftLeftByUIntImplSigned(e)
+    case  e: Operator.SInt.ShiftRightByIntFixedWidth  => shiftRightSignedByIntFixedWidthImpl(e)
+    case  e: Operator.SInt.ShiftLeftByIntFixedWidth   => shiftLeftByIntFixedWidthImpl(e)
+    case  e: Operator.SInt.ShiftLeftByUIntFixedWidth  => operatorImplAsBinaryOperatorLeftSigned("<<<")(e)
 
     //bits
     case  e: Operator.Bits.Cat                        => operatorImplAsCat(e)
@@ -1357,10 +1358,10 @@ end
     case  e: Operator.Bits.ShiftRightByInt            => shiftRightByIntImpl(e)
     case  e: Operator.Bits.ShiftLeftByInt             => shiftLeftByIntImpl(e)
     case  e: Operator.Bits.ShiftRightByUInt           => operatorImplAsBinaryOperator(">>>")(e)
-    case  e: Operator.Bits.ShiftLeftByUInt            =>  shiftLeftByUIntImpl(e)
-    case  e: Operator.Bits.ShiftRightByIntFixedWidth  =>  shiftRightByIntFixedWidthImpl(e)
-    case  e: Operator.Bits.ShiftLeftByIntFixedWidth   =>  shiftLeftByIntFixedWidthImpl(e)
-    case  e: Operator.Bits.ShiftLeftByUIntFixedWidth  =>  operatorImplAsBinaryOperator("<<<")(e)
+    case  e: Operator.Bits.ShiftLeftByUInt            => shiftLeftByUIntImpl(e)
+    case  e: Operator.Bits.ShiftRightByIntFixedWidth  => shiftRightByIntFixedWidthImpl(e)
+    case  e: Operator.Bits.ShiftLeftByIntFixedWidth   => shiftLeftByIntFixedWidthImpl(e)
+    case  e: Operator.Bits.ShiftLeftByUIntFixedWidth  => operatorImplAsBinaryOperator("<<<")(e)
 
     //bool
     case  e: Operator.Bool.Equal                      => operatorImplAsBinaryOperator("==")(e)


### PR DESCRIPTION
verilog constant format optmize 
```
case(addr)
  8'b00001011 : begin  data = 32'h32ad0000;
  8'b11110011 : begin  data = 32'h32ad0fff;
...
endcase
```
 to
```
case(addr)
  8'h0B : begin  data = 32'h32ad0000;
  8'hF3 : begin  data = 32'h32ad0fff;
...
endcase
```