### PR TITLE
fix memory sim double valid when interrupted more than once

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/AxiMemorySim.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/AxiMemorySim.scala
@@ -319,6 +319,12 @@ case class AxiMemorySim(axi : Axi4, clockDomain : ClockDomain, config : AxiMemor
             r.valid #= false
             clockDomain.waitSampling(random.nextInt(config.interruptMaxDelay + 1))
             r.valid #= true
+
+            if(i == job.burstLength)
+              r.payload.last #= true
+            r.payload.data #= memory.readBigInt(job.address + i * busWordWidth, busWordWidth)
+            clockDomain.waitSamplingWhere(r.ready.toBoolean)
+            i = i + 1
           }
           else {
             if(i == job.burstLength)


### PR DESCRIPTION
memory sim rvalid goes high twice for the same data if the memory sim is interrupted twice in a row. this change prevents that error. I didnt make changes to the altera behavior part of the code because I don't really know how that works.