### PR TITLE
Mem: add models for readUnderWrite modes, add noChange mode

### DIFF
--- a/core/src/main/scala/spinal/core/Mem.scala
+++ b/core/src/main/scala/spinal/core/Mem.scala
@@ -47,6 +47,9 @@ object readFirst extends ReadUnderWritePolicy {
   override def readUnderWriteString: String = "readFirst"
 }
 
+object noChange extends ReadUnderWritePolicy {
+  override def readUnderWriteString: String = "noChange"
+}
 
 object auto extends  MemTechnologyKind{
   override def technologyKind: String = "auto"

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -1153,19 +1153,53 @@ end
           emitWrite(b, memWrite.mem,  if (memWrite.writeEnable != null) emitExpression(memWrite.writeEnable) else null.asInstanceOf[String], memWrite.address, memWrite.data, memWrite.mask, memWrite.mem.getMemSymbolCount(), memWrite.mem.getMemSymbolWidth(), tab)
         }, null, tmpBuilder, memWrite.clockDomain, false)
       case memReadWrite: MemReadWrite  =>
-        if(memReadWrite.readUnderWrite != dontCare) SpinalError(s"memReadWrite can only be emited as dontCare into Verilog $memReadWrite")
         if(memReadWrite.aspectRatio != 1) SpinalError(s"Verilog backend can't emit ${memReadWrite.mem} because of its mixed width ports")
-        emitClockedProcess((tab, b) => {
-          val symbolCount = memReadWrite.mem.getMemSymbolCount()
-          b ++= s"${tab}if(${emitExpression(memReadWrite.chipSelect)}) begin\n"
-          emitRead(b, memReadWrite.mem, memReadWrite.address, memReadWrite, tab + "  ")
-          b ++= s"${tab}end\n"
-        }, null, tmpBuilder, memReadWrite.clockDomain, false)
 
-        emitClockedProcess((tab, b) => {
-          val symbolCount = memReadWrite.mem.getMemSymbolCount()
-          emitWrite(b, memReadWrite.mem,s"${emitExpression(memReadWrite.chipSelect)} && ${emitExpression(memReadWrite.writeEnable)} ", memReadWrite.address, memReadWrite.data, memReadWrite.mask, memReadWrite.mem.getMemSymbolCount(), memReadWrite.mem.getMemSymbolWidth(),tab)
-        }, null, tmpBuilder, memReadWrite.clockDomain, false)
+        memReadWrite.readUnderWrite match {
+          case mode: dontCare.type =>
+            emitClockedProcess((tab, b) => {
+              val symbolCount = memReadWrite.mem.getMemSymbolCount()
+              b ++= s"${tab}if(${emitExpression(memReadWrite.chipSelect)}) begin\n"
+              emitRead(b, memReadWrite.mem, memReadWrite.address, memReadWrite, tab + "  ")
+              b ++= s"${tab}end\n"
+            }, null, tmpBuilder, memReadWrite.clockDomain, false)
+
+            emitClockedProcess((tab, b) => {
+              val symbolCount = memReadWrite.mem.getMemSymbolCount()
+              emitWrite(b, memReadWrite.mem,s"${emitExpression(memReadWrite.chipSelect)} && ${emitExpression(memReadWrite.writeEnable)} ", memReadWrite.address, memReadWrite.data, memReadWrite.mask, memReadWrite.mem.getMemSymbolCount(), memReadWrite.mem.getMemSymbolWidth(),tab)
+            }, null, tmpBuilder, memReadWrite.clockDomain, false)
+          case mode: noChange.type =>
+            emitClockedProcess((tab, b) => {
+              val symbolCount = memReadWrite.mem.getMemSymbolCount()
+              b ++= s"${tab}if(${emitExpression(memReadWrite.chipSelect)}) begin\n"
+              emitWrite(b, memReadWrite.mem,  if (memReadWrite.writeEnable != null) emitExpression(memReadWrite.writeEnable) else null.asInstanceOf[String], memReadWrite.address, memReadWrite.data, memReadWrite.mask, memReadWrite.mem.getMemSymbolCount(), memReadWrite.mem.getMemSymbolWidth(), tab + "  ")
+              b ++= s"${tab}  if(~|${emitExpression(memReadWrite.writeEnable)}) begin\n"
+              emitRead(b, memReadWrite.mem, memReadWrite.address, memReadWrite, tab + "    ")
+              b ++= s"${tab}  end\n"
+              b ++= s"${tab}end\n"
+            }, null, tmpBuilder, memReadWrite.clockDomain, false)
+          case mode: writeFirst.type =>
+            emitClockedProcess((tab, b) => {
+              val symbolCount = memReadWrite.mem.getMemSymbolCount()
+              b ++= s"${tab}if(${emitExpression(memReadWrite.chipSelect)}) begin\n"
+              b ++= s"${tab}  if(${emitExpression(memReadWrite.writeEnable)}) begin\n"
+              emitWrite(b, memReadWrite.mem, null, memReadWrite.address, memReadWrite.data, memReadWrite.mask, memReadWrite.mem.getMemSymbolCount(), memReadWrite.mem.getMemSymbolWidth(), tab + "    ")
+              b ++= s"${tab}    ${emitExpression(memReadWrite)} <= ${emitExpression(memReadWrite.data)};\n"
+              b ++= s"${tab}  end else begin\n"
+              emitRead(b, memReadWrite.mem, memReadWrite.address, memReadWrite, tab + "    ")
+              b ++= s"${tab}  end\n"
+              b ++= s"${tab}end\n"
+            }, null, tmpBuilder, memReadWrite.clockDomain, false)
+          case mode: readFirst.type =>
+            emitClockedProcess((tab, b) => {
+              val symbolCount = memReadWrite.mem.getMemSymbolCount()
+              b ++= s"${tab}if(${emitExpression(memReadWrite.chipSelect)}) begin\n"
+              emitRead(b, memReadWrite.mem, memReadWrite.address, memReadWrite, tab + "  ")
+              emitWrite(b, memReadWrite.mem,  if (memReadWrite.writeEnable != null) emitExpression(memReadWrite.writeEnable) else null.asInstanceOf[String], memReadWrite.address, memReadWrite.data, memReadWrite.mask, memReadWrite.mem.getMemSymbolCount(), memReadWrite.mem.getMemSymbolWidth(), tab + "  ")
+              b ++= s"${tab}end\n"
+            }, null, tmpBuilder, memReadWrite.clockDomain, false)
+          case _ => SpinalError(s"memReadWrite can only be emited as readFirst, writeFirst, noChange or dontCare into Verilog $memReadWrite")
+        }
 
       case memReadSync: MemReadSync   =>
         if(memReadSync.aspectRatio != 1) SpinalError(s"Verilog backend can't emit ${memReadSync.mem} because of its mixed width ports")


### PR DESCRIPTION
Adds the ability to generate different intra-port memory read-under-write policies for a read/write memory port in Verilog (readFirst, writeFirst & noChange) with the existing dontCare behavior left as it was.

For memories without a byte lane enable (mask) this infers the expected modes for Xilinx Vivado, however Xilinx blockrams do not have distinct write-enable and mask ports. Vivado does not usually synthesis the expected structures but instead generates a SDP structure for the writeFirst and noChange cases (I'd hoped that it could generate an and gate with the writeEnable and mask signals, then use a single port). I wonder if there's a better way to tackle this?

Given Xilinx/Vivado's limitations I could omit the writeEnable signal (or pass a bit vector there instead of at the mask) -- what do you think? Based on documentation it would seem that Intel FPGAs do have distinct WE and mask signals (Lattice too?), whereas Microsemi seems to be more similar to Xilinx.

Is there a reasonable way to use SpinalHDL expressions to generate the RTL logic, rather than hard-coded strings of Verilog here? That would of course make the change portable to VHDL as well (or any other backend that could be implemented).

The additional of the noChange mode is helpful for Xilinx UltraRAM, if there are to be dual R/W ports on such a memory then it is not possible to read and write from both ports simultaneously. While it is possible to insert readSync and write primitives and arrange the signals for this condition Vivado synthesis is very flaky about inferring the expected memories (due I guess to having 2 processes accessing the memory, instead of the 1 that it expects), the noChange mode alleviates this..