### PR TITLE
Update InOutWrapper.scala to handle opendrain IO

### DIFF
--- a/lib/src/main/scala/spinal/lib/io/InOutWrapper.scala
+++ b/lib/src/main/scala/spinal/lib/io/InOutWrapper.scala
@@ -40,6 +40,16 @@ object InOutWrapper {
                 newIo := bundle.write
               }
             }
+            case bundle: ReadableOpenDrain[Bool] => {
+              val newIo = inout(Analog(bundle.dataType)).setWeakName(bundle.getName())
+              println("set_io " + bundle.getName())
+              bundle.setAsDirectionLess.unsetName().allowDirectionLessIo
+              bundle.read.assignFrom(newIo)
+              when(!bundle.write) {
+                newIo.assignFromBits(B"0")
+              }
+            }
+
             case bundle: ReadableOpenDrain[_] if bundle.isMasterInterface => {
               val newIo = inout(Analog(bundle.dataType)).setWeakName(bundle.getName())
               bundle.setAsDirectionLess.unsetName().allowDirectionLessIo


### PR DESCRIPTION
IO  that is generated by I2C module is not handled by any case currently. This is one possibly a fix to allow inout ports for i2c on a hardware.