### PR TITLE
adapt to new cocotb Makefile inclusion scheme

### DIFF
--- a/tester/src/test/python/spinal/Dummy/Makefile
+++ b/tester/src/test/python/spinal/Dummy/Makefile
@@ -13,5 +13,4 @@ endif
 
 MODULE=Dummy
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tester/src/test/python/spinal/TopLevel/Makefile
+++ b/tester/src/test/python/spinal/TopLevel/Makefile
@@ -1,5 +1,5 @@
 VERILOG_SOURCES =  $(PWD)/dump.v $(PWD)/../../../../../TopLevel.v
 TOPLEVEL=TopLevel
 MODULE=main
-include $(shell cocotb-config --makefiles)/Makefile.inc
+
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tester/src/test/python/spinal/common/Makefile.sim
+++ b/tester/src/test/python/spinal/common/Makefile.sim
@@ -8,7 +8,6 @@ ifeq ($(TOPLEVEL_LANG),vhdl)
 endif
 
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 


### PR DESCRIPTION
There are some errors in the github action output about these wrong entries.