### PR TITLE
Fix iverilog simulation under macOS

### DIFF
--- a/sim/src/main/resources/VpiPlugin.cpp
+++ b/sim/src/main/resources/VpiPlugin.cpp
@@ -70,6 +70,7 @@ bool register_cb(PLI_INT32(*f)(p_cb_data),
         int64_t cycles){
 
     s_cb_data cbData;
+    memset(&cbData, 0, sizeof(cbData));
     s_vpi_time simuTime;
     if (cycles < 0){
         cbData.time = NULL;

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -55,9 +55,8 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
   var runIface = 0
 
   CFLAGS += " -fPIC -DNDEBUG -I " + pluginsPath
-  CFLAGS += (if(isMac) " -dynamiclib " else "")
   LDFLAGS += (if(!isMac) " -shared" else "")
-  LDFLAGS += (if(!isWindows) " -lrt" else "")
+  LDFLAGS += (if(!isWindows && !isMac) " -lrt" else "")
 
   val jdk = System.getProperty("java.home").replace("/jre","").replace("\\jre","")
 
@@ -104,7 +103,7 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
       "Compilation of SharedMemIface_wrap.cxx failed")
 
         assert(Process(Seq(CC, 
-          CFLAGS, 
+          CFLAGS + (if(isMac) " -dynamiclib " else ""),
           "SharedMemIface.o", 
           "SharedMemIface_wrap.o",
           LDFLAGS, 

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -427,13 +427,13 @@ class IVerilogBackend(config: IVerilogBackendConfig) extends VpiBackend(config) 
 
     assert(Process(Seq(iverilogPath,
                        analyzeFlags,
+                       "-o",
+                       toplevelName + ".vvp",
                        "-s __simulation_def",
                        "-s",
                        toplevelName,
                        verilogSourcePaths,
-                       s"./rtl/__simulation_def.v",
-                       "-o",
-                       toplevelName + ".vvp").mkString(" "), 
+                       s"./rtl/__simulation_def.v").mkString(" "),
                      new File(workspacePath)).! (new Logger()) == 0, 
            s"Analyze step of verilog files failed") 
   }


### PR DESCRIPTION
This pr does these things:

1. Add `memset` call to avoid SIGSEGV of `vvp`.
2. Fix iverilog argument order, because iverilog requires `-o outputfile` appears before source files
3. Fix CFLAGS and LDFLAGS for correct compilation under macOS.

GHDL simulation under macOS is also tested and works.

Original problem:

1. Cannot link librt:

```
[info] clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
[info] clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
[info] ld: library not found for -lrt
[info] clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

2. Compilation failed:

```
[info] 7 warnings generated.
[info] clang: error: invalid argument '-bundle' not allowed with '-dynamiclib'
```

Whereas `iverilog-vpi --ldflags` shows:

```
 -bundle -undefined suppress -flat_namespace -L/usr/local/Cellar/icarus-verilog/11.0/lib
```

3. Wrong argument:

```
[info] 7 warnings generated.
[info] -o: No such file or directory
[info] Main.vvp: Unable to open input file
```

4. Simulation crash:

```
[info] 7 warnings generated.
[info] Shared memory key : SpinalHDL_0_1_1095352419_-940498754_1610702245514_-1987874356519673791
[info] Start of simulation
[error] Exception in thread "main" Exception in thread "Thread-30" spinal.sim.VpiException: Simulation crashed with return status 139
[error]         at spinal.sim.vpi.JNISharedMemIfaceJNI.SharedMemIface_check_ready(Native Method)
[error]         at spinal.sim.vpi.SharedMemIface.check_ready(SharedMemIface.java:128)
[error]         at spinal.sim.VpiBackend.instanciate_(VpiBackend.scala:150)
[error]         at spinal.sim.VpiBackend.instanciate(VpiBackend.scala:157)
[error]         at spinal.sim.VpiBackend.instanciate(VpiBackend.scala:169)
[error]         at spinal.sim.SimVpi.<init>(SimVpi.scala:15)
[error]         at spinal.core.sim.SpinalSimConfig$$anon$6.newSimRaw(SimBootstraps.scala:680)
[error]         at spinal.core.sim.SimCompiled.doSimApi(SimBootstraps.scala:393)
[error]         at spinal.core.sim.SimCompiled.doSim(SimBootstraps.scala:371)
[error]         at spinal.core.sim.SpinalSimConfig.doSim(SimBootstraps.scala:565)
[error]         at metaana.MainSim$.main(MainSim.scala:12)
[error]         at metaana.MainSim.main(MainSim.scala)
[error] java.lang.AssertionError: assertion failed: Simulation of Main failed
[error]         at scala.Predef$.assert(Predef.scala:170)
[error]         at spinal.sim.IVerilogBackend$$anon$2.run(VpiBackend.scala:458)
[error]         at java.base/java.lang.Thread.run(Thread.java:832)
[error] Nonzero exit code returned from runner: 1
[error] (Compile / runMain) Nonzero exit code returned from runner: 1
[error] Total time: 10 s, completed Jan 15, 2021, 5:17:25 PM
```

With this pr, all problems above are fixed.