### PR TITLE
Add handling of atrributes with integer argument

### DIFF
--- a/core/src/main/scala/spinal/core/Attribute.scala
+++ b/core/src/main/scala/spinal/core/Attribute.scala
@@ -52,6 +52,13 @@ class AttributeString(name: String, val value: String, kind: AttributeKind = DEF
 }
 
 
+class AttributeInteger(name: String, val value: Int, kind: AttributeKind = DEFAULT_ATTRIBUTE) extends Attribute {
+  override def getName: String = name
+  override def sameType(that: Attribute): Boolean = that.isInstanceOf[AttributeInteger]
+  override def attributeKind() = kind
+}
+
+
 class AttributeFlag(name: String, kind: AttributeKind = DEFAULT_ATTRIBUTE) extends Attribute {
   override def getName: String = name
   override def sameType(that: Attribute): Boolean = that.isInstanceOf[AttributeFlag]

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -695,6 +695,7 @@ trait SpinalTagReady {
   def addAttribute(attribute: Attribute): this.type = addTag(attribute)
   def addAttribute(name: String): this.type = addAttribute(new AttributeFlag(name))
   def addAttribute(name: String, value: String): this.type = addAttribute(new AttributeString(name, value))
+  def addAttribute(name: String, value: Int): this.type = addAttribute(new AttributeInteger(name, value))
 
   def onEachAttributes(doIt: (Attribute) => Unit): Unit = {
     if(_spinalTags == null) return

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -788,8 +788,9 @@ class ComponentEmitterVhdl(
 
     for (attribute <- map.values) {
       val typeString = attribute match {
-        case _: AttributeString => "string"
-        case _: AttributeFlag   => "boolean"
+        case _: AttributeString  => "string"
+        case _: AttributeInteger => "integer"
+        case _: AttributeFlag    => "boolean"
       }
 
       declarations ++= s"  attribute ${attribute.getName} : $typeString;\n"
@@ -1085,8 +1086,9 @@ class ComponentEmitterVhdl(
   def emitAttributes(node: String, attributes: Iterable[Attribute], vhdlType: String, ret: StringBuilder, postfix: String): Unit = {
     for (attribute <- attributes){
       val value = attribute match {
-        case attribute: AttributeString => "\"" + attribute.value + "\""
-        case attribute: AttributeFlag   => "true"
+        case attribute: AttributeString  => "\"" + attribute.value + "\""
+        case attribute: AttributeInteger => attribute.value.toString
+        case attribute: AttributeFlag    => "true"
       }
 
       ret ++= s"  attribute ${attribute.getName} of $node$postfix : $vhdlType is $value;\n"

--- a/core/src/main/scala/spinal/core/internals/VerilogBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VerilogBase.scala
@@ -82,6 +82,7 @@ trait VerilogBase extends VhdlVerilogBase{
   def emitSyntaxAttributes(attributes: Iterable[Attribute]): String = {
     val values = for (attribute <- attributes if attribute.attributeKind() == DEFAULT_ATTRIBUTE) yield attribute match {
       case attribute: AttributeString => attribute.getName + " = \"" + attribute.value + "\""
+      case attribute: AttributeInteger => attribute.getName + " = " + attribute.value.toString
       case attribute: AttributeFlag => attribute.getName
     }
 
@@ -93,6 +94,7 @@ trait VerilogBase extends VhdlVerilogBase{
   def emitCommentAttributes(attributes: Iterable[Attribute]): String = {
     val values = for (attribute <- attributes if attribute.attributeKind() == COMMENT_ATTRIBUTE) yield attribute match {
       case attribute: AttributeString => attribute.getName + " = \"" + attribute.value + "\""
+      case attribute: AttributeInteger => attribute.getName + " = " + attribute.value.toString
       case attribute: AttributeFlag => attribute.getName
     }
 


### PR DESCRIPTION
Some attributes require an integer argument value (eg Vivado CASCADE_HEIGHT; Quartus max_fan), allow SpinalHDL to handle these attributes.