### PR TITLE
fix(BusSlaveFactory):writeMemMultiWord has assignment overlap error

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -658,6 +658,7 @@ trait BusSlaveFactory extends Area{
     val maskWidth = mem.width / busDataWidth
     val mask = UInt(maskWidth bits)
     mask := 0
+    mask.allowOverride
     mask(writeAddress(mapping)(log2Up(mem.width / 8) - 1 downto log2Up(busDataWidth / 8))) := True
     port.mask := mask.asBits
 


### PR DESCRIPTION
the assignment of val mask in writeMemMultiWord used to be correct in old version,but now it rise assigment overlap error,add allowOverride to avoid this