### PR TITLE
Improve PulseCCByToggle, Unify StreamCCByToggle and StreamCCByToggleWithoutBuffer

### DIFF
--- a/lib/src/main/scala/spinal/lib/CrossClock.scala
+++ b/lib/src/main/scala/spinal/lib/CrossClock.scala
@@ -53,22 +53,14 @@ class PulseCCByToggle(clockIn: ClockDomain, clockOut: ClockDomain) extends Compo
     val pulseOut = out Bool()
   }
 
-  val inArea = new ClockingArea(clockIn) {
-    val target = RegInit(False)
-    when(io.pulseIn) {
-      target := !target
-    }
+  val inArea = clockIn on new Area {
+    val target = RegInit(False) toggleWhen(io.pulseIn)
   }
 
-  val outArea = new ClockingArea(clockOut) {
+  val outArea = clockOut on new Area {
     val target = BufferCC(inArea.target, False)
-    val hit    = RegInit(False);
 
-    when(target =/= hit) {
-      hit := !hit
-    }
-
-    io.pulseOut := (target =/= hit)
+    io.pulseOut := target.edge(False)
   }
 }
 

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -202,7 +202,7 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
   }
 
   def ccToggleWithoutBuffer(pushClock: ClockDomain, popClock: ClockDomain): Stream[T] = {
-    val cc = new StreamCCByToggle(payloadType, pushClock, popClock, withInputWait=true).setCompositeName(this,"ccToggle", true)
+    val cc = new StreamCCByToggle(payloadType, pushClock, popClock, withOutputBuffer=false, withInputWait=true).setCompositeName(this,"ccToggle", true)
     cc.io.input << this
     cc.io.output
   }
@@ -1180,7 +1180,7 @@ class StreamCCByToggle[T <: Data](dataType: HardType[T],
 
   val pushArea = inputClock on new Area {
     val hit = BufferCC(outHitSignal, False)
-    val accept = False
+    val accept = Bool()
     val target = RegInit(False) toggleWhen(accept)
     val data = RegNextWhen(io.input.payload, accept)
 

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1203,11 +1203,7 @@ class StreamCCByToggle[T <: Data](dataType: HardType[T],
 
     stream.valid := (target =/= hit)
 
-    if (!withInputWait) {
-      stream.payload := pushArea.data
-    } else {
-      stream.payload := RegNext(pushArea.data)
-    }
+    stream.payload := pushArea.data
     stream.payload.addTag(crossClockDomain)
 
     io.output << (if(withOutputBuffer) stream.m2sPipe(holdPayload = true) else stream)

--- a/lib/src/main/scala/spinal/lib/system/dma/sg/DmaSg.scala
+++ b/lib/src/main/scala/spinal/lib/system/dma/sg/DmaSg.scala
@@ -972,9 +972,7 @@ object DmaSg{
         }
 
 
-        val toggle = RegInit(False)
-        toggle := toggle ^ sel.fire
-
+        val toggle = RegInit(False) toggleWhen(sel.fire)
 
         def address = sel.address
 


### PR DESCRIPTION
makes use of new APIs ```clock on new Area {}``` and ```toggleWhen()``` and ```edge()```.

I don’t think that the added ```RegNext(pushArea.data)``` for the ```stream.payload``` in case of ```withInputWait = true``` warrants another pipeline stage on ```popArea.target```’s ```BufferCC```, as it was there in the old ```StreamCCByToggleWithoutBuffer``` implementation. As the correlated control signal ```popArea.target``` is at least one ```outputClock``` cycle slower than the always registered data in ```stream.payload```, it will for sure not be losing the payload update. At least it arrives in the same clock cycle as the data.