### PR TITLE
Add structs and records

### DIFF
--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -255,6 +255,7 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
 
   private[core] var dir: IODirection = null
   private[core] def isIo = dir != null
+  private[core] def isSuffix = parent != null && parent.isInstanceOf[Suffixable]
 
   var parent: Data = null
   def getRootParent: Data = if(parent == null) this else parent.getRootParent

--- a/core/src/main/scala/spinal/core/Struct.scala
+++ b/core/src/main/scala/spinal/core/Struct.scala
@@ -1,0 +1,178 @@
+package spinal.core
+
+import spinal.core.internals.TypeStruct
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * Class representing Verilog Struct and VHDL Record data types.
+ * @param typeName Underlying structure name to use if not the subclass name.
+ */
+abstract class SpinalStruct(val typeName: String = null) extends BaseType with Nameable with ValCallbackRec with DataPrimitives[SpinalStruct] {
+
+  def elements: ArrayBuffer[(String, Data)] = elementsCache
+
+  override private[spinal] def _data: SpinalStruct = this
+
+  def find(name: String): Data = {
+    val temp = elements.find((tuple) => tuple._1 == name).getOrElse(null)
+    if (temp == null) return null
+    temp._2
+  }
+
+  override def asBits: Bits = {
+    var ret: Bits = null
+    for ((eName, e) <- elements) {
+      if (ret == null.asInstanceOf[Object]) ret = e.asBits
+      else ret = e.asBits ## ret
+    }
+    if (ret.asInstanceOf[Object] == null) ret = Bits(0 bits)
+    ret
+  }
+
+  override def getBitsWidth: Int = {
+    var accumulateWidth = 0
+    for ((_, e) <- elements) {
+      val width = e.getBitsWidth
+      if (width == -1)
+        SpinalError("Can't return bits width")
+      accumulateWidth += width
+    }
+    accumulateWidth
+  }
+
+  override def assignFromBits(bits: Bits): Unit = {
+    var offset = 0
+    for ((_, e) <- elements) {
+      val width = e.getBitsWidth
+      e.assignFromBits(bits(offset, width bit))
+      offset = offset + width
+    }
+  }
+
+  override def assignFromBits(bits: Bits, hi: Int, lo: Int): Unit = {
+    var offset = 0
+    var bitsOffset = 0
+
+    for ((_, e) <- elements) {
+      val width = e.getBitsWidth
+
+      if (hi >= offset && lo < offset + width) {
+        val high = Math.min(hi-offset,width-1)
+        val low  = Math.max(lo-offset,0)
+        val bitUsage = high - low + 1
+        e.assignFromBits(bits(bitsOffset,bitUsage bit), high,low)
+        bitsOffset += bitUsage
+      }
+
+      offset = offset + width
+    }
+
+  }
+
+  /** Assign the bundle with an other bundle by name */
+  def assignAllByName(that: Bundle): Unit = {
+    for ((name, element) <- elements) {
+      val other = that.find(name)
+      if (other == null)
+        LocatedPendingError(s"Bundle assignment is not complete. Missing $name")
+      else element match {
+        case b: Bundle => b.assignAllByName(other.asInstanceOf[Bundle])
+        case _         => element := other
+      }
+    }
+  }
+
+  /** Assign all possible signal fo the bundle with an other bundle by name */
+  def assignSomeByName(that: Bundle): Unit = {
+    for ((name, element) <- elements) {
+      val other = that.find(name)
+      if (other != null) {
+        element match {
+          case b: Bundle => b.assignSomeByName(other.asInstanceOf[Bundle])
+          case _         => element := other
+        }
+      }
+    }
+  }
+
+  private[core] override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+    that match {
+      case that: SpinalStruct =>
+        if (!this.getClass.isAssignableFrom(that.getClass)) SpinalError("Structs must have the same final class to" +
+          " be assigned. Either use assignByName or assignSomeByName at \n" + ScalaLocated.long)
+        super.assignFromImpl(that, target, kind)
+      case _ => throw new Exception("Undefined assignment")
+    }
+  }
+
+  private[core] def isEquals(that: Any): Bool = {
+    that match {
+      case that: SpinalStruct => zippedMap(that, _ === _).reduce(_ && _)
+      case _               => SpinalError(s"Function isEquals is not implemented between $this and $that")
+    }
+  }
+
+  private[core] def isNotEquals(that: Any): Bool = {
+    that match {
+      case that: SpinalStruct => zippedMap(that, _ =/= _).reduce(_ || _)
+      case _               => SpinalError(s"Function isNotEquals is not implemented between $this and $that")
+    }
+  }
+
+  private[core] override def autoConnect(that: Data): Unit = {
+    that match {
+      case that: SpinalStruct => this.autoConnectBaseImpl(that)
+      case _               => SpinalError(s"Function autoConnect is not implemented between $this and $that")
+    }
+  }
+
+  def elementsString = this.elements.map(_.toString()).reduce(_ + "\n" + _)
+
+  private[core] def zippedMap[T](that: SpinalStruct, task: (Data, Data) => T): Seq[T] = {
+    if (that.elements.length != this.elements.length) SpinalError(s"Can't zip [$this] with [$that]  because they don't have the same number of elements.\nFirst one has :\n${this.elementsString}\nSeconde one has :\n${that.elementsString}\n")
+    this.elements.map(x => {
+      val (n, e) = x
+      val other = that.find(n)
+      if (other == null) SpinalError(s"Can't zip [$this] with [$that] because the element named '${n}' is missing in the second one")
+      task(e, other)
+    })
+  }
+
+  private var elementsCache = ArrayBuffer[(String, Data)]()
+
+  override def valCallbackRec(ref: Any, name: String): Unit = ref match {
+    case ref : Data => {
+      elementsCache += name -> ref
+      ref.parent = this
+      if(OwnableRef.proposal(ref, this)) ref.setPartialName(name, Nameable.DATAMODEL_WEAK)
+    }
+    case ref =>
+  }
+
+  def getTypeString: String = {
+    if (typeName == null)
+      getClass.getTypeName
+    else
+      typeName
+  }
+
+  override def getZero: this.type = {
+    val ret = cloneOf(this)
+    ret.elements.foreach(e => {
+      e._2 := e._2.getZero
+    })
+    ret.asInstanceOf[this.type]
+  }
+
+  override private[core] def newMultiplexerExpression() = ???
+
+  override private[core] def newBinaryMultiplexerExpression() = ???
+
+  /** Create a new instance of the same datatype without any configuration (width, direction) */
+  override private[core] def weakClone = ???
+
+  override def opName: String = "Struct"
+
+  override def getTypeObject: Any = TypeStruct
+}

--- a/core/src/main/scala/spinal/core/Struct.scala
+++ b/core/src/main/scala/spinal/core/Struct.scala
@@ -198,7 +198,7 @@ abstract class SpinalStruct(val typeName: String = null) extends BaseType with N
     case ref : Data => {
       elementsCache += name -> ref
       ref.parent = this
-      if(OwnableRef.proposal(ref, this)) ref.setPartialName(name, Nameable.DATAMODEL_WEAK)
+      if(OwnableRef.proposal(ref, this)) ref.setPartialName(name, Nameable.DATAMODEL_STRONG)
     }
     case ref =>
   }

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -378,9 +378,12 @@ trait Nameable extends OwnableRef with ContextUser{
         val ref = refOwner.asInstanceOf[Nameable]
         if (ref.isNamed) {
           val ownerName = ref.getName()
-          if(ownerName != "" && name != "")
-            ownerName + "_" + name
-          else
+          if(ownerName != "" && name != "") {
+            if (refOwner.isInstanceOf[SpinalStruct])
+              ownerName + "." + name
+            else
+              ownerName + "_" + name
+          } else
             ownerName + name
         } else {
           default

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -379,7 +379,7 @@ trait Nameable extends OwnableRef with ContextUser{
         if (ref.isNamed) {
           val ownerName = ref.getName()
           if(ownerName != "" && name != "") {
-            if (refOwner.isInstanceOf[SpinalStruct])
+            if (refOwner.isInstanceOf[Suffixable])
               ownerName + "." + name
             else
               ownerName + "_" + name

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -149,11 +149,11 @@ class ComponentEmitterVerilog(
 
     component.children.foreach(sub =>
       sub.getAllIo
-      .filterNot(_.isSuffix)
       .foreach(io => if(io.isOutput) {
         val componentSignalName = (sub.getNameElseThrow + "_" + io.getNameElseThrow)
         val name = component.localNamingScope.allocateName(componentSignalName)
-        declarations ++= emitExpressionWrap(io, name)
+        if (!io.isSuffix)
+          declarations ++= emitExpressionWrap(io, name)
         referencesOverrides(io) = name
       }
     ))

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -806,7 +806,7 @@ class ComponentEmitterVhdl(
   def emitSignals(): Unit = {
     component.dslBody.walkDeclarations {
       case signal: BaseType =>
-        if (!signal.isIo) {
+        if (!signal.isIo && !signal.parent.isInstanceOf[SpinalStruct]) {
           declarations ++= s"  signal ${emitReference(signal, false)} : ${emitDataType(signal)}${getBaseTypeSignalInitialisation(signal)};\n"
         }
         emitAttributes(signal, signal.instanceAttributes(Language.VHDL), "signal", declarations)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -106,8 +106,16 @@ class ComponentEmitterVhdl(
   }
 
   override def wrapSubInput(io: BaseType): Unit = {
-    val name = component.localNamingScope.allocateName(anonymSignalPrefix)
-    declarations ++= s"  signal $name : ${emitDataType(io)};\n"
+    if (referencesOverrides.contains(io))
+      return
+    var name: String = null
+    if (!io.isSuffix) {
+      name = component.localNamingScope.allocateName(anonymSignalPrefix)
+      declarations ++= s"  signal $name : ${emitDataType(io)};\n"
+    } else {
+      wrapSubInput(io.parent.asInstanceOf[BaseType])
+      name = referencesOverrides(io.parent) + "." + io.getPartialName()
+    }
     referencesOverrides(io) = name
   }
 

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -1607,6 +1607,30 @@ class SIntRangedAccessFloating extends BitVectorRangedAccessFloating {
   override def bitVectorRangedAccessFixedFactory: BitVectorRangedAccessFixed = new SIntRangedAccessFixed
 }
 
+/**
+  * SuffixExpression
+  */
+class SuffixExpression extends Expression with ScalaLocated {
+  var target: BaseType = null
+
+  override def opName: String = "Prefix.Suffix"
+  override def getTypeObject: Any = TypeStruct
+  override def remapExpressions(func: Expression => Expression): Unit = {}
+  override def foreachExpression(func: Expression => Unit): Unit = {}
+}
+
+object SuffixExpression {
+  def apply(target: Expression): SuffixExpression = {
+    if (!target.isInstanceOf[BaseType])
+      LocatedPendingError(s"INVALID SUFFIX Cannot suffix non-BaseType expression ${target} at")
+
+    val expr = new SuffixExpression
+
+    expr.target = target.asInstanceOf[BaseType]
+
+    expr
+  }
+}
 
 /**
   * Assigned bits

--- a/core/src/main/scala/spinal/core/internals/Misc.scala
+++ b/core/src/main/scala/spinal/core/internals/Misc.scala
@@ -46,6 +46,7 @@ object TypeBits
 object TypeUInt
 object TypeSInt
 object TypeEnum
+object TypeStruct
 
 
 trait DoubleLinkedContainerElement[SC  <: DoubleLinkedContainer[SC, SE], SE <: DoubleLinkedContainerElement[SC, SE]]{

--- a/core/src/main/scala/spinal/core/internals/Node.scala
+++ b/core/src/main/scala/spinal/core/internals/Node.scala
@@ -155,6 +155,9 @@ object InputNormalize {
   }
 }
 
+trait Suffixable {
+  def elements: Seq[(String, Data)]
+}
 
 trait WidthProvider extends ScalaLocated {
   def getWidth: Int

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -1972,6 +1972,14 @@ class PhaseCheck_noLatchNoOverride(pc: PhaseContext) extends PhaseCheck{
 
 
         def finalCheck(bt : BaseType): Unit ={
+          // Hold off until suffix parent is processed
+          if (bt.isSuffix)
+            return
+          if (bt.isInstanceOf[Suffixable]) {
+            if (bt.dlcIsEmpty)
+              return bt.asInstanceOf[Suffixable].elements.filter(_._2.isInstanceOf[BaseType]).foreach(e => finalCheck(e._2.asInstanceOf[BaseType]))
+          }
+
           val assignedBits = getOrEmpty(bt)
           if ((bt.isVital || !bt.dlcIsEmpty) && bt.rootScopeStatement == body && !assignedBits.isFull){
             if(bt.isComb) {

--- a/core/src/main/scala/spinal/core/internals/VerilogBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VerilogBase.scala
@@ -50,7 +50,10 @@ trait VerilogBase extends VhdlVerilogBase{
 
   def emitExpressionWrap(e: Expression, name: String): String = {
 //    s"  wire ${emitType(e)} ${name};\n"
-    theme.maintab + expressionAlign("wire", emitType(e), name) + ";\n"
+    if (!e.isInstanceOf[SpinalStruct])
+      theme.maintab + expressionAlign("wire", emitType(e), name) + ";\n"
+    else
+      theme.maintab + expressionAlign(e.asInstanceOf[SpinalStruct].getTypeString, "", name) + ";\n"
   }
 
   def emitExpressionWrap(e: Expression, name: String, nature: String): String = {

--- a/core/src/main/scala/spinal/core/internals/VerilogBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VerilogBase.scala
@@ -112,6 +112,10 @@ trait VerilogBase extends VhdlVerilogBase{
     s"${spinalEnum.getName()}_${source.getName()}_to_${target.getName()}"
   }
 
+  def emitStructType(struct: SpinalStruct): String = {
+    return struct.getTypeString
+  }
+
   def emitType(e: Expression): String = e.getTypeObject match {
     case `TypeBool` => ""
     case `TypeBits` => emitRange(e.asInstanceOf[WidthProvider])
@@ -120,6 +124,7 @@ trait VerilogBase extends VhdlVerilogBase{
     case `TypeEnum` => e match {
       case e : EnumEncoded => emitEnumType(e.getDefinition, e.getEncoding)
     }
+    case `TypeStruct` => emitStructType(e.asInstanceOf[SpinalStruct])
   }
 
   def emitDirection(baseType: BaseType) = baseType.dir match {

--- a/core/src/main/scala/spinal/core/internals/VhdlBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VhdlBase.scala
@@ -78,12 +78,17 @@ trait VhdlBase extends VhdlVerilogBase{
       return enum.getName() + "_" + encoding.getName() + "_type"
   }
 
+  def emitStructType(struct: SpinalStruct): String = {
+    return struct.getTypeString
+  }
+
   def emitDataType(node: Expression, constrained: Boolean = true) = node match {
     case bool: Bool => "std_logic"
     case uint: UInt => s"unsigned${if (constrained) emitRange(uint) else ""}"
     case sint: SInt => s"signed${if (constrained) emitRange(sint) else ""}"
     case bits: Bits => s"std_logic_vector${if (constrained) emitRange(bits) else ""}"
     case enum: SpinalEnumCraft[_] => emitEnumType(enum)
+    case struct: SpinalStruct => emitStructType(struct)
   }
 
   def emitDirection(baseType: BaseType) = baseType.dir match {


### PR DESCRIPTION
Add SystemVerilog Struct and VHDL Record under a unified SpinalStruct datatype.

Current state is a hack to get some limited record support in VHDL. The plan is to integrate changes deeper in the statement and expression logic.

This is not meant to advocate using records and structs over bundles but to provide support for blackboxes which do use records or structs.