### PR TITLE
Fixed sbt clean publishLocal issue on clean dev branch + Naming Vector Indexing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val all = (project in file("."))
 
 import sys.process._
 def gitHash(dir: File) = (try {
-  s"git -C ${dir.toString} rev-parse HEAD".!!
+  s"git -c ${dir.toString} rev-parse HEAD".!!
 } catch{
   case e : java.io.IOException => "???"
 }).linesIterator.next()

--- a/core/src/main/scala/spinal/core/Vec.scala
+++ b/core/src/main/scala/spinal/core/Vec.scala
@@ -104,7 +104,9 @@ class VecAccessAssign[T <: Data](enables: Seq[Bool], tos: Seq[BaseType], vec: Ve
 class Vec[T <: Data](val dataType: HardType[T], val vec: Vector[T]) extends MultiData with collection.IndexedSeq[T] {
   for(i <- elements.indices){
     val e = elements(i)._2
-    if(OwnableRef.proposal(e, this)) e.setPartialName(i.toString, Nameable.DATAMODEL_WEAK)
+    if(OwnableRef.proposal(e, this)) {
+      e.setPartialName(i.toString, Nameable.DATAMODEL_WEAK)
+    }
   }
 
   def range = vec.indices
@@ -170,15 +172,39 @@ class Vec[T <: Data](val dataType: HardType[T], val vec: Vector[T]) extends Mult
     }
 
 
+    val dimPattern = "(.*)_([0-9]+)dim"r
+    val (vecName, dimId) = this.getName() match {
+      case dimPattern(vecName, dimId) => (vecName, (dimId.toInt + 1).toString)
+      case x:String => (x, "0")
+      case _ => 
+    }
+
     val ret = dataType()
+    ret match {
+      case ret: Vec[_] => {
+        ret.setWeakName(s"${vecName}_${dimId}dim")
+      }
+      case _ => 
+    }
     val retFlatten = ret.flatten
     for(i <- 0 until vecTransposed.length){
       val target = retFlatten(i)
+      target.setCompositeName(this, s"mux${i}", true)
       target match {
         case bv: BitVector => bv.unfixWidth()
         case _             =>
       }
-      target.assignFrom(target.newMultiplexer(finalAddress, vecTransposed(i)))
+      //target.assignFrom(target.newMultiplexer(finalAddress, vecTransposed(i)))
+      switch (finalAddress) {
+        for (j <- 0 until vecTransposed(i).length - 1) {
+          is (j) {
+            target.assignFrom(vecTransposed(i)(j))
+          }
+        }
+        default {
+          target.assignFrom(vecTransposed(i)(vecTransposed(i).length - 1))
+        }
+      }
     }
     ret
   }


### PR DESCRIPTION
1. Fixed sbt clean publishLocal issue on clean dev branch
2. Currently it's not possible to name the wire generated from vector indexing `myVec(myUInt)` because of the verilog backend limitation. The generated code from vector indexing increase debug specially when the vector is multi dimensional. This implementation provides a clean way to generate named wires from vector indexing.

# Example Code:
```
import spinal.core._
import spinal.lib._

class NameVecIndexing extends Component with DscBase {
  val io = new Bundle {
    val qpsize = in  UInt(32 bits)
    val addr1 = in  UInt(32 bits)
    val addr2 = in  UInt(32 bits)
    val addr3 = in  UInt(32 bits)
    val qlevel = out (UInt(32 bits))
  }
  noIoPrefix()

  val qp_f = Vec(Vec(Vec(UInt(32 bits), 5), 4), 3)

  for (i <- 0 until 3) (
    for (j <- 0 until 4) (
      for (k <- 0 until 5) {
        qp_f(i)(j)(k) := i + j + k
      }
    )
  )

  io.addr1.addTag(tagAutoResize)
  io.addr2.addTag(tagAutoResize)
  io.addr3.addTag(tagAutoResize)
  io.qlevel := qp_f(io.addr1(8 downto 4).addTag(tagAutoResize))(io.addr2)(io.addr3)
}
```

# Generated verilog (Before commit):
```
module NameVecIndexing (
  input      [31:0]   qpsize,
  input      [31:0]   addr1,
  input      [31:0]   addr2,
  input      [31:0]   addr3,
  output     [31:0]   qlevel
);
  reg        [31:0]   _zz_3;
  reg        [31:0]   _zz_4;
  reg        [31:0]   _zz_5;
  reg        [31:0]   _zz_6;
  reg        [31:0]   _zz_7;
  reg        [31:0]   _zz_8;
  reg        [31:0]   _zz_9;
  reg        [31:0]   _zz_10;
  reg        [31:0]   _zz_11;
  reg        [31:0]   _zz_12;
  reg        [31:0]   _zz_13;
  reg        [31:0]   _zz_14;
  reg        [31:0]   _zz_15;
  reg        [31:0]   _zz_16;
  reg        [31:0]   _zz_17;
  reg        [31:0]   _zz_18;
  reg        [31:0]   _zz_19;
  reg        [31:0]   _zz_20;
  reg        [31:0]   _zz_21;
  reg        [31:0]   _zz_22;
  reg        [31:0]   _zz_23;
  reg        [31:0]   _zz_24;
  reg        [31:0]   _zz_25;
  reg        [31:0]   _zz_26;
  reg        [31:0]   _zz_27;
  reg        [31:0]   _zz_28;
  wire       [4:0]    _zz_29;
  wire       [2:0]    _zz_30;
  wire       [31:0]   qp_f_0_0_0;
  wire       [31:0]   qp_f_0_0_1;
  wire       [31:0]   qp_f_0_0_2;
  wire       [31:0]   qp_f_0_0_3;
  wire       [31:0]   qp_f_0_0_4;
  wire       [31:0]   qp_f_0_1_0;
  wire       [31:0]   qp_f_0_1_1;
  wire       [31:0]   qp_f_0_1_2;
  wire       [31:0]   qp_f_0_1_3;
  wire       [31:0]   qp_f_0_1_4;
  wire       [31:0]   qp_f_0_2_0;
  wire       [31:0]   qp_f_0_2_1;
  wire       [31:0]   qp_f_0_2_2;
  wire       [31:0]   qp_f_0_2_3;
  wire       [31:0]   qp_f_0_2_4;
  wire       [31:0]   qp_f_0_3_0;
  wire       [31:0]   qp_f_0_3_1;
  wire       [31:0]   qp_f_0_3_2;
  wire       [31:0]   qp_f_0_3_3;
  wire       [31:0]   qp_f_0_3_4;
  wire       [31:0]   qp_f_1_0_0;
  wire       [31:0]   qp_f_1_0_1;
  wire       [31:0]   qp_f_1_0_2;
  wire       [31:0]   qp_f_1_0_3;
  wire       [31:0]   qp_f_1_0_4;
  wire       [31:0]   qp_f_1_1_0;
  wire       [31:0]   qp_f_1_1_1;
  wire       [31:0]   qp_f_1_1_2;
  wire       [31:0]   qp_f_1_1_3;
  wire       [31:0]   qp_f_1_1_4;
  wire       [31:0]   qp_f_1_2_0;
  wire       [31:0]   qp_f_1_2_1;
  wire       [31:0]   qp_f_1_2_2;
  wire       [31:0]   qp_f_1_2_3;
  wire       [31:0]   qp_f_1_2_4;
  wire       [31:0]   qp_f_1_3_0;
  wire       [31:0]   qp_f_1_3_1;
  wire       [31:0]   qp_f_1_3_2;
  wire       [31:0]   qp_f_1_3_3;
  wire       [31:0]   qp_f_1_3_4;
  wire       [31:0]   qp_f_2_0_0;
  wire       [31:0]   qp_f_2_0_1;
  wire       [31:0]   qp_f_2_0_2;
  wire       [31:0]   qp_f_2_0_3;
  wire       [31:0]   qp_f_2_0_4;
  wire       [31:0]   qp_f_2_1_0;
  wire       [31:0]   qp_f_2_1_1;
  wire       [31:0]   qp_f_2_1_2;
  wire       [31:0]   qp_f_2_1_3;
  wire       [31:0]   qp_f_2_1_4;
  wire       [31:0]   qp_f_2_2_0;
  wire       [31:0]   qp_f_2_2_1;
  wire       [31:0]   qp_f_2_2_2;
  wire       [31:0]   qp_f_2_2_3;
  wire       [31:0]   qp_f_2_2_4;
  wire       [31:0]   qp_f_2_3_0;
  wire       [31:0]   qp_f_2_3_1;
  wire       [31:0]   qp_f_2_3_2;
  wire       [31:0]   qp_f_2_3_3;
  wire       [31:0]   qp_f_2_3_4;
  wire       [1:0]    _zz_1;
  wire       [1:0]    _zz_2;

  assign _zz_29 = addr1[8 : 4];
  assign _zz_30 = addr3[2:0];
  always @(*) begin
    case(_zz_30)
      3'b000 : begin
        _zz_3 = _zz_4;
      end
      3'b001 : begin
        _zz_3 = _zz_5;
      end
      3'b010 : begin
        _zz_3 = _zz_6;
      end
      3'b011 : begin
        _zz_3 = _zz_7;
      end
      default : begin
        _zz_3 = _zz_8;
      end
    endcase
  end

  always @(*) begin
    case(_zz_2)
      2'b00 : begin
        _zz_4 = _zz_9;
        _zz_5 = _zz_13;
        _zz_6 = _zz_17;
        _zz_7 = _zz_21;
        _zz_8 = _zz_25;
      end
      2'b01 : begin
        _zz_4 = _zz_10;
        _zz_5 = _zz_14;
        _zz_6 = _zz_18;
        _zz_7 = _zz_22;
        _zz_8 = _zz_26;
      end
      2'b10 : begin
        _zz_4 = _zz_11;
        _zz_5 = _zz_15;
        _zz_6 = _zz_19;
        _zz_7 = _zz_23;
        _zz_8 = _zz_27;
      end
      default : begin
        _zz_4 = _zz_12;
        _zz_5 = _zz_16;
        _zz_6 = _zz_20;
        _zz_7 = _zz_24;
        _zz_8 = _zz_28;
      end
    endcase
  end

  always @(*) begin
    case(_zz_1)
      2'b00 : begin
        _zz_9 = qp_f_0_0_0;
        _zz_10 = qp_f_0_1_0;
        _zz_11 = qp_f_0_2_0;
        _zz_12 = qp_f_0_3_0;
        _zz_13 = qp_f_0_0_1;
        _zz_14 = qp_f_0_1_1;
        _zz_15 = qp_f_0_2_1;
        _zz_16 = qp_f_0_3_1;
        _zz_17 = qp_f_0_0_2;
        _zz_18 = qp_f_0_1_2;
        _zz_19 = qp_f_0_2_2;
        _zz_20 = qp_f_0_3_2;
        _zz_21 = qp_f_0_0_3;
        _zz_22 = qp_f_0_1_3;
        _zz_23 = qp_f_0_2_3;
        _zz_24 = qp_f_0_3_3;
        _zz_25 = qp_f_0_0_4;
        _zz_26 = qp_f_0_1_4;
        _zz_27 = qp_f_0_2_4;
        _zz_28 = qp_f_0_3_4;
      end
      2'b01 : begin
        _zz_9 = qp_f_1_0_0;
        _zz_10 = qp_f_1_1_0;
        _zz_11 = qp_f_1_2_0;
        _zz_12 = qp_f_1_3_0;
        _zz_13 = qp_f_1_0_1;
        _zz_14 = qp_f_1_1_1;
        _zz_15 = qp_f_1_2_1;
        _zz_16 = qp_f_1_3_1;
        _zz_17 = qp_f_1_0_2;
        _zz_18 = qp_f_1_1_2;
        _zz_19 = qp_f_1_2_2;
        _zz_20 = qp_f_1_3_2;
        _zz_21 = qp_f_1_0_3;
        _zz_22 = qp_f_1_1_3;
        _zz_23 = qp_f_1_2_3;
        _zz_24 = qp_f_1_3_3;
        _zz_25 = qp_f_1_0_4;
        _zz_26 = qp_f_1_1_4;
        _zz_27 = qp_f_1_2_4;
        _zz_28 = qp_f_1_3_4;
      end
      default : begin
        _zz_9 = qp_f_2_0_0;
        _zz_10 = qp_f_2_1_0;
        _zz_11 = qp_f_2_2_0;
        _zz_12 = qp_f_2_3_0;
        _zz_13 = qp_f_2_0_1;
        _zz_14 = qp_f_2_1_1;
        _zz_15 = qp_f_2_2_1;
        _zz_16 = qp_f_2_3_1;
        _zz_17 = qp_f_2_0_2;
        _zz_18 = qp_f_2_1_2;
        _zz_19 = qp_f_2_2_2;
        _zz_20 = qp_f_2_3_2;
        _zz_21 = qp_f_2_0_3;
        _zz_22 = qp_f_2_1_3;
        _zz_23 = qp_f_2_2_3;
        _zz_24 = qp_f_2_3_3;
        _zz_25 = qp_f_2_0_4;
        _zz_26 = qp_f_2_1_4;
        _zz_27 = qp_f_2_2_4;
        _zz_28 = qp_f_2_3_4;
      end
    endcase
  end

  assign qp_f_0_0_0 = 32'h0;
  assign qp_f_0_0_1 = 32'h00000001;
  assign qp_f_0_0_2 = 32'h00000002;
  assign qp_f_0_0_3 = 32'h00000003;
  assign qp_f_0_0_4 = 32'h00000004;
  assign qp_f_0_1_0 = 32'h00000001;
  assign qp_f_0_1_1 = 32'h00000002;
  assign qp_f_0_1_2 = 32'h00000003;
  assign qp_f_0_1_3 = 32'h00000004;
  assign qp_f_0_1_4 = 32'h00000005;
  assign qp_f_0_2_0 = 32'h00000002;
  assign qp_f_0_2_1 = 32'h00000003;
  assign qp_f_0_2_2 = 32'h00000004;
  assign qp_f_0_2_3 = 32'h00000005;
  assign qp_f_0_2_4 = 32'h00000006;
  assign qp_f_0_3_0 = 32'h00000003;
  assign qp_f_0_3_1 = 32'h00000004;
  assign qp_f_0_3_2 = 32'h00000005;
  assign qp_f_0_3_3 = 32'h00000006;
  assign qp_f_0_3_4 = 32'h00000007;
  assign qp_f_1_0_0 = 32'h00000001;
  assign qp_f_1_0_1 = 32'h00000002;
  assign qp_f_1_0_2 = 32'h00000003;
  assign qp_f_1_0_3 = 32'h00000004;
  assign qp_f_1_0_4 = 32'h00000005;
  assign qp_f_1_1_0 = 32'h00000002;
  assign qp_f_1_1_1 = 32'h00000003;
  assign qp_f_1_1_2 = 32'h00000004;
  assign qp_f_1_1_3 = 32'h00000005;
  assign qp_f_1_1_4 = 32'h00000006;
  assign qp_f_1_2_0 = 32'h00000003;
  assign qp_f_1_2_1 = 32'h00000004;
  assign qp_f_1_2_2 = 32'h00000005;
  assign qp_f_1_2_3 = 32'h00000006;
  assign qp_f_1_2_4 = 32'h00000007;
  assign qp_f_1_3_0 = 32'h00000004;
  assign qp_f_1_3_1 = 32'h00000005;
  assign qp_f_1_3_2 = 32'h00000006;
  assign qp_f_1_3_3 = 32'h00000007;
  assign qp_f_1_3_4 = 32'h00000008;
  assign qp_f_2_0_0 = 32'h00000002;
  assign qp_f_2_0_1 = 32'h00000003;
  assign qp_f_2_0_2 = 32'h00000004;
  assign qp_f_2_0_3 = 32'h00000005;
  assign qp_f_2_0_4 = 32'h00000006;
  assign qp_f_2_1_0 = 32'h00000003;
  assign qp_f_2_1_1 = 32'h00000004;
  assign qp_f_2_1_2 = 32'h00000005;
  assign qp_f_2_1_3 = 32'h00000006;
  assign qp_f_2_1_4 = 32'h00000007;
  assign qp_f_2_2_0 = 32'h00000004;
  assign qp_f_2_2_1 = 32'h00000005;
  assign qp_f_2_2_2 = 32'h00000006;
  assign qp_f_2_2_3 = 32'h00000007;
  assign qp_f_2_2_4 = 32'h00000008;
  assign qp_f_2_3_0 = 32'h00000005;
  assign qp_f_2_3_1 = 32'h00000006;
  assign qp_f_2_3_2 = 32'h00000007;
  assign qp_f_2_3_3 = 32'h00000008;
  assign qp_f_2_3_4 = 32'h00000009;
  assign _zz_1 = _zz_29[1:0];
  assign _zz_2 = addr2[1:0];
  assign qlevel = _zz_3;

endmodule

```

# Generated Verilog (After Commit)
```
module NameVecIndexing (
  input      [31:0]   qpsize,
  input      [31:0]   addr1,
  input      [31:0]   addr2,
  input      [31:0]   addr3,
  output     [31:0]   qlevel
);
  wire       [2:0]    _zz_3;
  wire       [4:0]    _zz_4;
  wire       [31:0]   qp_f_0_0_0;
  wire       [31:0]   qp_f_0_0_1;
  wire       [31:0]   qp_f_0_0_2;
  wire       [31:0]   qp_f_0_0_3;
  wire       [31:0]   qp_f_0_0_4;
  wire       [31:0]   qp_f_0_1_0;
  wire       [31:0]   qp_f_0_1_1;
  wire       [31:0]   qp_f_0_1_2;
  wire       [31:0]   qp_f_0_1_3;
  wire       [31:0]   qp_f_0_1_4;
  wire       [31:0]   qp_f_0_2_0;
  wire       [31:0]   qp_f_0_2_1;
  wire       [31:0]   qp_f_0_2_2;
  wire       [31:0]   qp_f_0_2_3;
  wire       [31:0]   qp_f_0_2_4;
  wire       [31:0]   qp_f_0_3_0;
  wire       [31:0]   qp_f_0_3_1;
  wire       [31:0]   qp_f_0_3_2;
  wire       [31:0]   qp_f_0_3_3;
  wire       [31:0]   qp_f_0_3_4;
  wire       [31:0]   qp_f_1_0_0;
  wire       [31:0]   qp_f_1_0_1;
  wire       [31:0]   qp_f_1_0_2;
  wire       [31:0]   qp_f_1_0_3;
  wire       [31:0]   qp_f_1_0_4;
  wire       [31:0]   qp_f_1_1_0;
  wire       [31:0]   qp_f_1_1_1;
  wire       [31:0]   qp_f_1_1_2;
  wire       [31:0]   qp_f_1_1_3;
  wire       [31:0]   qp_f_1_1_4;
  wire       [31:0]   qp_f_1_2_0;
  wire       [31:0]   qp_f_1_2_1;
  wire       [31:0]   qp_f_1_2_2;
  wire       [31:0]   qp_f_1_2_3;
  wire       [31:0]   qp_f_1_2_4;
  wire       [31:0]   qp_f_1_3_0;
  wire       [31:0]   qp_f_1_3_1;
  wire       [31:0]   qp_f_1_3_2;
  wire       [31:0]   qp_f_1_3_3;
  wire       [31:0]   qp_f_1_3_4;
  wire       [31:0]   qp_f_2_0_0;
  wire       [31:0]   qp_f_2_0_1;
  wire       [31:0]   qp_f_2_0_2;
  wire       [31:0]   qp_f_2_0_3;
  wire       [31:0]   qp_f_2_0_4;
  wire       [31:0]   qp_f_2_1_0;
  wire       [31:0]   qp_f_2_1_1;
  wire       [31:0]   qp_f_2_1_2;
  wire       [31:0]   qp_f_2_1_3;
  wire       [31:0]   qp_f_2_1_4;
  wire       [31:0]   qp_f_2_2_0;
  wire       [31:0]   qp_f_2_2_1;
  wire       [31:0]   qp_f_2_2_2;
  wire       [31:0]   qp_f_2_2_3;
  wire       [31:0]   qp_f_2_2_4;
  wire       [31:0]   qp_f_2_3_0;
  wire       [31:0]   qp_f_2_3_1;
  wire       [31:0]   qp_f_2_3_2;
  wire       [31:0]   qp_f_2_3_3;
  wire       [31:0]   qp_f_2_3_4;
  wire       [1:0]    _zz_1;
  reg        [31:0]   qp_f_0dim_0_0;
  reg        [31:0]   qp_f_0dim_0_1;
  reg        [31:0]   qp_f_0dim_0_2;
  reg        [31:0]   qp_f_0dim_0_3;
  reg        [31:0]   qp_f_0dim_0_4;
  reg        [31:0]   qp_f_0dim_1_0;
  reg        [31:0]   qp_f_0dim_1_1;
  reg        [31:0]   qp_f_0dim_1_2;
  reg        [31:0]   qp_f_0dim_1_3;
  reg        [31:0]   qp_f_0dim_1_4;
  reg        [31:0]   qp_f_0dim_2_0;
  reg        [31:0]   qp_f_0dim_2_1;
  reg        [31:0]   qp_f_0dim_2_2;
  reg        [31:0]   qp_f_0dim_2_3;
  reg        [31:0]   qp_f_0dim_2_4;
  reg        [31:0]   qp_f_0dim_3_0;
  reg        [31:0]   qp_f_0dim_3_1;
  reg        [31:0]   qp_f_0dim_3_2;
  reg        [31:0]   qp_f_0dim_3_3;
  reg        [31:0]   qp_f_0dim_3_4;
  wire       [1:0]    _zz_2;
  reg        [31:0]   qp_f_1dim_0;
  reg        [31:0]   qp_f_1dim_1;
  reg        [31:0]   qp_f_1dim_2;
  reg        [31:0]   qp_f_1dim_3;
  reg        [31:0]   qp_f_1dim_4;
  reg        [31:0]   qp_f_1dim_mux0;

  assign _zz_3 = addr3[2:0];
  assign _zz_4 = addr1[8 : 4];
  assign qp_f_0_0_0 = 32'h0;
  assign qp_f_0_0_1 = 32'h00000001;
  assign qp_f_0_0_2 = 32'h00000002;
  assign qp_f_0_0_3 = 32'h00000003;
  assign qp_f_0_0_4 = 32'h00000004;
  assign qp_f_0_1_0 = 32'h00000001;
  assign qp_f_0_1_1 = 32'h00000002;
  assign qp_f_0_1_2 = 32'h00000003;
  assign qp_f_0_1_3 = 32'h00000004;
  assign qp_f_0_1_4 = 32'h00000005;
  assign qp_f_0_2_0 = 32'h00000002;
  assign qp_f_0_2_1 = 32'h00000003;
  assign qp_f_0_2_2 = 32'h00000004;
  assign qp_f_0_2_3 = 32'h00000005;
  assign qp_f_0_2_4 = 32'h00000006;
  assign qp_f_0_3_0 = 32'h00000003;
  assign qp_f_0_3_1 = 32'h00000004;
  assign qp_f_0_3_2 = 32'h00000005;
  assign qp_f_0_3_3 = 32'h00000006;
  assign qp_f_0_3_4 = 32'h00000007;
  assign qp_f_1_0_0 = 32'h00000001;
  assign qp_f_1_0_1 = 32'h00000002;
  assign qp_f_1_0_2 = 32'h00000003;
  assign qp_f_1_0_3 = 32'h00000004;
  assign qp_f_1_0_4 = 32'h00000005;
  assign qp_f_1_1_0 = 32'h00000002;
  assign qp_f_1_1_1 = 32'h00000003;
  assign qp_f_1_1_2 = 32'h00000004;
  assign qp_f_1_1_3 = 32'h00000005;
  assign qp_f_1_1_4 = 32'h00000006;
  assign qp_f_1_2_0 = 32'h00000003;
  assign qp_f_1_2_1 = 32'h00000004;
  assign qp_f_1_2_2 = 32'h00000005;
  assign qp_f_1_2_3 = 32'h00000006;
  assign qp_f_1_2_4 = 32'h00000007;
  assign qp_f_1_3_0 = 32'h00000004;
  assign qp_f_1_3_1 = 32'h00000005;
  assign qp_f_1_3_2 = 32'h00000006;
  assign qp_f_1_3_3 = 32'h00000007;
  assign qp_f_1_3_4 = 32'h00000008;
  assign qp_f_2_0_0 = 32'h00000002;
  assign qp_f_2_0_1 = 32'h00000003;
  assign qp_f_2_0_2 = 32'h00000004;
  assign qp_f_2_0_3 = 32'h00000005;
  assign qp_f_2_0_4 = 32'h00000006;
  assign qp_f_2_1_0 = 32'h00000003;
  assign qp_f_2_1_1 = 32'h00000004;
  assign qp_f_2_1_2 = 32'h00000005;
  assign qp_f_2_1_3 = 32'h00000006;
  assign qp_f_2_1_4 = 32'h00000007;
  assign qp_f_2_2_0 = 32'h00000004;
  assign qp_f_2_2_1 = 32'h00000005;
  assign qp_f_2_2_2 = 32'h00000006;
  assign qp_f_2_2_3 = 32'h00000007;
  assign qp_f_2_2_4 = 32'h00000008;
  assign qp_f_2_3_0 = 32'h00000005;
  assign qp_f_2_3_1 = 32'h00000006;
  assign qp_f_2_3_2 = 32'h00000007;
  assign qp_f_2_3_3 = 32'h00000008;
  assign qp_f_2_3_4 = 32'h00000009;
  assign _zz_1 = _zz_4[1:0];
  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_0_0 = qp_f_0_0_0;
      end
      2'b01 : begin
        qp_f_0dim_0_0 = qp_f_1_0_0;
      end
      default : begin
        qp_f_0dim_0_0 = qp_f_2_0_0;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_0_1 = qp_f_0_0_1;
      end
      2'b01 : begin
        qp_f_0dim_0_1 = qp_f_1_0_1;
      end
      default : begin
        qp_f_0dim_0_1 = qp_f_2_0_1;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_0_2 = qp_f_0_0_2;
      end
      2'b01 : begin
        qp_f_0dim_0_2 = qp_f_1_0_2;
      end
      default : begin
        qp_f_0dim_0_2 = qp_f_2_0_2;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_0_3 = qp_f_0_0_3;
      end
      2'b01 : begin
        qp_f_0dim_0_3 = qp_f_1_0_3;
      end
      default : begin
        qp_f_0dim_0_3 = qp_f_2_0_3;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_0_4 = qp_f_0_0_4;
      end
      2'b01 : begin
        qp_f_0dim_0_4 = qp_f_1_0_4;
      end
      default : begin
        qp_f_0dim_0_4 = qp_f_2_0_4;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_1_0 = qp_f_0_1_0;
      end
      2'b01 : begin
        qp_f_0dim_1_0 = qp_f_1_1_0;
      end
      default : begin
        qp_f_0dim_1_0 = qp_f_2_1_0;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_1_1 = qp_f_0_1_1;
      end
      2'b01 : begin
        qp_f_0dim_1_1 = qp_f_1_1_1;
      end
      default : begin
        qp_f_0dim_1_1 = qp_f_2_1_1;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_1_2 = qp_f_0_1_2;
      end
      2'b01 : begin
        qp_f_0dim_1_2 = qp_f_1_1_2;
      end
      default : begin
        qp_f_0dim_1_2 = qp_f_2_1_2;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_1_3 = qp_f_0_1_3;
      end
      2'b01 : begin
        qp_f_0dim_1_3 = qp_f_1_1_3;
      end
      default : begin
        qp_f_0dim_1_3 = qp_f_2_1_3;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_1_4 = qp_f_0_1_4;
      end
      2'b01 : begin
        qp_f_0dim_1_4 = qp_f_1_1_4;
      end
      default : begin
        qp_f_0dim_1_4 = qp_f_2_1_4;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_2_0 = qp_f_0_2_0;
      end
      2'b01 : begin
        qp_f_0dim_2_0 = qp_f_1_2_0;
      end
      default : begin
        qp_f_0dim_2_0 = qp_f_2_2_0;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_2_1 = qp_f_0_2_1;
      end
      2'b01 : begin
        qp_f_0dim_2_1 = qp_f_1_2_1;
      end
      default : begin
        qp_f_0dim_2_1 = qp_f_2_2_1;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_2_2 = qp_f_0_2_2;
      end
      2'b01 : begin
        qp_f_0dim_2_2 = qp_f_1_2_2;
      end
      default : begin
        qp_f_0dim_2_2 = qp_f_2_2_2;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_2_3 = qp_f_0_2_3;
      end
      2'b01 : begin
        qp_f_0dim_2_3 = qp_f_1_2_3;
      end
      default : begin
        qp_f_0dim_2_3 = qp_f_2_2_3;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_2_4 = qp_f_0_2_4;
      end
      2'b01 : begin
        qp_f_0dim_2_4 = qp_f_1_2_4;
      end
      default : begin
        qp_f_0dim_2_4 = qp_f_2_2_4;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_3_0 = qp_f_0_3_0;
      end
      2'b01 : begin
        qp_f_0dim_3_0 = qp_f_1_3_0;
      end
      default : begin
        qp_f_0dim_3_0 = qp_f_2_3_0;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_3_1 = qp_f_0_3_1;
      end
      2'b01 : begin
        qp_f_0dim_3_1 = qp_f_1_3_1;
      end
      default : begin
        qp_f_0dim_3_1 = qp_f_2_3_1;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_3_2 = qp_f_0_3_2;
      end
      2'b01 : begin
        qp_f_0dim_3_2 = qp_f_1_3_2;
      end
      default : begin
        qp_f_0dim_3_2 = qp_f_2_3_2;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_3_3 = qp_f_0_3_3;
      end
      2'b01 : begin
        qp_f_0dim_3_3 = qp_f_1_3_3;
      end
      default : begin
        qp_f_0dim_3_3 = qp_f_2_3_3;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_1)
      2'b00 : begin
        qp_f_0dim_3_4 = qp_f_0_3_4;
      end
      2'b01 : begin
        qp_f_0dim_3_4 = qp_f_1_3_4;
      end
      default : begin
        qp_f_0dim_3_4 = qp_f_2_3_4;
      end
    endcase
  end

  assign _zz_2 = addr2[1:0];
  always @ (*) begin
    case(_zz_2)
      2'b00 : begin
        qp_f_1dim_0 = qp_f_0dim_0_0;
      end
      2'b01 : begin
        qp_f_1dim_0 = qp_f_0dim_1_0;
      end
      2'b10 : begin
        qp_f_1dim_0 = qp_f_0dim_2_0;
      end
      default : begin
        qp_f_1dim_0 = qp_f_0dim_3_0;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_2)
      2'b00 : begin
        qp_f_1dim_1 = qp_f_0dim_0_1;
      end
      2'b01 : begin
        qp_f_1dim_1 = qp_f_0dim_1_1;
      end
      2'b10 : begin
        qp_f_1dim_1 = qp_f_0dim_2_1;
      end
      default : begin
        qp_f_1dim_1 = qp_f_0dim_3_1;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_2)
      2'b00 : begin
        qp_f_1dim_2 = qp_f_0dim_0_2;
      end
      2'b01 : begin
        qp_f_1dim_2 = qp_f_0dim_1_2;
      end
      2'b10 : begin
        qp_f_1dim_2 = qp_f_0dim_2_2;
      end
      default : begin
        qp_f_1dim_2 = qp_f_0dim_3_2;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_2)
      2'b00 : begin
        qp_f_1dim_3 = qp_f_0dim_0_3;
      end
      2'b01 : begin
        qp_f_1dim_3 = qp_f_0dim_1_3;
      end
      2'b10 : begin
        qp_f_1dim_3 = qp_f_0dim_2_3;
      end
      default : begin
        qp_f_1dim_3 = qp_f_0dim_3_3;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_2)
      2'b00 : begin
        qp_f_1dim_4 = qp_f_0dim_0_4;
      end
      2'b01 : begin
        qp_f_1dim_4 = qp_f_0dim_1_4;
      end
      2'b10 : begin
        qp_f_1dim_4 = qp_f_0dim_2_4;
      end
      default : begin
        qp_f_1dim_4 = qp_f_0dim_3_4;
      end
    endcase
  end

  always @ (*) begin
    case(_zz_3)
      3'b000 : begin
        qp_f_1dim_mux0 = qp_f_1dim_0;
      end
      3'b001 : begin
        qp_f_1dim_mux0 = qp_f_1dim_1;
      end
      3'b010 : begin
        qp_f_1dim_mux0 = qp_f_1dim_2;
      end
      3'b011 : begin
        qp_f_1dim_mux0 = qp_f_1dim_3;
      end
      default : begin
        qp_f_1dim_mux0 = qp_f_1dim_4;
      end
    endcase
  end

  assign qlevel = qp_f_1dim_mux0;

endmodule
```