### PR TITLE
fix 3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ scalaVersion := "2.11.12"
 
 libraryDependencies ++= Seq(
   "com.github.spinalhdl" % "spinalhdl-core_2.11" % "latest.release",
-  "com.github.spinalhdl" % "spinalhdl-lib_2.11" % "latest.release"
-
+  "com.github.spinalhdl" % "spinalhdl-lib_2.11" % "latest.release",
   compilerPlugin("com.github.spinalhdl" % "spinalhdl-idsl-plugin_2.11" % "latest.release")
 )
 ```

--- a/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
@@ -173,6 +173,22 @@ class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
   }
 }
 
+object UartCtrl {
+  def apply(config: UartCtrlInitConfig, readonly: Boolean = false): UartCtrl = {
+    val uartCtrl = new UartCtrl()
+    uartCtrl.io.config.setClockDivider(config.baudrate Hz)
+    uartCtrl.io.config.frame.dataLength := config.dataLength  //8 bits
+    uartCtrl.io.config.frame.parity := config.parity
+    uartCtrl.io.config.frame.stop := config.stop
+    uartCtrl.io.writeBreak := False
+    if (readonly) {
+      uartCtrl.io.write.valid := False
+      uartCtrl.io.write.payload := B(0)
+    }
+    uartCtrl
+  }
+}
+
 case class UartCtrlInitConfig(
   baudrate : Int = 0,
   dataLength : Int = 0,
@@ -245,11 +261,14 @@ class UartCtrlUsageExample extends Component{
     val leds = out Bits(8 bits)
   }
 
-  val uartCtrl = new UartCtrl()
-  uartCtrl.io.config.setClockDivider(921.6 kHz)
-  uartCtrl.io.config.frame.dataLength := 7  //8 bits
-  uartCtrl.io.config.frame.parity := UartParityType.NONE
-  uartCtrl.io.config.frame.stop := UartStopType.ONE
+  val uartCtrl: UartCtrl = UartCtrl(
+    config = UartCtrlInitConfig(
+      baudrate = 921600,
+      dataLength = 7,  // 8 bits
+      parity = UartParityType.NONE,
+      stop = UartStopType.ONE
+    )
+  )
   uartCtrl.io.uart <> io.uart
 
   //Assign io.led with a register loaded each time a byte is received

--- a/lib/src/main/scala/spinal/lib/eda/altera/QuartusFlow.scala
+++ b/lib/src/main/scala/spinal/lib/eda/altera/QuartusFlow.scala
@@ -91,6 +91,8 @@ object QuartusTest {
   }
 }
 
+object QuartusProject
+
 class QuartusProject(quartusPath: String, workspacePath: String) {
   private def search(file: File, name: String): String = {
     try {
@@ -119,10 +121,11 @@ class QuartusProject(quartusPath: String, workspacePath: String) {
     printf("Area: %s\n\rFMax: %f MHz\n\r", area, fMax/1e6)
   }
 
-  def compile(): Unit = {
+  def compile(): QuartusProject = {
     if (qpfPath != null)
       doCmd(s"""${Paths.get(quartusPath,"quartus_sh")} --flow compile $qpfPath""")
     report()
+    this
   }
 
   def program(): Unit = {


### PR DESCRIPTION
1. fix a syntax error in `readme.md` sbt example. only add a `,` 😂 
2. last week I added a class `QuartusProject` but I find that user cannot access it. So I add an object.
and then we can use in this way:
```scala
QuartusProject(...).compile().program()
```
3. the `UartCtrlUsageExample` maybe too old to use. I add an object for simple usage and update the example.
I think it's more friendly to starters and very convenient to debug FPGA. For example, when you need to read data from single RX pin:
```scala
val uartCtrl: UartCtrl = UartCtrl(
    config = UartCtrlInitConfig(
      baudrate = 921600,
      dataLength = 7,  // 8 bits
      parity = UartParityType.NONE,
      stop = UartStopType.ONE
    ),
    readonly = true
  )
```