### PR TITLE
one line bug fix for AxiMemorySim

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/AxiMemorySim.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/AxiMemorySim.scala
@@ -324,7 +324,7 @@ case class AxiMemorySim(axi : Axi4, clockDomain : ClockDomain, config : AxiMemor
             if(i == job.burstLength)
               r.payload.last #= true
             r.payload.data #= memory.readBigInt(job.address + i * busWordWidth, busWordWidth)
-            clockDomain.waitSampling()
+            clockDomain.waitSamplingWhere(r.ready.toBoolean)
             i = i + 1
           }
         }


### PR DESCRIPTION
The bug is that when AxiMemorySim handing read channel, AXI slave should wait for the RREADY signal from AXI master before sending next data.