### PR TITLE
Initial support for build SpinalHDL on AArch64

### DIFF
--- a/sim/src/main/resources/SharedMemIface.cpp
+++ b/sim/src/main/resources/SharedMemIface.cpp
@@ -234,8 +234,8 @@ void SharedMemIface::check_ready(){
 
         #ifndef NO_SPINLOCK_YIELD_OPTIMIZATION
         if (spin_count < SPINLOCK_MAX_ACQUIRE_SPINS) {
-            _mm_pause();
-        } else {
+            _spin_pause();
+	} else {
             std::this_thread::yield();
             spin_count = 0;
         }

--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -415,7 +415,8 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
       jdk + "/include"
     }
 
-    val flags   = if(isMac) List("-dynamiclib") else List("-fPIC", "-m64", "-shared", "-Wno-attributes")
+    val arch = System.getProperty("os.arch")
+    val flags   = if(isMac) List("-dynamiclib") else (if(arch == "arm" || arch == "aarch64") List("-fPIC", "-shared", "-Wno-attributes") else List("-fPIC", "-m64", "-shared", "-Wno-attributes"))
 
     config.rtlSourcesPaths.filter(s => s.endsWith(".bin") || s.endsWith(".mem")).foreach(path =>  FileUtils.copyFileToDirectory(new File(path), new File(s"./")))
 


### PR DESCRIPTION
      Recently, I tried to build and test SpinalHDL on my Raspberry Pi 4, but unfortunately it only focus on X64 and seems nobody run it on ARM before, so I checked the failures that block SpinalHDL running on ARM and prepared this patch, now SpinalHDL  could be successfully built on my Raspberry Pi, and passed most of the tests except for some cases like Axi4CrossbarTester and StreamTester2 -- it consumed most of the memory on my Raspberry Pi which has 8GB LPDDR4 totally and make at least 3 out of the total 4 cores in 100% load, running for nearly 15 hours, my Raspberry Pi is becoming very hot:), but the final test result still could not be got.
      I guess this patch should be OK, but some tests may be time out due to the poor performance of Raspberry Pi when comparing with a PC or Server, so the simulation speed is not affordable, I would appreciated it if anyone can help to test this patch on an ARM PC or Server with AArch64 processor, e.g.,  the AWS Graviton2.
      By the way, sbt installed on my Raspberry Pi is the latest version 1.5.1.