### PR TITLE
Add writeByteEnable to BusSlaveFactory and support unaligned access in read/writeMultiWord for AXI4

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/avalon/AvalonMMSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/AvalonMMSlaveFactory.scala
@@ -39,8 +39,10 @@ class AvalonMMSlaveFactory(bus: AvalonMM) extends BusSlaveFactoryDelayed{
   readAtCmd.valid := doRead
   readAtCmd.payload := 0
 
-  def readAddress() : UInt = bus.address
-  def writeAddress() : UInt = bus.address
+  override def readAddress() : UInt = bus.address
+  override def writeAddress() : UInt = bus.address
+
+  override def writeByteEnable(): Bits = bus.byteEnable
 
   override def readHalt(): Unit = bus.waitRequestn := False
   override def writeHalt(): Unit = bus.waitRequestn := False

--- a/lib/src/main/scala/spinal/lib/bus/bmb/BmbSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bmb/BmbSlaveFactory.scala
@@ -33,8 +33,10 @@ case class BmbSlaveFactory(bus: Bmb) extends BusSlaveFactoryDelayed{
   rsp.context := bus.cmd.context
   rsp.source := bus.cmd.source
 
-  def readAddress() : UInt = bus.cmd.address
-  def writeAddress() : UInt = bus.cmd.address
+  override def readAddress() : UInt = bus.cmd.address
+  override def writeAddress() : UInt = bus.cmd.address
+
+  override def writeByteEnable(): Bits = bus.cmd.mask
 
   override def readHalt(): Unit = readHaltTrigger := True
   override def writeHalt(): Unit = writeHaltTrigger := True


### PR DESCRIPTION
Currently, BusSlaveFactory does not support masked write. This pr adds preliminary support to it. I am working on a Axi4BusSlaveFactory.

By the way, the code style in the repo is pretty inconsistent... I wish they are described and enforced by scalafmt.conf.