### PR TITLE
Uncomment and fix AxiLite4SlaveFactoryTesterCocotbBoot

### DIFF
--- a/tester/src/test/python/spinal/AxiLite4SlaveFactoryTester/AxiLite4SlaveFactoryTester.py
+++ b/tester/src/test/python/spinal/AxiLite4SlaveFactoryTester/AxiLite4SlaveFactoryTester.py
@@ -22,6 +22,9 @@ class UutModel:
         while True:
             yield RisingEdge(dut.clk)
             assertEquals(dut.io_nonStopWrited,truncUInt(int(dut.io_bus_w_payload_data) >> 4,dut.io_nonStopWrited),"io_nonStopWrited")
+            # when read to addr=2 and write to addr=7 happen at the same cycle
+            # the former takes precedence
+            regBassigned = False
             if int(dut.io_bus_r_valid) & int(dut.io_bus_r_ready) == 1:
                 if self.readAddresses.empty():
                     raise TestFailure("FAIL readAddresses is empty")
@@ -33,6 +36,7 @@ class UutModel:
 
                 if addr == 2:
                     self.regB = 33
+                    regBassigned = True
 
 
             if int(dut.io_bus_ar_valid) & int(dut.io_bus_ar_ready) == 1:
@@ -43,7 +47,7 @@ class UutModel:
                 addr = int(dut.io_bus_aw_payload_addr)
                 if addr == 9:
                     self.regA = truncUInt(int(dut.io_bus_w_payload_data) >> 10,20)
-                if addr == 7:
+                if addr == 7 and not regBassigned:
                     self.regB = truncUInt(int(dut.io_bus_w_payload_data) >> 10,20)
                 if addr == 15:
                     self.regA = 11

--- a/tester/src/test/python/spinal/common/Makefile.def
+++ b/tester/src/test/python/spinal/common/Makefile.def
@@ -1,3 +1,6 @@
 TOPLEVEL_LANG ?= verilog
 
-SIM_ARGS += --ieee-asserts=disable
+# ghdl specific args
+ifeq ($(TOPLEVEL_LANG),vhdl)
+	SIM_ARGS += --ieee-asserts=disable
+endif

--- a/tester/src/test/scala/spinal/tester/scalatest/AxiLite4SlaveFactoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/AxiLite4SlaveFactoryTester.scala
@@ -30,9 +30,9 @@ object AxiLite4SlaveFactoryTester{
   }
 }
 
-//class AxiLite4SlaveFactoryTesterCocotbBoot extends SpinalTesterCocotbBase {
-//  override def getName: String = "AxiLite4SlaveFactoryTester"
-//  override def pythonTestLocation: String = "tester/src/test/python/spinal/AxiLite4SlaveFactoryTester"
-//  override def createToplevel: Component = new AxiLite4SlaveFactoryTester.AxiLite4SlaveFactoryTester
-//  withWaveform = true
-//}
+class AxiLite4SlaveFactoryTesterCocotbBoot extends SpinalTesterCocotbBase {
+  override def getName: String = "AxiLite4SlaveFactoryTester"
+  override def pythonTestLocation: String = "tester/src/test/python/spinal/AxiLite4SlaveFactoryTester"
+  override def createToplevel: Component = new AxiLite4SlaveFactoryTester.AxiLite4SlaveFactoryTester
+  withWaveform = true
+}


### PR DESCRIPTION
Generated verilog:

```verilog
      case(io_bus_aw_payload_addr)
        4'b1001 : begin
          if(ctrl_writeOccur)begin
            regA <= io_bus_w_payload_data[29 : 10];
          end
        end
        4'b0111 : begin
          if(ctrl_writeOccur)begin
            regB <= io_bus_w_payload_data[29 : 10];
          end
        end
        4'b1111 : begin
          if(ctrl_writeOccur)begin
            regA <= 20'h0000b;
          end
        end
        default : begin
        end
      endcase
      case(ctrl_readDataStage_payload_addr)
        4'b0010 : begin
          if(ctrl_readOccur)begin
            regB <= 20'h00021;
          end
        end
        default : begin
        end
      endcase

```