### PR TITLE
Copyedits on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 ## About SpinalHDL
 
 SpinalHDL is:
-- A language to describe digital hardware 
-- Compatible with EDA tools as it generate the corresponding VHDL/Verilog file
-- Much more powerful than VHDL, Verilog and SystemVerilog by its syntaxes and features
-- Much less verbose than VHDL, Verilog and SystemVerilog
-- Not an HLS, nor based on the event driven paradigm
-- Only generating what you asked it in a one to one way (no black-magic, no blackbox)
-- Not introducing Area/Performance overhead in your design (versus a hand written VHDL/Verilog)
-- Based on the RTL description paradigm, but can go much further
-- Allowing you to use Object Oriented Programming and Functional Programming to elaborate your hardware and verify it
-- Free and can be used in the industry without any license
+
+ - A language to describe digital hardware
+ - Compatible with EDA tools, as it generates VHDL/Verilog files
+ - Much more powerful than VHDL, Verilog, and SystemVerilog in its syntax and features
+ - Much less verbose than VHDL, Verilog, and SystemVerilog
+ - Not an HLS, nor based on the event-driven paradigm
+ - Only generates what you asked it in a one-to-one way (no black-magic, no black box)
+ - Not introducing area/performance overheads in your design (versus a hand-written VHDL/Verilog design)
+ - Based on the RTL description paradigm, but can go much further
+ - Allowing you to use Object-Oriented Programming and Functional Programming to elaborate your hardware and verify it
+ - Free and can be used in the industry without any license
 
 ## Links
-- Documentation                  <br> https://spinalhdl.github.io/SpinalDoc-RTD/
-- Presentation of the language   <br> https://spinalhdl.github.io/SpinalDoc-RTD/SpinalHDL/Getting%20Started/presentation.html
-- SBT base project               <br> https://github.com/SpinalHDL/SpinalTemplateSbt
-- Gradle base project            <br> https://github.com/SpinalHDL/SpinalTemplateGradle
-- jupyter bootcamp               <br> https://github.com/SpinalHDL/Spinal-bootcamp
-- Workshop                       <br> https://github.com/SpinalHDL/SpinalWorkshop
-- Google group                   <br> https://groups.google.com/forum/#!forum/spinalhdl-hardware-description-language
+
+ - Documentation                  <br> https://spinalhdl.github.io/SpinalDoc-RTD/
+ - Presentation of the language   <br> https://spinalhdl.github.io/SpinalDoc-RTD/SpinalHDL/Getting%20Started/presentation.html
+ - SBT base project               <br> https://github.com/SpinalHDL/SpinalTemplateSbt
+ - Gradle base project            <br> https://github.com/SpinalHDL/SpinalTemplateGradle
+ - Jupyter bootcamp               <br> https://github.com/SpinalHDL/Spinal-bootcamp
+ - Workshop                       <br> https://github.com/SpinalHDL/SpinalWorkshop
+ - Google group                   <br> https://groups.google.com/forum/#!forum/spinalhdl-hardware-description-language
 
 [![Join the chat at https://gitter.im/SpinalHDL/SpinalHDL](https://badges.gitter.im/SpinalHDL/SpinalHDL.svg)](https://gitter.im/SpinalHDL/SpinalHDL?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -40,7 +42,8 @@ libraryDependencies ++= Seq(
 )
 ```
 
-You can force to pick a specific SpinalHDL version by replacing the 'latest.release'. See https://github.com/SpinalHDL/SpinalTemplateSbt/blob/master/build.sbt
+You can force SBT to pick a specific SpinalHDL version by replacing `latest.release` with a specific version.
+See the [SpinalHDL SBT Template project's `build.sbt` file](https://github.com/SpinalHDL/SpinalTemplateSbt/blob/master/build.sbt) for a full SBT example.
 
 ### Gradle
 
@@ -62,20 +65,22 @@ dependencies {
 
 The files are available [on Maven](https://mvnrepository.com/artifact/com.github.spinalhdl) as well.
 
-## Changes logs
+## Change logs
 
 https://github.com/SpinalHDL/SpinalHDL/tags
 
 ## License
 
-The SpinalHDL core is using the LGPL3 license while SpinalHDL lib is using the MIT one. That's for the formalities. But there is some practices statements of those license implications :
+The SpinalHDL core is using the LGPL3 license while SpinalHDL lib is using the MIT license. That's for the formalities. But there are some practical statements implied by those licenses:
 
-Your freedoms are :
-- You can use SpinalHDL core and lib in your closed/commercial projects.
-- The generated RTL is yours (.vhd/.v files)
-- Your hardware description is yours (.scala files)
+Your freedoms are:
 
-Your obligations (and my wish) are :
-- If you modify the SpinalHDL core (the compiler itself), please, share your improvements.
+ - You can use SpinalHDL core and lib in your closed/commercial projects.
+ - The generated RTL is yours (.vhd/.v files)
+ - Your hardware description is yours (.scala files)
+
+Your obligations (and my wish) are:
+
+ - If you modify the SpinalHDL core (the compiler itself), please, share your improvements.
 
 Also, SpinalHDL is provided "as is", without warranty of any kind.


### PR DESCRIPTION
Changes in this PR include:

 - Reformatted markdown lists.
 - Small spelling/grammatical fixes throughout
 - Cleaner-looking link to the `SpinalTemplateSbt` project's `build.sbt` file.