### PR TITLE
fix: globalPrefix should bypass for BlackBox

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -909,7 +909,12 @@ class PhaseNameNodesByReflection(pc: PhaseContext) extends PhaseMisc{
     for (c <- sortedComponents) {
       if(c != topLevel) {
         if (c.definitionName == null) {
-          c.definitionName = privateNamespaceName + classNameOf(c)
+          val pre = c match {
+            case t: BlackBox => ""
+            case _ => config.globalPrefix
+          }
+          val privateNsN = (if(config.privateNamespace) topLevel.definitionName + "_" else "")
+          c.definitionName = pre + privateNsN + classNameOf(c)
         }
       }
       if (c.definitionName == "") {

--- a/core/src/test/scala/spinal/core/Play.scala
+++ b/core/src/test/scala/spinal/core/Play.scala
@@ -126,6 +126,41 @@ object Play43 extends App{
   }
 }
 
+object playBB extends App{
+  class MyBlackBox extends BlackBox {
+    val io = new Bundle {
+      val din = in Bits (8 bit)
+      val dout = out Bits (8 bit)
+    }
+
+    io.dout := io.din
+  }
+
+  class Bypass extends Component {
+    val io = new Bundle {
+      val din = in Bits (8 bit)
+      val dout = out Bits (8 bit)
+    }
+
+    io.dout := io.din
+  }
+
+  class Top extends Component{
+    val io = new Bundle{
+      val din = in Bits(8 bit)
+      val dout = out Bits(8 bit)
+    }
+
+    val uut1 = new MyBlackBox
+    val uut2 = new Bypass
+
+    uut1.io.din := io.din
+    uut2.io.din := io.din
+
+    io.dout := uut1.io.dout | uut2.io.dout
+  }
+  SpinalConfig(globalPrefix = "jj_").generateVerilog(new Top)
+}
 
 //object Play2 extends App{
 //  class Toplevel extends Component{


### PR DESCRIPTION
hi @Dolu1990 :
the globalPrefix should not valid for BlackBox, so here is a fix.

Verilog Example:
```verilog
module jj_Top (
  input      [7:0]    io_din,
  output     [7:0]    io_dout
);
  wire       [7:0]    uut1_io_dout;
  wire       [7:0]    uut2_io_dout;

  MyBlackBox uut1 ( // !!! black box need keep raw name , not jj_MyBlackBox
    .io_din     (io_din[7:0]        ), //i
    .io_dout    (uut1_io_dout[7:0]  )  //o
  );
  jj_Bypass uut2 (
    .io_din     (io_din[7:0]        ), //i
    .io_dout    (uut2_io_dout[7:0]  )  //o
  );
  assign io_dout = (uut1_io_dout | uut2_io_dout);

endmodule

module jj_Bypass (
  input      [7:0]    io_din,
  output     [7:0]    io_dout
);

  assign io_dout = io_din;

endmodule 
```