### PR TITLE
Fix signal names when wrapping suffixed sub inputs

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -96,7 +96,13 @@ class ComponentEmitterVerilog(
       declarations ++= emitBaseTypeWrap(io, name)
     } else {
       wrapSubInput(io.parent.asInstanceOf[BaseType])
-      name = referencesOverrides(io.parent) + "." + io.getPartialName()
+      var parentName: String = ""
+      referencesOverrides(io.parent) match {
+        case s: String => parentName = s
+        case n: Nameable => parentName = n.getNameElseThrow
+        case _ => throw new Exception(s"Could not determine name of ${io}")
+      }
+      name = parentName + "." + io.getPartialName()
     }
     referencesOverrides(io) = name
   }

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -114,7 +114,13 @@ class ComponentEmitterVhdl(
       declarations ++= s"  signal $name : ${emitDataType(io)};\n"
     } else {
       wrapSubInput(io.parent.asInstanceOf[BaseType])
-      name = referencesOverrides(io.parent) + "." + io.getPartialName()
+      var parentName: String = ""
+      referencesOverrides(io.parent) match {
+        case s: String => parentName = s
+        case n: Nameable => parentName = n.getNameElseThrow
+        case _ => throw new Exception(s"Could not determine name of ${io}")
+      }
+      name = parentName + "." + io.getPartialName()
     }
     referencesOverrides(io) = name
   }


### PR DESCRIPTION
Small bug fix, I missed wrapped suffixed (structs) subcomponent inputs during my initial development.