### PR TITLE
verilog blackbox generic parameter BigInt support

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -248,6 +248,7 @@ class ComponentEmitterVerilog(
               case (name: String, i: Int)       => logics ++= s"    .${name}($i),\n"
               case (name: String, d: Double)    => logics ++= s"    .${name}($d),\n"
               case (name: String, b: Boolean)   => logics ++= s"    .${name}(${if(b) "1'b1" else "1'b0"}),\n"
+              case (name: String, b: BigInt)    => logics ++= s"    .${name}(${b.toString(16).size*4}'h${b.toString(16)}),\n"
               case _                            => SpinalError(s"The generic type ${"\""}${e._1} - ${e._2}${"\""} of the blackbox ${"\""}${bb.definitionName}${"\""} is not supported in Verilog")
             }
           }


### PR DESCRIPTION
@Dolu1990 verilog could suport bigInt like  with format as `65'h1ffff_ffff_ffff_ffff`, so add BigInt support 
```scala
  val generic = new Generic{
    val PHV_1B_NUM = c.phvc.cB1Num
    val TEST  = BigInt("ffff1234ff",16)
  }
```

```verilog
  mybb #(
    .PHV_1B_NUM(64),
   ...
    .TEST(40'hffff1234ff) 
  )  uutmybb (   
```