### PR TITLE
Allow Verilog emitter to render MaskedLitterals as case items into a pure case statement

### DIFF
--- a/core/src/main/scala/spinal/core/MaskedLiteral.scala
+++ b/core/src/main/scala/spinal/core/MaskedLiteral.scala
@@ -72,8 +72,7 @@ class MaskedLiteral(val value: BigInt, val careAbout: BigInt, val width: Int){
 
   def =/=(that: BitVector): Bool = !(this === that)
 
-  override def toString: String = {
-
+  def getBitsString(width: Int, dontCareSymbol : Char) : String = {
     def bigInt2ListBoolean(value: BigInt, size: BitCount): List[Boolean] = {
       def bigInt2ListBool(that: BigInt): List[Boolean] = {
         if(that == 0)  Nil
@@ -89,17 +88,17 @@ class MaskedLiteral(val value: BigInt, val careAbout: BigInt, val width: Int){
       else                      l ::: List.fill(size - l.length)(false)
     }
 
-    val valueList = bigInt2ListBoolean(this.value, this.width bits)
-    val careList  = bigInt2ListBoolean(this.careAbout, this.width bits)
+    val valueList = bigInt2ListBoolean(this.value, width bits)
+    val careList  = bigInt2ListBoolean(this.careAbout, width bits)
 
-    val maskStr = careList.zip(valueList).map {
-      case (false, _)    => "-"
+    careList.zip(valueList).map {
+      case (false, _)    => dontCareSymbol
       case (true, true)  => "1"
       case (true, false) => "0"
     }.reverse.mkString("")
-
-    "M\"" + maskStr + "\""
   }
+
+  override def toString: String = "M\"" + getBitsString(this.width, '-') + "\""
 }
 
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -627,17 +627,17 @@ class ComponentEmitterVerilog(
             lastWhen = treeStatement
             statementIndex = emitLeafStatements(statements,statementIndex, scopePtr, assignmentKind,b, tab + "  ")
           case switchStatement : SwitchStatement =>
-            def checkPure(o : Any): Boolean = o match {
+            def checkPure(o : Expression): Boolean = o match {
               case l: Literal => true
               case k: SwitchStatementKeyBool => k.key != null
               case _ => false
             }
-            def checkMaskedLiteral(o : Any): Boolean = o match {
+            def checkMaskedLiteral(o : Expression): Boolean = o match {
               case k: SwitchStatementKeyBool => k.key != null
               case _ => false
             }
-            val hasMaskedLiterals = switchStatement.elements.exists(_.keys.exists((k)=>checkMaskedLiteral(k)))
-            val isPure = switchStatement.elements.forall(_.keys.forall(checkPure(_)))
+            val hasMaskedLiterals = switchStatement.elements.exists(_.keys.exists(checkMaskedLiteral))
+            val isPure = switchStatement.elements.forall(_.keys.forall(checkPure))
 
             //Generate the code
             def findSwitchScopeRec(scope: ScopeStatement): ScopeStatement = scope.parentStatement match {

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -2108,15 +2108,17 @@ class RangedAssignmentFloating() extends BitVectorAssignmentExpression with Widt
 
 
 object SwitchStatementKeyBool{
-  def apply(cond: Expression): SwitchStatementKeyBool = {
+  def apply(cond: Expression, key : MaskedLiteral=null): SwitchStatementKeyBool = {
     val ret  = new SwitchStatementKeyBool
     ret.cond = cond
+    ret.key = key
     ret
   }
 }
 
 class SwitchStatementKeyBool extends Expression {
   var cond : Expression = null
+  var key : MaskedLiteral = null
 
   override def opName: String = "is(b)"
   override def getTypeObject: Any = TypeBool

--- a/core/src/main/scala/spinal/core/when.scala
+++ b/core/src/main/scala/spinal/core/when.scala
@@ -207,9 +207,9 @@ object is {
         }
       case value: SpinalEnumElement[_] => onBaseType(value())
       case key: MaskedLiteral          => switchValue match {
-        case switchValue: Bits => switchElement.keys += SwitchStatementKeyBool(switchValue === key)
-        case switchValue: UInt => switchElement.keys += SwitchStatementKeyBool(switchValue === key)
-        case switchValue: SInt => switchElement.keys += SwitchStatementKeyBool(switchValue === key)
+        case switchValue: Bits => switchElement.keys += SwitchStatementKeyBool(switchValue === key, key)
+        case switchValue: UInt => switchElement.keys += SwitchStatementKeyBool(switchValue === key, key)
+        case switchValue: SInt => switchElement.keys += SwitchStatementKeyBool(switchValue === key, key)
         case _                 => SpinalError("The switch is not a Bits, UInt or SInt")
       }
       //    }


### PR DESCRIPTION
This change allow the Verilog emitter to render:
```scala
switch(cond1 ## cond2 ## cond3)
  is(M"1--") { }
}
```
more idiomatically, with casez & ? for don't care bits:
```
casez(...)
  3'b1??: ...
endcase
```

As opposed to the chain of if/else that it would currently generate