### PR TITLE
Add support for multi word memory access in BusSlaveFactory

### DIFF
--- a/lib/src/main/scala/spinal/lib/Mem.scala
+++ b/lib/src/main/scala/spinal/lib/Mem.scala
@@ -89,11 +89,23 @@ class MemPimped[T <: Data](mem: Mem[T]) {
   }
 
 
+  /**
+    * Create a write port of memory.
+    */
   def writePort : Flow[MemWriteCmd[T]] = {
     val ret = Flow(MemWriteCmd(mem))
     when(ret.valid){
       mem.write(ret.address,ret.data)
     }
+    ret
+  }
+
+  /**
+    * Create a write port of memory with masking.
+    */
+  def writePortWithMask : Flow[MemWriteCmdWithMask[T]] = {
+    val ret = Flow(MemWriteCmdWithMask(mem))
+    mem.write(ret.address,ret.data, ret.valid, ret.mask)
     ret
   }
 
@@ -108,6 +120,12 @@ class MemPimped[T <: Data](mem: Mem[T]) {
 case class MemWriteCmd[T <: Data](mem : Mem[T]) extends Bundle{
   val address = mem.addressType()
   val data    = mem.wordType()
+}
+
+case class MemWriteCmdWithMask[T <: Data](mem : Mem[T]) extends Bundle {
+  val address = mem.addressType()
+  val data    = mem.wordType()
+  val mask    = Bits
 }
 
 case class MemReadPort[T <: Data](dataType : T,addressWidth : Int) extends Bundle with IMasterSlave{

--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -581,6 +581,21 @@ trait BusSlaveFactory extends Area{
     mem
   }
 
+  /**
+    * Memory map a Mem to bus for reading. Elements can be larger than bus data width in bits.
+    */
+  def readSyncMemMultiWord[T <: Data](mem: Mem[T],
+                                      addressOffset: BigInt): Mem[T] = {
+    val mapping = SizeMapping(addressOffset, mem.wordCount << log2Up(mem.width / 8))
+    val memAddress = readAddress(mapping) >> log2Up(mem.width / 8)
+    val readData = mem.readSync(memAddress).asBits
+    val offset = readAddress(mapping)(log2Up(mem.width / 8) - 1 downto log2Up(busDataWidth / 8))
+    val partialRead = readData(offset << log2Up(busDataWidth), busDataWidth bits)
+    multiCycleRead(mapping, 2)
+    readPrimitive(partialRead, mapping, 0, null)
+    mem
+  }
+
   def writeMemWordAligned[T <: Data](mem           : Mem[T],
                                      addressOffset : BigInt,
                                      bitOffset     : Int = 0) : Mem[T] = {


### PR DESCRIPTION
Before this commit, the functions `readSyncMemWordAligned` and `writeMemWordAligned` only support aligned word access. This pr implements two new functions that support multi word memory access (elements of Mem span across several words).