### PR TITLE
Specifying the file path when generating Qsys .tcl

### DIFF
--- a/lib/src/main/scala/spinal/lib/cpu/riscv/impl/build/RiscvAvalon.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/impl/build/RiscvAvalon.scala
@@ -4,7 +4,7 @@ import spinal.core._
 import spinal.lib._
 import spinal.lib.bus.avalon._
 import spinal.lib.cpu.riscv.impl._
-import spinal.lib.eda.altera.{InterruptReceiverTag, QSysify, ResetEmitterTag}
+import spinal.lib.eda.altera.{InterruptTag, QSysify, ResetEmitterTag}
 
 import cpu.riscv.impl.extension._
 
@@ -146,7 +146,7 @@ object RiscvAvalon{
     report.toplevel.io.i addTag(ClockDomainTag(report.toplevel.clockDomain))
     report.toplevel.io.d addTag(ClockDomainTag(report.toplevel.clockDomain))
     if(interruptCount != 0)
-      report.toplevel.io.interrupt addTag(InterruptReceiverTag(report.toplevel.io.i,report.toplevel.clockDomain))
+      report.toplevel.io.interrupt addTag InterruptTag(report.toplevel.clockDomain, report.toplevel.io.i)
     if(debug) {
       report.toplevel.io.debugBus addTag(ClockDomainTag(report.toplevel.debugExtension.clockDomain))
       report.toplevel.io.debugResetOut.addTag(ResetEmitterTag(report.toplevel.debugExtension.clockDomain))

--- a/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
+++ b/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
@@ -10,8 +10,8 @@ import scala.collection.mutable.StringBuilder
 import spinal.lib.bus.amba4.axilite.AxiLite4
 
 object QSysify{
-  def apply(that : Component) : Unit = {
-    val tool = new QSysify
+  def apply(that : Component, filePath : String = "") : Unit = {
+    val tool = new QSysify(filePath)
     tool.interfaceEmiters += new AvalonEmitter()
     tool.interfaceEmiters += new ApbEmitter()
     tool.interfaceEmiters += new Axi4Emitter()
@@ -31,12 +31,12 @@ trait QSysifyInterfaceEmiter{
   def emit(i : Data,builder : StringBuilder) : Boolean
 }
 
-class QSysify{
+class QSysify(filePath : String) {
   val interfaceEmiters = mutable.ArrayBuffer[QSysifyInterfaceEmiter]()
   def emit(that : Component) {
     val name = that.definitionName
     var out: java.io.FileWriter = null
-    out = new java.io.FileWriter(name + "_hw.tcl")
+    out = new java.io.FileWriter(filePath + name + "_hw.tcl")
     val builder = new StringBuilder()
 
     genHeader()


### PR DESCRIPTION
```scala
QSysify(SpinalVerilog(new TopLevel).toplevel, "../")
```
The Quartus Platform Designer requires that ".tcl" and ".v" in the same path.