### PR TITLE
Pass simulator flags to iverilog and ghdl

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -213,6 +213,9 @@ case class SpinalGhdlBackendConfig[T <: Component](override val rtl : SpinalRepo
 object SpinalGhdlBackend {
   def apply[T <: Component](config: SpinalGhdlBackendConfig[T]) = { 
     val vconfig = new GhdlBackendConfig()
+    vconfig.analyzeFlags = config.simulatorFlags.mkString(" ")
+    vconfig.runFlags = config.simulatorFlags.mkString(" ")
+
     val signalsCollector = SpinalVpiBackend(config, vconfig)
     new GhdlBackend(vconfig){
       val signals = signalsCollector
@@ -223,6 +226,9 @@ object SpinalGhdlBackend {
 object SpinalIVerilogBackend {
   def apply[T <: Component](config: SpinalIVerilogBackendConfig[T]) = { 
     val vconfig = new IVerilogBackendConfig()
+    vconfig.analyzeFlags = config.simulatorFlags.mkString(" ")
+    vconfig.runFlags = config.simulatorFlags.mkString(" ")
+
     val signalsCollector = SpinalVpiBackend(config, vconfig)
     new IVerilogBackend(vconfig){
       val signals = signalsCollector


### PR DESCRIPTION
Currently, user can pass simulator flags via `addSimulatorFlag` function, but only iverilator backend receives the flags https://github.com/SpinalHDL/SpinalHDL/blob/adf552d8f500e7419fff395b7049228e4bc5de26/sim/src/main/scala/spinal/sim/VerilatorBackend.scala#L459.

This pr passes `simulatorFlags` to iverilog and ghdl backend as well.