### PR TITLE
Fix typo and extend argument range of riscv core

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -2126,7 +2126,7 @@ object BitsLiteral {
     val minimalWidth   = Math.max(poisonBitCount,valueBitCount)
     var bitCount       = specifiedBitCount
 
-    if (value < 0) throw new Exception("literal value is negative and can be represented")
+    if (value < 0) throw new Exception("literal value is negative and cannot be represented")
 
     if (bitCount != -1) {
       if (minimalWidth > bitCount) throw new Exception(s"literal 0x${value.toString(16)} can't fit in Bits($specifiedBitCount bits)")
@@ -2167,7 +2167,7 @@ object UIntLiteral {
     var bitCount       = specifiedBitCount
 
     if (value < 0)
-      throw new Exception("literal value is negative and can be represented")
+      throw new Exception("literal value is negative and cannot be represented")
 
     if (bitCount != -1) {
       if (minimalWidth > bitCount) throw new Exception(s"literal 0x${value.toString(16)} can't fit in UInt($specifiedBitCount bits)")

--- a/lib/src/main/scala/spinal/lib/cpu/riscv/impl/RiscvCore.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/impl/RiscvCore.scala
@@ -33,7 +33,7 @@ object cmdStream_rspFlow extends InstructionBusKind with DataBusKind
 
 case class RiscvCoreConfig(val pcWidth : Int = 32,
                            val addrWidth : Int = 32,
-                           val startAddress : Int = 0,
+                           val startAddress : BigInt = 0,
                            val bypassExecute0 : Boolean = true,
                            val bypassExecute1 : Boolean = true,
                            val bypassWriteBack : Boolean = true,


### PR DESCRIPTION
I made two small improvements:

1. Fixed typo: can -> cannot
2. Use BigInt for startAddress