### PR TITLE
instance port width info add back and bug fix when it is Literal 

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -264,8 +264,11 @@ class ComponentEmitterVerilog(
       if(openSubIo.contains(data)) ""
       else {
         val wireName = emitReference(data, false)
-      // val section = if(data.getBitsWidth == 1) "" else  s"[${data.getBitsWidth - 1}:0]"
-        wireName// + section  //Section removed as it can be a literal
+        val section = if(data.getBitsWidth == 1) "" else  s"[${data.getBitsWidth - 1}:0]"
+        referencesOverrides.getOrElse(data, data.getNameElseThrow) match {
+          case x: Literal => wireName
+          case _ =>  wireName + section
+        } //Section removed as it can be a literal
       }
     }
 


### PR DESCRIPTION
hi @Dolu1990 , i add back instance port width information , because i think it' usefull for designer check the port width at the first sight.

```verilog 
    .io_qi_cs        (ctrl_flow_cs                       ), //i
    .io_qi_wr        (ctrl_flow_wr                       ), //i
    .io_qi_addr      (ctrl_flow_addr[33:0]               ), //i
    .io_qi_wflag     (ctrl_flow_wflag[31:0]              ), //i
    .io_qi_wdata     (ctrl_flow_wdata[1023:0]            ), //i
    .io_qi_rflag     (flagQrw_io_qi_rflag[31:0]          ), //o
    .io_qi_rdata     (flagQrw_io_qi_rdata[1023:0]        ), //o
    .io_qi_rdvld     (flagQrw_io_qi_rdvld                ), //o
    .io_qi_ready     (flagQrw_io_qi_ready                ), //o
    .io_qi_rready    (ctrl_flow_rready                   ), //i
    .io_qo_cs        (flagQrw_io_qo_cs                   ), //o
    .io_qo_wr        (flagQrw_io_qo_wr                   ), //o
    .io_qo_addr      (flagQrw_io_qo_addr[33:0]           ), //o
    .io_qo_wdata     (flagQrw_io_qo_wdata[1023:0]        ), //o
    .io_qo_rdata     (tag_wtype_ctrl_flow_rdata[1023:0]  ), //i
    .io_qo_rdvld     (tag_wtype_ctrl_flow_rdvld          ), //i
    .io_qo_ready     (tag_wtype_ctrl_flow_ready          ), //i
    .io_qo_rready    (flagQrw_io_qo_rready               ), //o
    .clk             (clk                                ), //i
    .resetn          (resetn                             )  //i   
```

and also fix the old issue of when the port expression is Literal 
```log
%Error: xxxx/tmp/job_1/DataCRCTB.v:43:21: syntax error, unexpected '['
   43 |     .c      (4'b0000[3:0]          ),  
      |                     ^
%Error: xxxx/tmp/job_1/DataCRCTB.v:48:21: syntax error, unexpected '['
   48 |     .c      (4'b0000[3:0]            ),  
      |                     ^
%Error: Exiting due to 2 error(s)
```
now it's ok for Literal 
```
  CRC4_D892_0x13 cRCParallel (
    .d      (t_io_wo_wdata[891:0]  ), //i
    .c      (4'b0000               ), //i
    .res    (cRCParallel_res[3:0]  )  //o
  );
  CRC4_D892_0x13 cRCParallel_1 (
    .d      (cRCParallel_1_d[891:0]  ), //i
    .c      (4'b0000                 ), //i
    .res    (cRCParallel_1_res[3:0]  )  //o
  );  
```