### PR TITLE
Formal: add enhanced past method

### DIFF
--- a/core/src/main/scala/spinal/core/Formal.scala
+++ b/core/src/main/scala/spinal/core/Formal.scala
@@ -16,6 +16,48 @@ object Formal {
   }
   def past[T <: Data](that : T) : T = past(that, 1)
 
+  /** past implementation optimizied for multiple delays
+   *
+   * Instead of giving a delay in cycles, you can provide a sequence of delays and will
+   * get a Vec containing the history of your value at the given time points.
+   *
+   * Examples:
+   *
+   * A signal should have been held for the last four cycles: `past(signal, 1 to 4).reduce(_ && _)` (start
+   * the range at 0 if the signal should still be high in the current cycle.
+   *
+   * A signal should have been raised in the last four cycles: `past(signal, 1 to 4).reduce(_ || _)`.
+   *
+   * Some data should have been stable: `past(data, 0 to 4).reduce(_ === _)`.
+   *
+   * Some data should have had a specific value: `past(data, 0 to 4).fold(True)(_ && (_ === correctValue))`
+   * or `past(data, 0 to 4).map(_ === correctValue).reduce(_ && _)`.
+   *
+   * Running average of a value: `past(value, (0 to 8)).sum() >>> 3`
+   *
+   * You can also give a specific number of delays: `past(data, Seq(0, 1, 3, 5))`.
+   *
+   * Check some condition every n cycles: `past(data, (0 to 2).map(_ * n))`
+   */
+  def past[T <: Data](that : T, delays : scala.collection.Iterable[Int]) : Vec[T] = {
+    val delays_ = delays.toSeq
+
+    var ptr = that
+    val vec = Vec(null.asInstanceOf[T], delays_.max)
+    if (delays_.contains(0)) {
+      vec(0) := ptr
+    }
+    for(i <- 1 to delays_.max) {
+      ptr = RegNext(ptr)
+      ptr.unsetName().setCompositeName(that, "past_" + i, true)
+      if (delays_.contains(i)) {
+        vec(i) := ptr
+      }
+    }
+
+    vec
+  }
+
   def rose(that : Bool) : Bool = that.rise(True)
   def fell(that : Bool) : Bool = that.fall(False)
   def changed[T <: BaseType](that : T, init : T = null) : Bool = RegNext(that, init = init) =/= that


### PR DESCRIPTION
I had a lot of code like

```scala
cover(inStream.fire
  && past(inStream.fire, 1)
  && past(inStream.fire, 2)
  && past(inStream.fire, 3)
  && past(inStream.fire, 4)
  && past(inStream.fire, 5))
```

and I was looking for a solution that reduces the boilerplate. In the end I found something that generalizes quite well to other use cases. The core concept is that we give in a sequence of time points and get out the history of the value. The desired functionality can then be achieved by reducing with an appropriate operator. By the way I find it quite useful even outside of formal verification (for example, writing `past(signal)` instead of `RegNext(signal)`, so maybe it would fit better somewhere else…

This is almost completely untested, but let me know what you think.