### PR TITLE
Now all three simulators have the same wave trace timescale of 1ns.

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -218,23 +218,17 @@ object SpinalVpiBackend {
 
     vconfig.rtlSourcesPaths ++= rtl.rtlSourcesPaths.map(new File(_).getAbsolutePath)
     vconfig.toplevelName      = rtl.toplevelName
-    vconfig.wavePath          = "wave.vcd"
-    vconfig.waveFormat        = WaveFormat.VCD
-//    vconfig.vcdPath           = vcdPath
-//    vconfig.vcdPrefix         = vcdPrefix
+    vconfig.wavePath          = "test.vcd"
+    vconfig.waveFormat        = waveFormat match {
+      case WaveFormat.DEFAULT => WaveFormat.VCD
+      case _ => waveFormat
+    }
     vconfig.workspaceName     = workspaceName
     vconfig.workspacePath     = workspacePath
-//    vconfig.waveFormat        = waveFormat match {
-//      case WaveFormat.DEFAULT => WaveFormat.VCD
-//      case _ => waveFormat
-//    }
-//    vconfig.waveDepth         = waveDepth
-//    vconfig.optimisationLevel = optimisationLevel
-//    vconfig.simulatorFlags        = simulatorFlags
-    
     vconfig.useCache = usePluginsCache
     vconfig.pluginsPath = if(usePluginsCache) {
-      val pluginsCachePathFile = new File(pluginsCachePath)
+    
+    val pluginsCachePathFile = new File(pluginsCachePath)
       if(!pluginsCachePathFile.exists()) {
         pluginsCachePathFile.mkdirs
       }

--- a/sim/src/main/resources/VpiPlugin.cpp
+++ b/sim/src/main/resources/VpiPlugin.cpp
@@ -380,7 +380,7 @@ bool write_cmd(){
 bool sleep_cmd(){
 
     #ifndef IVERILOG_PLUGIN
-    register_cb(delay_ro_cb, cbAfterDelay, shared_struct->sleep_cycles);
+    register_cb(delay_ro_cb, cbAfterDelay, shared_struct->sleep_cycles*1000000);
     #else
     register_cb(delay_rw_cb, cbAfterDelay, shared_struct->sleep_cycles);
     #endif

--- a/sim/src/main/scala/spinal/sim/Misc.scala
+++ b/sim/src/main/scala/spinal/sim/Misc.scala
@@ -14,20 +14,25 @@ object SimError{
 }
 
 object WaveFormat{
+  //Common waveformat options
   object VCD extends WaveFormat("vcd")
-  object VCDGZ extends WaveFormat("vcdgz")
   object FST extends WaveFormat("fst")
+  object DEFAULT extends WaveFormat
+  object NONE extends WaveFormat
+ 
+  //GHDL only
+  object VCDGZ extends WaveFormat("vcdgz")
+  object GHW extends WaveFormat("ghw")
+
+  //Icarus Verilator only
   object FST_SPEED extends WaveFormat("fst-speed")
   object FST_SPACE extends WaveFormat("fst-space")
-  object GHW extends WaveFormat("ghw")
   object LXT extends WaveFormat("lxt")
   object LXT_SPEED extends WaveFormat("lxt-speed")
   object LXT_SPACE extends WaveFormat("lxt-space")
   object LXT2 extends WaveFormat("lxt2")
   object LXT2_SPEED extends WaveFormat("lxt2-speed")
   object LXT2_SPACE extends WaveFormat("lxt2-space")
-  object DEFAULT extends WaveFormat
-  object NONE extends WaveFormat
 }
 
 class WaveFormat(val ext : String = "???")

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -409,6 +409,8 @@ class IVerilogBackend(config: IVerilogBackendConfig) extends VpiBackend(config) 
                                             .mkString(" ")
 
     val simulationDefSource = s"""
+                               |`timescale 1ns/1ns
+                               |
                                |module __simulation_def;
                                |initial
                                | begin


### PR DESCRIPTION
This PR makes the timescale of Icarus Verilog and GHDL in agreement to Verilator one (1ns per step). This helps a lot when comparing traces produced by different simulators.

Minor cosmetic things: default name for wavefiles in all simulators is test.vcd, DEFAULT behavior generates a VCD file.