### PR TITLE
create alias for always using downto range properly

### DIFF
--- a/core/src/main/scala/spinal/core/internals/PhaseVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVhdl.scala
@@ -278,12 +278,13 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
       val ret = new StringBuilder()
 
       (s"function pkg_extract (that : $kind; base : unsigned; size : integer) return $kind", {
-        ret ++= "   constant elementCount : integer := (that'length-size)+1;\n"
-        ret ++= s"   type tableType is array (0 to elementCount-1) of $kind(size-1 downto 0);\n"
-        ret ++= "   variable table : tableType;\n"
+        ret ++= s"    alias temp : $kind(that'length-1 downto 0) is that;"
+        ret ++= "    constant elementCount : integer := temp'length - size + 1;\n"
+        ret ++= s"    type tableType is array (0 to elementCount-1) of $kind(size-1 downto 0);\n"
+        ret ++= "    variable table : tableType;\n"
         ret ++= "  begin\n"
         ret ++= "    for i in 0 to elementCount-1 loop\n"
-        ret ++= "      table(i) := that(i + size - 1 downto i);\n"
+        ret ++= "      table(i) := temp(i + size - 1 downto i);\n"
         ret ++= "    end loop;\n"
         ret ++= "    return table(to_integer(base));\n"
         ret ++= "  end pkg_extract;\n\n"
@@ -382,17 +383,21 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
     ret ++= "\n"
     ret ++= "  -- unsigned shifts\n"
     ret ++= "  function pkg_shiftRight (that : unsigned; size : natural) return unsigned is\n"
+    ret ++= "    variable ret : unsigned(that'length-1 downto 0);\n"
     ret ++= "  begin\n"
     ret ++= "    if size >= that'length then\n"
     ret ++= "      return \"\";\n"
     ret ++= "    else\n"
-    ret ++= "      return shift_right(that,size)(that'length-1-size downto 0);\n"
+    ret ++= "      ret := shift_right(that,size);\n"
+    ret ++= "      return ret(that'length-1-size downto 0);\n"
     ret ++= "    end if;\n"
     ret ++= "  end pkg_shiftRight;\n"
     ret ++= "\n"
     ret ++= "  function pkg_shiftRight (that : unsigned; size : unsigned) return unsigned is\n"
+    ret ++= "    variable ret : unsigned(that'length-1 downto 0);\n"
     ret ++= "  begin\n"
-    ret ++= "    return shift_right(that,to_integer(size));\n"
+    ret ++= "    ret := shift_right(that,to_integer(size));\n"
+    ret ++= "    return ret;\n"
     ret ++= "  end pkg_shiftRight;\n"
     ret ++= "\n"
     ret ++= "  function pkg_shiftLeft (that : unsigned; size : natural) return unsigned is\n"
@@ -453,24 +458,21 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
     ret ++= "  end pkg_rotateLeft;\n"
     ret ++= "\n"
     ret ++= "  function pkg_extract (that : std_logic_vector; high : integer; low : integer) return std_logic_vector is\n"
-    ret ++= "    variable temp : std_logic_vector(high-low downto 0);\n"
+    ret ++= "    alias temp : std_logic_vector(that'length-1 downto 0) is that;\n"
     ret ++= "  begin\n"
-    ret ++= "    temp := that(high downto low);\n"
-    ret ++= "    return temp;\n"
+    ret ++= "    return temp(high downto low);\n"
     ret ++= "  end pkg_extract;\n"
     ret ++= "\n"
     ret ++= "  function pkg_extract (that : unsigned; high : integer; low : integer) return unsigned is\n"
-    ret ++= "    variable temp : unsigned(high-low downto 0);\n"
+    ret ++= "    alias temp : unsigned(that'length-1 downto 0) is that;\n"
     ret ++= "  begin\n"
-    ret ++= "    temp := that(high downto low);\n"
-    ret ++= "    return temp;\n"
+    ret ++= "    return temp(high downto low);\n"
     ret ++= "  end pkg_extract;\n"
     ret ++= "\n"
     ret ++= "  function pkg_extract (that : signed; high : integer; low : integer) return signed is\n"
-    ret ++= "    variable temp : signed(high-low downto 0);\n"
+    ret ++= "    alias temp : signed(that'length-1 downto 0) is that;\n"
     ret ++= "  begin\n"
-    ret ++= "    temp := that(high downto low);\n"
-    ret ++= "    return temp;\n"
+    ret ++= "    return temp(high downto low);\n"
     ret ++= "  end pkg_extract;\n"
     ret ++= "\n"
     ret ++= "  function pkg_mux (sel : std_logic; one : std_logic; zero : std_logic) return std_logic is\n"
@@ -546,23 +548,20 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
     ret ++= "  end pkg_toSigned;\n"
     ret ++= "\n"
     ret ++= "  function pkg_stdLogicVector (lit : std_logic_vector) return std_logic_vector is\n"
-    ret ++= "    variable ret : std_logic_vector(lit'length-1 downto 0);\n"
+    ret ++= "    alias ret : std_logic_vector(lit'length-1 downto 0) is lit;\n"
     ret ++= "  begin\n"
-    ret ++= "    ret := lit;\n"
     ret ++= "    return ret;\n"
     ret ++= "  end pkg_stdLogicVector;\n"
     ret ++= "\n"
     ret ++= "  function pkg_unsigned (lit : unsigned) return unsigned is\n"
-    ret ++= "    variable ret : unsigned(lit'length-1 downto 0);\n"
+    ret ++= "    alias ret : unsigned(lit'length-1 downto 0) is lit;\n"
     ret ++= "  begin\n"
-    ret ++= "    ret := lit;\n"
     ret ++= "    return ret;\n"
     ret ++= "  end pkg_unsigned;\n"
     ret ++= "\n"
     ret ++= "  function pkg_signed (lit : signed) return signed is\n"
-    ret ++= "    variable ret : signed(lit'length-1 downto 0);\n"
+    ret ++= "    alias ret : signed(lit'length-1 downto 0) is lit;\n"
     ret ++= "  begin\n"
-    ret ++= "    ret := lit;\n"
     ret ++= "    return ret;\n"
     ret ++= "  end pkg_signed;\n"
     ret ++= "\n"
@@ -587,14 +586,15 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
 
     ret ++=
      """|  function pkg_resize (that : signed; width : integer) return signed is
+        |    alias temp : signed(that'length-1 downto 0) is that;
         |    variable ret : signed(width-1 downto 0);
         |  begin
-        |    if that'length = 0 then
+        |    if temp'length = 0 then
         |       ret := (others => '0');
-        |    elsif that'length >= width then
-        |       ret := that(width-1 downto 0);
+        |    elsif temp'length >= width then
+        |       ret := temp(width-1 downto 0);
         |    else
-        |       ret := resize(that,width);
+        |       ret := resize(temp,width);
         |    end if;
         |    return ret;
         |  end pkg_resize;


### PR DESCRIPTION
This avoiding warnings created by some simulation tools. You should not assume that a parameter as std_logic_vector will always be 'downto'. Even or especially if it’s generated code, we should avoid this warning.