### PR TITLE
Add workaround for oshi not working under Apple M1

### DIFF
--- a/lib/src/main/scala/spinal/lib/eda/bench/Bench.scala
+++ b/lib/src/main/scala/spinal/lib/eda/bench/Bench.scala
@@ -1,9 +1,9 @@
 package spinal.lib.eda.bench
 import spinal.core._
-import java.util.concurrent.ForkJoinPool
-
 import spinal.lib.StreamFifo
+import spinal.sim.SimManager
 
+import java.util.concurrent.ForkJoinPool
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
@@ -22,7 +22,7 @@ object Bench{
   def apply(rtls : Seq[Rtl], targets : Seq[Target], workspacesRoot : String = sys.env.getOrElse("SPINAL_BENCH_WORKSPACE", null)): Unit ={
     import scala.concurrent.ExecutionContext
     implicit val ec = ExecutionContext.fromExecutorService(
-      new ForkJoinPool(Math.max(1,new oshi.SystemInfo().getHardware.getProcessor.getLogicalProcessorCount/2), ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true)
+      new ForkJoinPool(Math.max(1, SimManager.cpuCount / 2), ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true)
     )
 
     val results = (for (rtl <- rtls) yield {

--- a/sim/src/main/scala/spinal/sim/SimManager.scala
+++ b/sim/src/main/scala/spinal/sim/SimManager.scala
@@ -68,8 +68,15 @@ class SimFailure(message : String) extends Exception (message)
 object SimManager{
   var cpuAffinity = 0
   lazy val cpuCount = {
-    val systemInfo = new oshi.SystemInfo
-    systemInfo.getHardware.getProcessor.getLogicalProcessorCount
+    try {
+      val systemInfo = new oshi.SystemInfo
+      systemInfo.getHardware.getProcessor.getLogicalProcessorCount
+    } catch {
+      // fallback when oshi can't work on Apple M1
+      // see https://github.com/oshi/oshi/issues/1462
+      // remove this workaround when the issue is fixed
+      case e @ (_ : NoClassDefFoundError | _ : UnsatisfiedLinkError) => Runtime.getRuntime().availableProcessors()
+    }
   }
   def newCpuAffinity() : Int = synchronized {
     val ret = cpuAffinity


### PR DESCRIPTION
See https://github.com/oshi/oshi/issues/1462 for oshi issue on Apple M1.

By the way, I am curious about why using oshi instead of `Runtime.getRuntime().availableProcessors()`?