### PR TITLE
optimize andR orR xorR for verilog

### DIFF
--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -51,11 +51,32 @@ abstract class BitVector extends BaseType with Widthable {
   def range: Range = 0 until getWidth
 
   /** Logical OR of all bits */
-  def orR: Bool = this.asBits =/= 0
+//  def orR: Bool = this.asBits =/= 0
+  def orR: Bool = {
+    if(GlobalData.get.config.mode == VHDL) {
+      this.asBits =/= 0
+    } else {
+      wrapUnaryWithBool(new Operator.BitVector.orR)
+    }
+  }
   /** Logical AND of all bits */
-  def andR: Bool = this.asBits === ((BigInt(1) << getWidth) - 1)
+//  def andR: Bool = this.asBits === ((BigInt(1) << getWidth) - 1)
+  def andR: Bool = {
+    if(GlobalData.get.config.mode == VHDL) {
+      this.asBits === ((BigInt(1) << getWidth) - 1)
+    } else {
+      wrapUnaryWithBool(new Operator.BitVector.andR)
+    }
+  }
   /** Logical XOR of all bits */
-  def xorR: Bool = this.asBools.reduce(_ ^ _)
+//  def xorR: Bool = this.asBools.reduce(_ ^ _)
+  def xorR: Bool = {
+    if(GlobalData.get.config.mode == VHDL) {
+      this.asBools.reduce(_ ^ _)
+    } else {
+      wrapUnaryWithBool(new Operator.BitVector.xorR)
+    }
+  }
 
   /**
     * Compare a BitVector with a MaskedLiteral (M"110--0")

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -1580,6 +1580,10 @@ end
     case  e: BitVectorRangedAccessFixed               => accessBitVectorFixed(e)
     case  e: BitVectorRangedAccessFloating            => accessBitVectorFloating(e)
 
+    case  e: Operator.BitVector.orR                    => s"(|${emitExpression(e.source)})"
+    case  e: Operator.BitVector.andR                   => s"(&${emitExpression(e.source)})"
+    case  e: Operator.BitVector.xorR                   => s"(^${emitExpression(e.source)})"
+
     case e : Operator.Formal.Past                     => s"$$past(${emitExpression(e.source)}, ${e.delay})"
     case e : Operator.Formal.Rose                     => s"$$rose(${emitExpression(e.source)})"
     case e : Operator.Formal.Fell                     => s"$$fell(${emitExpression(e.source)})"

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -407,6 +407,20 @@ object Operator {
     * BitVector operator
     */
   object BitVector {
+    class orR extends UnaryOperator {
+      override def getTypeObject = TypeBool
+      override def opName: String = "| Bits"
+    }
+
+    class andR extends UnaryOperator {
+      override def getTypeObject = TypeBool
+      override def opName: String = "& Bits"
+    }
+
+    class xorR extends UnaryOperator {
+      override def getTypeObject = TypeBool
+      override def opName: String = "^ Bits"
+    }
 
     abstract class And extends BinaryOperatorWidthableInputs with Widthable {
       def resizeFactory: Resize


### PR DESCRIPTION
For the example
```scala
class top extends Component{
  val a = Bits(16 bits)
  val res1 = a.andR
  val res2 = a.orR
  val res3 = a.xorR
}

object main {
  def main(args: Array[String]) {
    SpinalVerilog(new top())
  }
}
```
Before optimization will generate
```verilog
// Generator : SpinalHDL v1.6.1    git head : 524dbb3d7d3aae8680c579a4592db4c57588aeb8
// Component : top
// Git hash  : 3677620be63b5823279e1781c49a2ac657b4c0e0

module top (
);

  wire       [15:0]   a;
  wire                res1;
  wire                res2;
  wire                res3;

  assign res1 = (a == 16'hffff);
  assign res2 = (a != 16'h0);
  assign res3 = (((((((((((((((a[0] ^ a[1]) ^ a[2]) ^ a[3]) ^ a[4]) ^ a[5]) ^ a[6]) ^ a[7]) ^ a[8]) ^ a[9]) ^ a[10]) ^ a[11]) ^ a[12]) ^ a[13]) ^ a[14]) ^ a[15]);

endmodule
```
After optimization will generate
```verilog
// Generator : SpinalHDL v1.6.1    git head : 524dbb3d7d3aae8680c579a4592db4c57588aeb8
// Component : top
// Git hash  : 155008698b959c9734b2e1d656a3234913966bc1

module top (
);

  wire       [15:0]   a;
  wire                res1;
  wire                res2;
  wire                res3;

  assign res1 = (&a);
  assign res2 = (|a);
  assign res3 = (^a);

endmodule
```
As you see, what you write is what you get for verilog enginner. And it is clean and good for debug if many logics are mixed together.