### PR TITLE
support localparam for verilog

### DIFF
--- a/core/src/main/scala/spinal/core/Enum.scala
+++ b/core/src/main/scala/spinal/core/Enum.scala
@@ -80,6 +80,9 @@ class SpinalEnum(var defaultEncoding: SpinalEnumEncoding = native) extends Namea
   type C = SpinalEnumCraft[this.type]
   type E = SpinalEnumElement[this.type]
 
+  private[core] var isPrefixEnable = true
+  private[core] var isGlobalEnable = true
+
   /** Contains all elements of the enumeration */
   @dontName val elements = ArrayBuffer[SpinalEnumElement[this.type]]()
 
@@ -101,6 +104,14 @@ class SpinalEnum(var defaultEncoding: SpinalEnumEncoding = native) extends Namea
     if (name != null) v.setName(name)
     elements += v
     v
+  }
+
+  def rawElementName() = {
+    isPrefixEnable = false
+  }
+
+  def setLocal() = {
+    isGlobalEnable = false
   }
 }
 

--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -157,13 +157,14 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
         val bitCount     = encoding.getWidth(enumDef)
         val vhdlEnumType = emitEnumType(enumDef, encoding, "")
 
-        ret ++= s"`define $vhdlEnumType [${bitCount - 1}:0]\n"
+//        ret ++= s"`define $vhdlEnumType [${bitCount - 1}:0]\n"
+        if(enumDef.isGlobalEnable) {
+          for (element <- enumDef.elements) {
+            ret ++= s"`define ${emitEnumLiteral(element, encoding, "")} ${idToBits(element, encoding)}\n"
+          }
 
-        for (element <- enumDef.elements) {
-          ret ++= s"`define ${emitEnumLiteral(element, encoding,"")} ${idToBits(element, encoding)}\n"
+          ret ++= "\n"
         }
-
-        ret ++= "\n"
       }
     }
 

--- a/core/src/main/scala/spinal/core/internals/VerilogBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VerilogBase.scala
@@ -106,17 +106,31 @@ trait VerilogBase extends VhdlVerilogBase{
   }
 
   def emitEnumLiteral[T <: SpinalEnum](enum: SpinalEnumElement[T], encoding: SpinalEnumEncoding, prefix: String = "`"): String = {
-    prefix + globalPrefix + enum.spinalEnum.getName() + "_" + encoding.getName() + "_" + enum.getName()
+//    prefix + enum.spinalEnum.getName() + "_" + encoding.getName() + "_" + enum.getName()
+    var prefix_fix = prefix;
+    if(prefix=="`" && !enum.spinalEnum.isGlobalEnable) prefix_fix = ""
+
+    if(enum.spinalEnum.isPrefixEnable) {
+      if(encoding==binaryOneHot) {
+        prefix_fix + enum.spinalEnum.getName() + "_" + "OH" + "_" + enum.getName()
+      } else {
+        prefix_fix + enum.spinalEnum.getName() + "_" + enum.getName()
+      }
+    } else {
+      prefix_fix + enum.getName()
+    }
   }
 
   def emitEnumType[T <: SpinalEnum](enum: SpinalEnumCraft[T], prefix: String): String = emitEnumType(enum.spinalEnum, enum.getEncoding, prefix)
 
   def emitEnumType(enum: SpinalEnum, encoding: SpinalEnumEncoding, prefix: String = "`"): String = {
-    prefix + globalPrefix + enum.getName() + "_" + encoding.getName() + "_type"
+//    prefix + enum.getName() + "_" + encoding.getName() + "_type"
+    val bitCount     = encoding.getWidth(enum)
+    s"[${bitCount - 1}:0]"
   }
 
   def getReEncodingFuntion(spinalEnum: SpinalEnum, source: SpinalEnumEncoding, target: SpinalEnumEncoding): String = {
-    s"${globalPrefix}${spinalEnum.getName()}_${source.getName()}_to_${target.getName()}"
+    s"${spinalEnum.getName()}_${source.getName()}_to_${target.getName()}"
   }
 
   def emitStructType(struct: SpinalStruct): String = {

--- a/core/src/main/scala/spinal/core/internals/VerilogBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VerilogBase.scala
@@ -112,12 +112,12 @@ trait VerilogBase extends VhdlVerilogBase{
 
     if(enum.spinalEnum.isPrefixEnable) {
       if(encoding==binaryOneHot) {
-        prefix_fix + enum.spinalEnum.getName() + "_" + "OH" + "_" + enum.getName()
+        prefix_fix + globalPrefix + enum.spinalEnum.getName() + "_" + "OH" + "_" + enum.getName()
       } else {
-        prefix_fix + enum.spinalEnum.getName() + "_" + enum.getName()
+        prefix_fix + globalPrefix + enum.spinalEnum.getName() + "_" + enum.getName()
       }
     } else {
-      prefix_fix + enum.getName()
+      prefix_fix + globalPrefix + enum.getName()
     }
   }
 
@@ -130,7 +130,7 @@ trait VerilogBase extends VhdlVerilogBase{
   }
 
   def getReEncodingFuntion(spinalEnum: SpinalEnum, source: SpinalEnumEncoding, target: SpinalEnumEncoding): String = {
-    s"${spinalEnum.getName()}_${source.getName()}_to_${target.getName()}"
+    s"${globalPrefix}${spinalEnum.getName()}_${source.getName()}_to_${target.getName()}"
   }
 
   def emitStructType(struct: SpinalStruct): String = {


### PR DESCRIPTION
As #319 , I add localparam support for verilog.
```scala
class top extends Component{
    object mainState extends SpinalEnum() {
    val Idle, Start, Data, Parity, Stop = newElement()
    setLocal()   //default is global define
//    rawElementName()  //default prefix with object name
  }

  val curr_st = mainState()
  curr_st := mainState.Idle

  val next_st = mainState()
  next_st := mainState.Idle

}

object main {
  def main(args: Array[String]) {
    SpinalVerilog(new top())
//    SpinalConfig().withoutEnumString().generateVerilog(new top())
  }
}
```
use `setLocal()`, you can generate localparam instead of define for enum

```verilog
// Generator : SpinalHDL v1.6.1    git head : 524dbb3d7d3aae8680c579a4592db4c57588aeb8
// Component : top
// Git hash  : 524dbb3d7d3aae8680c579a4592db4c57588aeb8


module top (
);
  localparam mainState_Idle = 3'd0;
  localparam mainState_Start = 3'd1;
  localparam mainState_Data = 3'd2;
  localparam mainState_Parity = 3'd3;
  localparam mainState_Stop = 3'd4;

  wire       [2:0]    curr_st;
  wire       [2:0]    next_st;

  assign curr_st = mainState_Idle;
  assign next_st = mainState_Idle;

endmodule
```

use `rawElementName()`, you can remove the prefix name of object name
```scala
class top extends Component{
    object mainState extends SpinalEnum() {
    val Idle, Start, Data, Parity, Stop = newElement()
    setLocal()   //default is global define
    rawElementName()  //default prefix with object name
  }

  val curr_st = mainState()
  curr_st := mainState.Idle

  val next_st = mainState()
  next_st := mainState.Idle

}

object main {
  def main(args: Array[String]) {
    SpinalVerilog(new top())
//    SpinalConfig().withoutEnumString().generateVerilog(new top())
  }
}
```
will generate
```verilog
// Generator : SpinalHDL v1.6.1    git head : 524dbb3d7d3aae8680c579a4592db4c57588aeb8
// Component : top
// Git hash  : c3cb5a1e22f552ac73dee6d9d519ab5e88db8499


module top (
);
  localparam Idle = 3'd0;
  localparam Start = 3'd1;
  localparam Data = 3'd2;
  localparam Parity = 3'd3;
  localparam Stop = 3'd4;

  wire       [2:0]    curr_st;
  wire       [2:0]    next_st;

  assign curr_st = Idle;
  assign next_st = Idle;

endmodule
```
