### PR TITLE
unify pipes, use Composite, optimize s2mPipe

### DIFF
--- a/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
@@ -481,7 +481,7 @@ class RepeatabilityTester extends AnyFunSuite{
 
   test("Apb3I2cCtrlGraph"){
     val dut = SpinalConfig(defaultClockDomainFrequency = FixedFrequency(50 MHz)).generateVerilog(new Apb3I2cCtrl(configI2C)).toplevel
-    assert(GraphUtils.countNames(dut) == 216)
+    assert(GraphUtils.countNames(dut) == 217)
   }
 
   test("UartGraph"){


### PR DESCRIPTION
The pipe generators are silimar in nature, so their code
should look as similar as possible. The new composite style
helps create better output. Also s2mPipe’s rBits/rData can
use simpler logic to only depend on this/self.ready.

Passes all tests