### PR TITLE
Fix UFix maxValue bug from issue #343.

### DIFF
--- a/core/src/main/scala/spinal/core/FixedPoint.scala
+++ b/core/src/main/scala/spinal/core/FixedPoint.scala
@@ -507,7 +507,7 @@ class UFix(maxExp: Int, bitCount: Int) extends XFix[UFix, UInt](maxExp, bitCount
     ret
   }
 
-  def maxValue: BigDecimal = Math.pow(2.0, maxExp) * (1.0 - 1.0 / math.pow(2.0, bitCount - 1))
+  def maxValue: BigDecimal = Math.pow(2.0, maxExp) * (1.0 - 1.0 / math.pow(2.0, bitCount))
   def minValue: BigDecimal = 0.0
 
   override def resolution: BigDecimal = Math.pow(2.0, maxExp - bitCount)


### PR DESCRIPTION
This commit fixes a copy/paste bug in the `maxValue` calculation for the
`UFix` type in `FixedPoint.scala`.

The original `maxValue` calculation was copied from `SFix`, and resulted
in spurious assertion failures for users who were trying to assign the
maximum possible value to their `UFix` instances.

The issue was fixed by removing the `- 1` in the `UFix` `maxValue`
calculation that was inherited from the `SFix` `maxValue` calculation
to account for the sign bit.