### PR TITLE
Fix check in oneHotAccess in Vec

### DIFF
--- a/core/src/main/scala/spinal/core/Vec.scala
+++ b/core/src/main/scala/spinal/core/Vec.scala
@@ -223,8 +223,8 @@ class Vec[T <: Data](val dataType: HardType[T], val vec: Vector[T]) extends Mult
   /** Access an element of the bector by a oneHot value */
   def oneHotAccess(oneHot: Bits): T = {
 
-    if(elements.size == oneHot.getWidth){
-      SpinalError(s"To many bit to address the vector (${oneHot.getWidth} in place of ${elements.size})\n at\n${ScalaLocated.long}")
+    if(elements.size != oneHot.getWidth){
+      SpinalError(s"Invalid length of oneHot selection vector (${oneHot.getWidth}), not matching length of Vec (${elements.size})\n at\n${ScalaLocated.long}")
     }
 
     val ret = cloneOf(dataType)


### PR DESCRIPTION
Is discussed on Gitter

 - Length of oneHot signal must match length of Vec
 - Make message clearer - the same error gets raised irrespective
   of whether the selection signal is too short or too long