### PR TITLE
avoid using functions for bit assignment

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -532,28 +532,30 @@ class ComponentEmitterVerilog(
           //assert(process.nameableTargets.size == 1)
           for(node <- process.nameableTargets) node match {
             case node: BaseType =>
-              val funcName = "zz_" + emitReference(node, false).replaceAllLiterally(".", "__")
-              declarations ++= s"  function ${emitType(node)} $funcName(input dummy);\n"
-//              declarations ++= s"    reg ${emitType(node)} ${emitReference(node, false)};\n"
-              declarations ++= s"    begin\n"
+//              val funcName = "zz_" + emitReference(node, false).replaceAllLiterally(".", "__")
+//              declarations ++= s"  function ${emitType(node)} $funcName(input dummy);\n"
 
+//              declarations ++= s"    begin\n"
+
+              logics ++= s"  always @ (*) begin\n"
               val statements = ArrayBuffer[LeafStatement]()
               node.foreachStatements(s => statements += s.asInstanceOf[LeafStatement])
 
-              val oldRef = referencesOverrides.getOrElse(node, null)
-              referencesOverrides(node) = funcName
-              emitLeafStatements(statements, 0, process.scope, "=", declarations, "      ")
+//              val oldRef = referencesOverrides.getOrElse(node, null)
+//              referencesOverrides(node) = funcName
+              emitLeafStatements(statements, 0, process.scope, "=", logics, "    ")
 
-              if(oldRef != null) referencesOverrides(node) = oldRef else referencesOverrides.remove(node)
-//              declarations ++= s"      $funcName = ${emitReference(node, false)};\n"
-              declarations ++= s"    end\n"
-              declarations ++= s"  endfunction\n"
+//              if(oldRef != null) referencesOverrides(node) = oldRef else referencesOverrides.remove(node)
 
-              val name = component.localNamingScope.allocateName(anonymSignalPrefix)
-              declarations ++= s"  wire ${emitType(node)} $name;\n"
-              logics ++= s"  assign $name = ${funcName}(1'b0);\n"
-//              logics ++= s"  always @ ($name) ${emitReference(node, false)} = $name;\n"
-              logics ++= s"  always @(*) ${emitReference(node, false)} = $name;\n"
+              logics ++= "  end\n\n"
+//              declarations ++= s"    end\n"
+//              declarations ++= s"  endfunction\n"
+
+//              val name = component.localNamingScope.allocateName(anonymSignalPrefix)
+//              declarations ++= s"  wire ${emitType(node)} $name;\n"
+//              logics ++= s"  assign $name = ${funcName}(1'b0);\n"
+
+//              logics ++= s"  always @ (*) ${emitReference(node, false)} = $name;\n"
           }
         }
     }


### PR DESCRIPTION
For instance:
```scala
class top extends Component{
  val myBits = B(8 bits, (7 downto 5) -> B"101", 4 -> true, 3 -> True, default -> false)
}

object main {
  def main(args: Array[String]) {
    SpinalVerilog(new top())
  }
}
```
will generate
```verilog
// Generator : SpinalHDL v1.6.1    git head : 524dbb3d7d3aae8680c579a4592db4c57588aeb8
// Component : top
// Git hash  : 58e077ba1f6e9688b293766733b3b090d3310cc8

module top (
);

  reg        [7:0]    myBits;
  function [7:0] zz_myBits(input dummy);
    begin
      zz_myBits = 8'h0;
      zz_myBits[7 : 5] = 3'b101;
      zz_myBits[4] = 1'b1;
      zz_myBits[3] = 1'b1;
    end
  endfunction
  wire [7:0] _zz_1;

  assign _zz_1 = zz_myBits(1'b0);
  always @(*) myBits = _zz_1;

endmodule
```
For function is rarely used in verilog. I optimized this part, generated as follow:
```verilog
// Generator : SpinalHDL v1.6.1    git head : 524dbb3d7d3aae8680c579a4592db4c57588aeb8
// Component : top
// Git hash  : 58e077ba1f6e9688b293766733b3b090d3310cc8

module top (
);

  reg        [7:0]    myBits;

  always @ (*) begin
    myBits = 8'h0;
    myBits[7 : 5] = 3'b101;
    myBits[4] = 1'b1;
    myBits[3] = 1'b1;
  end


endmodule
```
As you see, itermediate variable and function definition are all eliminated.