### PR TITLE
merged code paths for Delay

### DIFF
--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -780,7 +780,7 @@ class TraversableOncePimped[T <: Data](pimped: Seq[T]) {
 
 
 object Delay {
-  def apply[T <: Data](that: T, cycleCount: Int,when : Bool = null,init : T = null.asInstanceOf[T]): T = {
+  def apply[T <: Data](that: T, cycleCount: Int,when : Bool = null,init : T = null.asInstanceOf[T],onEachReg : T => Unit = null): T = {
     require(cycleCount >= 0,"Negative cycleCount is not allowed in Delay")
     var ptr = that
     for(i <- 0 until cycleCount) {
@@ -788,22 +788,13 @@ object Delay {
         ptr = RegNext(ptr, init)
       else
         ptr = RegNextWhen(ptr, when, init)
+
+      if(onEachReg != null) {
+        onEachReg(ptr)
+      }
       ptr.unsetName().setCompositeName(that, "delay_" + (i + 1), true)
     }
     ptr
-  }
-}
-
-object DelayWithInit {
-  def apply[T <: Data](that: T, cycleCount: Int)(onEachReg : (T) => Unit = null): T = {
-    cycleCount match {
-      case 0 => that
-      case _ => {
-        val reg = RegNext(that)
-        if(onEachReg != null) onEachReg(reg)
-        DelayWithInit(reg, cycleCount - 1)(onEachReg)
-      }
-    }
   }
 }
 

--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -800,7 +800,7 @@ object Delay {
 
 object DelayWithInit {
   def apply[T <: Data](that: T, cycleCount: Int)(onEachReg: (T) => Unit = null): T = {
-    Delay(that, cycleCount, onEachReg = onEachReg)
+    Delay[T](that, cycleCount, onEachReg = onEachReg)
   }
 }
 

--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -789,10 +789,10 @@ object Delay {
       else
         ptr = RegNextWhen(ptr, when, init)
 
+      ptr.unsetName().setCompositeName(that, "delay_" + (i + 1), true)
       if(onEachReg != null) {
         onEachReg(ptr)
       }
-      ptr.unsetName().setCompositeName(that, "delay_" + (i + 1), true)
     }
     ptr
   }

--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -780,7 +780,7 @@ class TraversableOncePimped[T <: Data](pimped: Seq[T]) {
 
 
 object Delay {
-  def apply[T <: Data](that: T, cycleCount: Int,when : Bool = null,init : T = null.asInstanceOf[T],onEachReg : T => Unit = null): T = {
+  def apply[T <: Data](that: T, cycleCount: Int,when : Bool = null,init : T = null.asInstanceOf[T],onEachReg : T => Unit = null.asInstanceOf[T => Unit]): T = {
     require(cycleCount >= 0,"Negative cycleCount is not allowed in Delay")
     var ptr = that
     for(i <- 0 until cycleCount) {
@@ -795,6 +795,12 @@ object Delay {
       ptr.unsetName().setCompositeName(that, "delay_" + (i + 1), true)
     }
     ptr
+  }
+}
+
+object DelayWithInit {
+  def apply[T <: Data](that: T, cycleCount: Int)(onEachReg: (T) => Unit = null): T = {
+    Delay(that, cycleCount, onEachReg = onEachReg)
   }
 }
 


### PR DESCRIPTION
removes the old `DelayWithInit` function and merge it into the main `Delay`. Seems to be currently breaking VexRiscv :(. 

