### PR TITLE
Wave tracing off for sub component

### DIFF
--- a/core/src/main/scala/spinal/core/Attribute.scala
+++ b/core/src/main/scala/spinal/core/Attribute.scala
@@ -63,5 +63,13 @@ object Verilator{
   object public extends AttributeFlag("verilator public", COMMENT_ATTRIBUTE){
     override def isLanguageReady(language: Language) : Boolean = language == Language.VERILOG || language == Language.SYSTEM_VERILOG
   }
+
+  object tracing_off extends AttributeFlag("verilator tracing_off", COMMENT_ATTRIBUTE){
+    override def isLanguageReady(language: Language) : Boolean = language == Language.VERILOG || language == Language.SYSTEM_VERILOG
+  }    
+
+  object tracing_on extends AttributeFlag("verilator tracing_on", COMMENT_ATTRIBUTE){
+    override def isLanguageReady(language: Language) : Boolean = language == Language.VERILOG || language == Language.SYSTEM_VERILOG
+  } 
 }
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -210,12 +210,6 @@ class ComponentEmitterVerilog(
   }
 
   def emitSubComponents(openSubIo: mutable.HashSet[BaseType]): Unit = {
-    def traceOff(uut: String): String = {
-      s"""// verilator tracing_off
-         |${uut}
-         |// verilator tracing_on""".stripMargin
-    }
-
     //Fixing the spacing
     def netsWithSection(data: BaseType): String = {
       if(openSubIo.contains(data)) ""

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -23,6 +23,7 @@ package spinal.core.internals
 import java.io.File
 
 import spinal.core._
+import spinal.core.sim.{SimPublic, TracingOff}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -76,12 +77,10 @@ class ComponentEmitterVerilog(
 
       if(outputsToBufferize.contains(baseType) || baseType.isInput){
         portMaps += f"${syntax}${dir}%6s ${""}%3s ${section}%-8s ${name}${EDAcomment}${comma}"
-//        portMaps += s"${emitSyntaxAttributes(baseType.instanceAttributes)}${emitDirection(baseType)} ${emitType(baseType)} ${baseType.getName()}${emitCommentAttributes(baseType.instanceAttributes)}"
       } else {
         val siginit = if(outputsToBufferize.contains(baseType)) "" else getBaseTypeSignalInitialisation(baseType)
         val isReg   = if(signalNeedProcess(baseType)) "reg" else ""
         portMaps += f"${syntax}${dir}%6s ${isReg}%3s ${section}%-8s ${name}${siginit}${EDAcomment}${comma}"
-//        portMaps += s"${emitSyntaxAttributes(baseType.instanceAttributes)}${emitDirection(baseType)} ${if(signalNeedProcess(baseType) && !outputsToBufferize.contains(baseType)) "reg " else ""}${emitType(baseType)} ${baseType.getName()}${if(outputsToBufferize.contains(baseType)) "" else getBaseTypeSignalInitialisation(baseType)}${emitCommentAttributes(baseType.instanceAttributes)}"
       }
     }
   }
@@ -211,6 +210,21 @@ class ComponentEmitterVerilog(
   }
 
   def emitSubComponents(openSubIo: mutable.HashSet[BaseType]): Unit = {
+    def traceOff(uut: String): String = {
+      s"""// verilator tracing_off
+         |${uut}
+         |// verilator tracing_on""".stripMargin
+    }
+
+    //Fixing the spacing
+    def netsWithSection(data: BaseType): String = {
+      if(openSubIo.contains(data)) ""
+      else {
+        val wireName = emitReference(data, false)
+        val section = if(data.getBitsWidth == 1) "" else  s"[${data.getBitsWidth - 1}:0]"
+        wireName + section
+      }
+    }
 
     for (child <- component.children) {
       val isBB             = child.isInstanceOf[BlackBox] && child.asInstanceOf[BlackBox].isBlackBox
@@ -218,6 +232,12 @@ class ComponentEmitterVerilog(
       val definitionString =  if (isBB) child.definitionName else getOrDefault(emitedComponentRef, child, child).definitionName
 
       val instanceAttributes = emitSyntaxAttributes(child.instanceAttributes)
+
+      val istracingOff = child.hasTag(TracingOff)
+
+      if(istracingOff){
+        logics ++= s" ${emitCommentAttributes(List(Verilator.tracing_off))} \n"
+      }
 
       logics ++= s"  $instanceAttributes$definitionString "
 
@@ -242,29 +262,9 @@ class ComponentEmitterVerilog(
         }
       }
 
-      //Fixing the spacing
-      def netsWithSection(data: BaseType): String = {
-        if(openSubIo.contains(data)) ""
-        else {
-          val wireName = emitReference(data, false)
-          val section = if(data.getBitsWidth == 1) "" else  s"[${data.getBitsWidth - 1}:0]"
-          wireName + section
-        }
-      }
-
       val maxNameLength: Int = if(child.getOrdredNodeIo.isEmpty) 0 else child.getOrdredNodeIo.map(data => emitReferenceNoOverrides(data).length()).max
 
       val maxNameLengthCon: Int = if(child.getOrdredNodeIo.isEmpty) 0 else child.getOrdredNodeIo.map(data => netsWithSection(data).length()).max
-
-//      var maxNameLength = 0
-//      for(data <- child.getOrdredNodeIo) {
-//        if (emitReferenceNoOverrides(data).toString.length() > maxNameLength) maxNameLength = emitReferenceNoOverrides(data).toString.length()
-//      }
-//      var maxNameLengthCon = 0
-//      for(data <- child.getOrdredNodeIo) {
-//        val logic = if(openSubIo.contains(data)) "" else emitReference(data, false)
-//        if (logic.toString.length() > maxNameLengthCon) maxNameLengthCon = logic.toString.length()
-//      }
 
       logics ++= s"${child.getName()} (\n"
 
@@ -281,9 +281,14 @@ class ComponentEmitterVerilog(
         s"    .${portAlign}    (${wireAlign}  )${comma} //${dirtag}\n"
       }.mkString
 
+
       logics ++= instports
       logics ++= s"  );"
       logics ++= s"\n"
+
+      if(istracingOff){
+        logics ++= s" ${emitCommentAttributes(List(Verilator.tracing_on))} \n"
+      }
     }
   }
 

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -290,6 +290,7 @@ object SpinalVpiBackend {
 /** Tag SimPublic  */
 object SimPublic extends SpinalTag
 
+object TracingOff extends SpinalTag
 
 /**
   * Swap all oldTag with newTag

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -236,6 +236,9 @@ package object sim {
     def simPublic(): T = bt.addTag(SimPublic)
   }
 
+  implicit class SimpComponentPimper[T <: Component](uut: T) {
+    def tracingOff(): T = uut.addTag(TracingOff)
+  }
 
   /**
     * Add implicit function to Bool

--- a/tester/src/main/scala/spinal/tester/code/PlaySim.scala
+++ b/tester/src/main/scala/spinal/tester/code/PlaySim.scala
@@ -232,3 +232,30 @@ object PlaySimGhdlBugTodo extends App{
   }
 }
 
+object PlayTracingOff extends App{
+  class Sub extends Component {
+    val a = in SInt (16 bits)
+    val b = out SInt (16 bits)
+    b := a
+  }
+
+  class WaveTop extends Component {
+    val io = new Bundle{
+      val a = in SInt (16 bits)
+      val b = out SInt (16 bits)
+    }
+    val sub0 = new Sub
+    sub0.a := io.a
+    val sub1 = new Sub
+    sub1.a := sub0.b
+    io.b := sub1.b
+  }
+
+  SpinalVerilog(new Sub)
+//  SpinalConfig(targetDirectory = "./tmp").generateVerilog{
+//    val dut = new WaveTop
+//    dut.sub0.tracingOff()
+//    dut
+//  }
+}
+

--- a/tester/src/main/scala/spinal/tester/code/PlaySim.scala
+++ b/tester/src/main/scala/spinal/tester/code/PlaySim.scala
@@ -251,11 +251,10 @@ object PlayTracingOff extends App{
     io.b := sub1.b
   }
 
-  SpinalVerilog(new Sub)
-//  SpinalConfig(targetDirectory = "./tmp").generateVerilog{
-//    val dut = new WaveTop
-//    dut.sub0.tracingOff()
-//    dut
-//  }
+  SpinalConfig(targetDirectory = "./tmp").generateVerilog{
+    val dut = new WaveTop
+    dut.sub0.tracingOff()
+    dut
+  }
 }
 


### PR DESCRIPTION
hi @Dolu1990 
now we can closeOff the sub component wave dumping which we don't care.
Usage:
```scala 
SimConfig.compile {
  val dut = new GnssTB(cfg)
  ...
  dut.uAE_Top.uCorrelater.tracingOff()
  dut
}
```
Another good news is that the latest **Verilator4.0.34** have greatly improved on simulation speed.
and also fix FstWave with slowest speed issue . the current sim speed of FST is even faster than VCD. you cant try that.

here is simple compare report for my project case
 
 verilator4.034 | waveSize | simTime | comment      
--------------------------|----------|---------|--------------
 VcdWave                  | 12G      | 463.4s  |  with larger Size
 FstWave                  | 1.1G     | 370.1s  | even fast than VCD
 FstWave(tracingOff sub)   | 12M      | 76.6s   | tracing Off uCorrelatoer

*cpu: Intel-i5*
