### PR TITLE
oneFilePerComponent update

### DIFF
--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -60,6 +60,15 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
       outFile.close()
     }
     else {
+      val fileList = new java.io.FileWriter(pc.config.targetDirectory + topLevel.definitionName + ".lst")
+      // dump Enum define to define.v instead attach that on every .v file
+      val defineFileName = pc.config.targetDirectory + "/enumdefine" + (if(pc.config.isSystemVerilog) ".sv" else ".v")
+      val defineFile = new java.io.FileWriter(defineFileName)
+      emitEnumPackage(defineFile)
+      defineFile.flush()
+      defineFile.close()
+      fileList.write(defineFileName.replace("//", "/") + "\n")
+
       for (c <- sortedComponents) {
         val moduleContent = compile(c)()
 
@@ -72,15 +81,17 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
             if(pc.config.dumpWave != null) {
               outFile.write("`timescale 1ns/1ps ")
             }
-            emitEnumPackage(outFile)
+//            emitEnumPackage(outFile)
             outFile.write(moduleContent)
             outFile.flush()
             outFile.close()
+            fileList.write(targetFilePath.replace("//", "/") + "\n")
           }
         }
-
       }
 
+      fileList.flush()
+      fileList.close()
     }
   }
 


### PR DESCRIPTION
@Dolu1990 , here is little two fix.
- 1: oneFilePerComponent Enumdefine generate every .v file will lead EDA-tool `redefine` warning, fixed 
![image](https://user-images.githubusercontent.com/6213885/93415348-e1e7aa80-f8d5-11ea-88b3-2dda2b0388f6.png)

- 2: generate filelist
