### PR TITLE
add cache for verilator binaries

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -36,6 +36,7 @@ import sys.process._
 case class SpinalVerilatorBackendConfig[T <: Component](
                                                          rtl               : SpinalReport[T],
                                                          waveFormat        : WaveFormat = WaveFormat.NONE,
+                                                         maxCacheEntries   : Int = 100,
                                                          cachePath         : String = null,
                                                          workspacePath     : String = "./",
                                                          workspaceName     : String = null,
@@ -60,6 +61,7 @@ object SpinalVerilatorBackend {
     vconfig.toplevelName      = rtl.toplevelName
     vconfig.vcdPath           = vcdPath
     vconfig.vcdPrefix         = vcdPrefix
+    vconfig.maxCacheEntries   = maxCacheEntries
     vconfig.cachePath         = cachePath
     vconfig.workspaceName     = workspaceName
     vconfig.workspacePath     = workspacePath
@@ -473,6 +475,7 @@ case class SpinalSimConfig(
                             var _waveFormat        : WaveFormat = WaveFormat.NONE,
                             var _backend           : SpinalSimBackendSel = SpinalSimBackendSel.VERILATOR,
                             var _withCoverage      : Boolean = false,
+                            var _maxCacheEntries   : Int = 100,
                             var _disableCache      : Boolean = false
 ){
 
@@ -564,6 +567,11 @@ case class SpinalSimConfig(
     this
   }
 
+  def maxCacheEntries(count: Int): this.type = {
+    _maxCacheEntries = count
+    this
+  }
+
   def disableCache: this.type = {
     _disableCache = true
     this
@@ -615,7 +623,6 @@ case class SpinalSimConfig(
     if (_workspaceName == null)
       _workspaceName = s"${report.toplevelName}"
 
-    val cacheWorkspaceName = _workspaceName
     _workspaceName = SimWorkspace.allocateWorkspace(_workspacePath, _workspaceName)
 
     println(f"[Progress] Simulation workspace in ${new File(s"${_workspacePath}/${_workspaceName}").getAbsolutePath}")
@@ -634,7 +641,8 @@ case class SpinalSimConfig(
         val vConfig = SpinalVerilatorBackendConfig[T](
           rtl = report,
           waveFormat = _waveFormat,
-          cachePath = if (!_disableCache) s"${_workspacePath}/.cache/${cacheWorkspaceName}" else null,
+          maxCacheEntries = _maxCacheEntries,
+          cachePath = if (!_disableCache) s"${_workspacePath}/.cache" else null,
           workspacePath = s"${_workspacePath}/${_workspaceName}",
           vcdPath = s"${_workspacePath}/${_workspaceName}",
           vcdPrefix = null,

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -615,6 +615,7 @@ case class SpinalSimConfig(
     if (_workspaceName == null)
       _workspaceName = s"${report.toplevelName}"
 
+    val cacheWorkspaceName = _workspaceName
     _workspaceName = SimWorkspace.allocateWorkspace(_workspacePath, _workspaceName)
 
     println(f"[Progress] Simulation workspace in ${new File(s"${_workspacePath}/${_workspaceName}").getAbsolutePath}")
@@ -633,7 +634,7 @@ case class SpinalSimConfig(
         val vConfig = SpinalVerilatorBackendConfig[T](
           rtl = report,
           waveFormat = _waveFormat,
-          cachePath = if (!_disableCache) s"${_workspacePath}/.cache/${_workspaceName}" else null,
+          cachePath = if (!_disableCache) s"${_workspacePath}/.cache/${cacheWorkspaceName}" else null,
           workspacePath = s"${_workspacePath}/${_workspaceName}",
           vcdPath = s"${_workspacePath}/${_workspaceName}",
           vcdPrefix = null,

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -472,7 +472,8 @@ case class SpinalSimConfig(
                             var _additionalIncludeDir : ArrayBuffer[String] = ArrayBuffer[String](),
                             var _waveFormat        : WaveFormat = WaveFormat.NONE,
                             var _backend           : SpinalSimBackendSel = SpinalSimBackendSel.VERILATOR,
-                            var _withCoverage      : Boolean = false
+                            var _withCoverage      : Boolean = false,
+                            var _disableCache      : Boolean = false
 ){
 
 
@@ -563,6 +564,11 @@ case class SpinalSimConfig(
     this
   }
 
+  def disableCache: this.type = {
+    _disableCache = true
+    this
+  }
+
   def doSim[T <: Component](report: SpinalReport[T])(body: T => Unit): Unit = compile(report).doSim(body)
   def doSim[T <: Component](report: SpinalReport[T], name: String)(body: T => Unit): Unit = compile(report).doSim(name)(body)
   def doSim[T <: Component](report: SpinalReport[T], name: String, seed: Int)(body: T => Unit): Unit = compile(report).doSim(name, seed)(body)
@@ -627,7 +633,7 @@ case class SpinalSimConfig(
         val vConfig = SpinalVerilatorBackendConfig[T](
           rtl = report,
           waveFormat = _waveFormat,
-          cachePath = s"${_workspacePath}/.cache/${_workspaceName}",
+          cachePath = if (!_disableCache) s"${_workspacePath}/.cache/${_workspaceName}" else null,
           workspacePath = s"${_workspacePath}/${_workspaceName}",
           vcdPath = s"${_workspacePath}/${_workspaceName}",
           vcdPrefix = null,

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -36,6 +36,7 @@ import sys.process._
 case class SpinalVerilatorBackendConfig[T <: Component](
                                                          rtl               : SpinalReport[T],
                                                          waveFormat        : WaveFormat = WaveFormat.NONE,
+                                                         cachePath         : String = null,
                                                          workspacePath     : String = "./",
                                                          workspaceName     : String = null,
                                                          vcdPath           : String = null,
@@ -59,6 +60,7 @@ object SpinalVerilatorBackend {
     vconfig.toplevelName      = rtl.toplevelName
     vconfig.vcdPath           = vcdPath
     vconfig.vcdPrefix         = vcdPrefix
+    vconfig.cachePath         = cachePath
     vconfig.workspaceName     = workspaceName
     vconfig.workspacePath     = workspacePath
     vconfig.waveFormat        = waveFormat match {
@@ -625,6 +627,7 @@ case class SpinalSimConfig(
         val vConfig = SpinalVerilatorBackendConfig[T](
           rtl = report,
           waveFormat = _waveFormat,
+          cachePath = s"${_workspacePath}/.cache/${_workspaceName}",
           workspacePath = s"${_workspacePath}/${_workspaceName}",
           vcdPath = s"${_workspacePath}/${_workspaceName}",
           vcdPrefix = null,

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -476,6 +476,7 @@ case class SpinalSimConfig(
                             var _backend           : SpinalSimBackendSel = SpinalSimBackendSel.VERILATOR,
                             var _withCoverage      : Boolean = false,
                             var _maxCacheEntries   : Int = 100,
+                            var _cachePath         : String = null,   // null => workspacePath + "/.cache"
                             var _disableCache      : Boolean = false
 ){
 
@@ -572,6 +573,11 @@ case class SpinalSimConfig(
     this
   }
 
+  def cachePath(path: String): this.type = {
+    _cachePath = path
+    this
+  }
+
   def disableCache: this.type = {
     _disableCache = true
     this
@@ -642,7 +648,7 @@ case class SpinalSimConfig(
           rtl = report,
           waveFormat = _waveFormat,
           maxCacheEntries = _maxCacheEntries,
-          cachePath = if (!_disableCache) s"${_workspacePath}/.cache" else null,
+          cachePath = if (!_disableCache) (if (_cachePath != null) _cachePath else s"${_workspacePath}/.cache") else null,
           workspacePath = s"${_workspacePath}/${_workspaceName}",
           vcdPath = s"${_workspacePath}/${_workspaceName}",
           vcdPrefix = null,

--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -506,7 +506,7 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
       case false => null
     }
 
-    // skip verilator compilation if nothing changed (hashed equal)
+    // skip verilator compilation if nothing changed (hashes equal)
     if (hash == previousHash) {
       val workspaceDir = new File(s"${workspacePath}/${workspaceName}")
       val backupDir = new File(s"${cachePath}/${workspaceName}")

--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -509,11 +509,11 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
     // skip verilator compilation if nothing changed (hashes equal)
     if (hash == previousHash) {
       val workspaceDir = new File(s"${workspacePath}/${workspaceName}")
-      val backupDir = new File(s"${cachePath}/${workspaceName}")
+      val cacheDir = new File(s"${cachePath}/${workspaceName}")
 
-      if (backupDir.exists()) {
+      if (cacheDir.exists()) {
         FileUtils.deleteQuietly(workspaceDir)
-        FileUtils.moveDirectory(backupDir, workspaceDir)
+        FileUtils.moveDirectory(cacheDir, workspaceDir)
 
         println("[info] Verilator options and sources unchanged, using cached binaries")
         return

--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -580,8 +580,9 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
         val cacheDir = new File(cachePath)
         if (cacheDir.isDirectory()) {
           if (maxCacheEntries > 0) {
-            val cacheEntriesArr = cacheDir.listFiles().filter(_.isDirectory())
-            cacheEntriesArr.sortInPlaceWith(_.lastModified() < _.lastModified())
+            val cacheEntriesArr = cacheDir.listFiles()
+              .filter(_.isDirectory())
+              .sortWith(_.lastModified() < _.lastModified())
 
             val cacheEntries = cacheEntriesArr.toBuffer
             val cacheEntryFound = workspaceCacheDir.isDirectory()

--- a/tester/src/test/scala/spinal/tester/scalatest/VerilatorCacheTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/VerilatorCacheTester.scala
@@ -1,0 +1,191 @@
+package spinal.tester.scalatest
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import spinal.core.sim._
+
+import java.io.File
+import org.apache.commons.io.FileUtils
+import java.io.PrintStream
+
+
+object VerilatorCacheTester {
+  case class ComponentA(n: Int, x: BigInt) extends Component {
+    val io = new Bundle {
+      val x = out Bits(n bits)
+    }
+
+    io.x := x
+  }
+
+
+  class VerilatorCacheUsedChecker(out: PrintStream) extends PrintStream(out) {
+    var verilatorCompilationRunning = false
+    var verilatorCompilationDone = false
+    var verilatorCacheUsed = false
+
+    def reset(): Unit = {
+      verilatorCompilationRunning = false
+      verilatorCompilationDone = false
+      verilatorCacheUsed = false
+    }
+
+    def test(shouldUseCache: Boolean): Unit = {
+      assert(verilatorCompilationRunning == false, "Verilator compilation should not be running now")
+      assert(verilatorCompilationDone == true, "Verilator compilation should be done now")
+
+      if (shouldUseCache) {
+        assert(verilatorCacheUsed == true, "Verilator cache not used but it should be used")
+      } else {
+        assert(verilatorCacheUsed == false, "Verilator cache used but it should not be used")
+      }
+    }
+
+    override def println(x: Any): Unit = {
+      if (x.isInstanceOf[String]) {
+        val str = x.asInstanceOf[String]
+
+        if (str == "[Progress] Verilator compilation started") {
+          verilatorCompilationRunning = true
+          verilatorCompilationDone = false
+          verilatorCacheUsed = false
+        } else if (str.startsWith("[Progress] Verilator compilation done in ")) {
+          verilatorCompilationRunning = false
+          verilatorCompilationDone = true
+        }
+
+        if (verilatorCompilationRunning) {
+          if (str == "[info] Found cached verilator binaries") {
+            verilatorCacheUsed = true
+          }
+        }
+
+        super.println(x)
+      } else {
+        super.println(x)
+      }
+    }
+  }
+}
+
+class VerilatorCacheTester extends AnyFunSuite {
+  import VerilatorCacheTester._
+
+  def deleteCache(): Unit = {
+    val cacheDir = new File(SimConfig._workspacePath + "/.cache")
+    if (cacheDir.exists()) {
+      FileUtils.forceDelete(cacheDir)
+    }
+  }
+
+  def testComponentA(verilatorCacheUsedChecker: VerilatorCacheUsedChecker, n: Int, x: BigInt, shouldUseCache: Boolean, disableCache: Boolean = false, maxCacheEntries: Int = -1, waveDepth: Int = -1): Long = {
+    var cfg = SimConfig
+    if (disableCache) cfg = cfg.disableCache
+    if (maxCacheEntries >= 0) cfg = cfg.maxCacheEntries(maxCacheEntries)
+    if (waveDepth >= 0) cfg = cfg.withWave(waveDepth)
+
+    verilatorCacheUsedChecker.reset()
+
+    val tStart = System.nanoTime()
+    cfg.compile(ComponentA(n, x)).doSim(dut => assert(dut.io.x.toBigInt == x))
+    val duration = System.nanoTime()-tStart
+
+    verilatorCacheUsedChecker.test(shouldUseCache)
+
+    duration
+  }
+
+  test("verilator cache") {
+    deleteCache()
+
+    var durationWithoutCacheTotal: Double = 0
+    var durationWithoutCacheCount = 0
+
+    var durationWithCacheTotal: Double = 0
+    var durationWithCacheCount = 0
+
+    val verilatorCacheUsedChecker = new VerilatorCacheUsedChecker(Console.out)
+    Console.withOut(verilatorCacheUsedChecker) {
+      // first compilation with cache disabled
+      durationWithoutCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=0, shouldUseCache=false, disableCache=true)
+      durationWithoutCacheCount += 1
+
+      // first compilation with cache enabled
+      durationWithoutCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=0, shouldUseCache=false)
+      durationWithoutCacheCount += 1
+
+      // now cache should be used
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=0, shouldUseCache=true)
+      durationWithCacheCount += 1
+
+      // nothing changed, cache should be used again
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=0, shouldUseCache=true)
+      durationWithCacheCount += 1
+
+      // change component, should not use cache
+      durationWithoutCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=1, shouldUseCache=false)
+      durationWithoutCacheCount += 1
+
+      // now the cache should be used again
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=1, shouldUseCache=true)
+      durationWithCacheCount += 1
+
+      // nothing changed, cache should be used again
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=1, shouldUseCache=true)
+      durationWithCacheCount += 1
+
+      // cache disabled, cache should not be used
+      durationWithoutCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=1, shouldUseCache=false, disableCache=true)
+      durationWithoutCacheCount += 1
+
+      // cache reenabled, cache should be used
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=1, shouldUseCache=true)
+      durationWithCacheCount += 1
+
+      // restore previous component configuration, should use cache
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=0, shouldUseCache=true)
+      durationWithCacheCount += 1
+
+      // 2 cache entries used till now, should not use cache and generate 2 new cache entries
+      durationWithoutCacheTotal += testComponentA(verilatorCacheUsedChecker, n=4, x=0, shouldUseCache=false, maxCacheEntries=4)
+      durationWithoutCacheTotal += testComponentA(verilatorCacheUsedChecker, n=4, x=1, shouldUseCache=false, maxCacheEntries=4)
+      durationWithoutCacheCount += 2
+
+      // 4 (=max) cache entries used, should use cache
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=0, shouldUseCache=true, maxCacheEntries=4)
+      Thread.sleep(1100)    // ensure different timestamps
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=1, shouldUseCache=true, maxCacheEntries=4)
+      Thread.sleep(1100)    // ensure different timestamps
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=4, x=0, shouldUseCache=true, maxCacheEntries=4)
+      Thread.sleep(1100)    // ensure different timestamps
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=4, x=1, shouldUseCache=true, maxCacheEntries=4)
+      Thread.sleep(1100)    // ensure different timestamps
+      durationWithCacheCount += 4
+
+      // 4 (=max) cache entries used, new configuration, should not use cache
+      durationWithoutCacheTotal += testComponentA(verilatorCacheUsedChecker, n=4, x=2, shouldUseCache=false, maxCacheEntries=4)
+      durationWithoutCacheCount += 1
+
+      // cache entry deleted in previous test, should not use cache
+      durationWithoutCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=0, shouldUseCache=false, maxCacheEntries=5)
+      durationWithoutCacheCount += 1
+
+      // other cache entries (+ new cache entry) should not have been deleted, should use cache
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=3, x=1, shouldUseCache=true, maxCacheEntries=5)
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=4, x=0, shouldUseCache=true, maxCacheEntries=5)
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=4, x=1, shouldUseCache=true, maxCacheEntries=5)
+      durationWithCacheTotal += testComponentA(verilatorCacheUsedChecker, n=4, x=2, shouldUseCache=true, maxCacheEntries=5)
+      durationWithCacheCount += 4
+
+      // change sim config, should not use cache
+      durationWithoutCacheTotal += testComponentA(verilatorCacheUsedChecker, n=4, x=2, shouldUseCache=false, waveDepth=1)
+      durationWithoutCacheCount += 1
+    }
+
+    val durationWithoutCacheAvg = durationWithoutCacheTotal / durationWithoutCacheCount
+    val durationWithCacheAvg = durationWithCacheTotal / durationWithCacheCount
+
+    assert(durationWithCacheAvg < durationWithoutCacheAvg, "Verilator compilation needs more time when using the cache")
+  }
+}
+

--- a/tester/src/test/scala/spinal/tester/scalatest/VerilatorCacheTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/VerilatorCacheTester.scala
@@ -71,15 +71,16 @@ object VerilatorCacheTester {
 class VerilatorCacheTester extends AnyFunSuite {
   import VerilatorCacheTester._
 
+  val cacheDir = new File(SimConfig._workspacePath + "/.cache_cachetest")
+
   def deleteCache(): Unit = {
-    val cacheDir = new File(SimConfig._workspacePath + "/.cache")
     if (cacheDir.exists()) {
       FileUtils.forceDelete(cacheDir)
     }
   }
 
   def testComponentA(verilatorCacheUsedChecker: VerilatorCacheUsedChecker, n: Int, x: BigInt, shouldUseCache: Boolean, disableCache: Boolean = false, maxCacheEntries: Int = -1, waveDepth: Int = -1): Long = {
-    var cfg = SimConfig
+    var cfg = SimConfig.cachePath(cacheDir.getAbsolutePath())
     if (disableCache) cfg = cfg.disableCache
     if (maxCacheEntries >= 0) cfg = cfg.maxCacheEntries(maxCacheEntries)
     if (waveDepth >= 0) cfg = cfg.withWave(waveDepth)


### PR DESCRIPTION
Creates a cache for the binaries generated by verilator. The hash of the verilator options and the source file contents will be saved and compared before verilator gets invoked. If the hashes equal, the binaries are copied from the cache and verilator compilation will be skipped.

This works for me for some components. SpinalHDL does not always generate the same RTL given the same scala source code. In this case the cached is not used (because the hash always changes). A possible fix (besides fixing SpinalHDL to generate the same RTL given the same scala source) would be to use the scala source code for the hash generation, but this would be more complicated (how to get the corresponding scala source filenames?) and would maybe introduce some problems (for some reason SpinalHDL should generate not the same RTL, then the cached binaries will be used though verilator should be invoked).

Tested on Linux (Ubuntu). Should also be tested on Windows and Mac.

Fix #475 