### PR TITLE
added more useful error message

### DIFF
--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -354,6 +354,7 @@ object Spinal{
       case `VHDL`    => SpinalVhdlBoot(configPatched)(gen)
       case `Verilog` => SpinalVerilogBoot(configPatched)(gen)
       case `SystemVerilog` => SpinalVerilogBoot(configPatched)(gen)
+      case null => throw new Exception("Please specify mode in SpinalConfig (mode=[Verilog, SystemVerilog, VHDL])")
     }
 
     println({SpinalLog.tag("Done", Console.GREEN)} + s" at ${f"${Driver.executionTime}%1.3f"}")


### PR DESCRIPTION
Makes it more obvious what you did wrong if you don't include mode in spinalConfig. I wasn't sure how SpinalHDL handles errors, so I just made an exception.  