### PR TITLE
add altera virtual-jtag elements

### DIFF
--- a/lib/src/main/scala/spinal/lib/blackbox/altera/vjtag.scala
+++ b/lib/src/main/scala/spinal/lib/blackbox/altera/vjtag.scala
@@ -1,0 +1,29 @@
+package spinal.lib.blackbox.altera
+
+import spinal.core._
+import spinal.lib.com.jtag.JtagTapInstructionCtrl
+
+
+case class VJTAG() extends BlackBox{
+ 
+
+  val virtual_state_cdr  = out Bool()
+  val virtual_state_sdr  = out Bool()
+  val tck  = out Bool()
+  val tdi  = out Bool()
+  val virtual_state_udr  = out Bool()
+  val tdo  = in Bool()
+
+  def toJtagTapInstructionCtrl() = {
+    val i = JtagTapInstructionCtrl()
+    i.enable := True
+    i.tdi     <> tdi
+    i.capture <> virtual_state_cdr
+    i.shift   <> virtual_state_sdr
+    i.update  <> virtual_state_udr
+    i.tdo     <> tdo
+    i.reset := False
+    i
+  }
+}
+

--- a/lib/src/main/scala/spinal/lib/com/jtag/altera/VJtag2BmbMaster.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/altera/VJtag2BmbMaster.scala
@@ -1,0 +1,36 @@
+package spinal.lib.com.jtag.altera
+
+import spinal.core._
+import spinal.lib.blackbox.altera.VJTAG
+import spinal.lib.bus.bmb.{Bmb, BmbInterconnectGenerator}
+import spinal.lib.generator._
+import spinal.lib.master
+import spinal.lib.system.debugger.{JtagBridgeNoTap, SystemDebugger, SystemDebuggerConfig}
+
+case class VJtag2BmbMaster() extends Component{
+  val jtagConfig = SystemDebuggerConfig()
+
+  val io = new Bundle{
+    val bmb = master(Bmb(jtagConfig.getBmbParameter))
+  }
+
+  val vjtag = VJTAG()
+  val jtagClockDomain = ClockDomain(vjtag.tck)
+
+  val jtagBridge = new JtagBridgeNoTap(jtagConfig, jtagClockDomain)
+  jtagBridge.io.ctrl << vjtag.toJtagTapInstructionCtrl()
+
+  val debugger = new SystemDebugger(jtagConfig)
+  debugger.io.remote <> jtagBridge.io.remote
+
+  io.bmb << debugger.io.mem.toBmb()
+}
+
+case class VJtag2BmbMasterGenerator()(implicit interconnect : BmbInterconnectGenerator) extends Generator{
+  val bmb = produce(logic.io.bmb)
+  val logic = add task VJtag2BmbMaster()
+  interconnect.addMaster(
+    accessRequirements = SystemDebuggerConfig().getBmbParameter,
+    bus = bmb
+  )
+}


### PR DESCRIPTION
Hello Charles,
this pull request adds the equivalent of the xilinx BSCANE2 element for the virtual jtag element from altera.
You can have a look at https://github.com/michg/pyocdriscv32 at the saxon target.
Regards,
Michael
