### PR TITLE
Add read/write instructionCtrl to JtagTap 

### DIFF
--- a/lib/src/main/scala/spinal/lib/com/jtag/JtagTap.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/JtagTap.scala
@@ -132,6 +132,13 @@ class JtagTap(jtag: Jtag, instructionWidth: Int) extends Area with JtagTapFuncti
     map(area.ctrl, instructionId)
     area
   }
+  // from a jtag main standpoint. the jtag debugger either updates(write to) the DR, or captures it (read from)
+  def readAndWrite[T<: Data](captureData: T, updateData: T, captureReady: Bool, updateValid:Bool)(instructionId: Int) = {
+    val area = new JtagTapInstructionReadWrite(captureData, updateData, captureReady)
+    map(area.ctrl, instructionId)
+    updateValid := area.ctrl.enable && area.ctrl.update
+    area
+  }
   override def flowFragmentPush[T <: Data](sink : Flow[Fragment[Bits]], sinkClockDomain : ClockDomain)(instructionId: Int) = {
     val area = new JtagTapInstructionFlowFragmentPush(sink, sinkClockDomain)
     map(area.ctrl, instructionId)


### PR DESCRIPTION
this added instruction allows the jtagTap ctrl to have different input and output data