### PR TITLE
Fix gitHash when building as a subproject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,6 +133,7 @@ lazy val core = (project in file("core"))
     version := SpinalVersion.core,
     sourceGenerators in Compile += Def.task {
       val dir = (sourceManaged in Compile).value
+      dir.mkdirs()
       val file = dir / "Info.scala"
       IO.write(file, """package spinal.core
                        |object Info {

--- a/build.sbt
+++ b/build.sbt
@@ -78,8 +78,8 @@ lazy val all = (project in file("."))
 
 
 import sys.process._
-def gitHash = (try {
-  "git rev-parse HEAD".!!
+def gitHash(dir: File) = (try {
+  s"git -C ${dir.toString} rev-parse HEAD".!!
 } catch{
   case e : java.io.IOException => "???"
 }).linesIterator.next()
@@ -140,7 +140,7 @@ lazy val core = (project in file("core"))
                        |  val name = "%s"
                        |  val gitHash = "%s"
                        |}
-                       |""".stripMargin.format(SpinalVersion.core, name, gitHash))
+                       |""".stripMargin.format(SpinalVersion.core, name, gitHash(dir)))
       Seq(file)
     }.taskValue
   )


### PR DESCRIPTION
This is a small change that lets git find the current hash when building as a subproject with a different working directory.

For example I use this in my project's `build.sbt` when working from sources:
```
lazy val spinalHdlIdslPlugin = ProjectRef(file("./ext/SpinalHDL"), "idslplugin")
lazy val spinalHdlCore = ProjectRef(file("./ext/SpinalHDL"), "core")
lazy val spinalHdlLib = ProjectRef(file("./ext/SpinalHDL"), "lib")

dependsOn(spinalHdlCore,spinalHdlLib,spinalHdlIdslPlugin)

scalacOptions += (artifactPath in(spinalHdlIdslPlugin, Compile, packageBin)).map { file =>
  s"-Xplugin:${file.getAbsolutePath}"
}.value
```