### PR TITLE
WIP: Fix multicycle read: don't overflow counter

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -555,15 +555,22 @@ trait BusSlaveFactory extends Area{
 
   def multiCycleRead(address: AddressMapping, cycles: BigInt): Unit = {
     val counter = Counter(cycles)
+    val reading = False
     onReadPrimitive(
       address       = address,
       haltSensitive = false,
       documentation = null
     ){
-      counter.increment()
+      reading := True
       when(!counter.willOverflowIfInc){
         readHalt()
+        counter.increment()
       }
+    }
+
+    // clear counter before next read
+    when(!reading) {
+      counter.clear()
     }
   }
 


### PR DESCRIPTION
In the original implementation, when `cycles = 2`, the counter will wrap around every 2 cycles:

```
valid 010101010101
ready 000000000000
```

However, this can violate the requirement in AXI:

```
The slave can assert the RVALID signal only when it drives valid read data. When asserted, RVALID must remain asserted until the rising clock edge after the master asserts RREADY. Even if a slave has only one source of read data, it must assert the RVALID signal only in response to a request for data.
``` 

If `RREADY` stays low for some cycles, `RVALID` will deassert before the master asserts `RREADY`.

This problem is found when formal verifying an `AXILite4` slave created with `AxiLite4SlaveFactory`.

With this fix, the valid signal would be:

```
valid 01110
ready 0001*
```

But there is a small concern whether this fix might break someone's logic.

EDIT:  ~~I found a problem with this fix. DO NOT MERGE.~~ FIXED.