### PR TITLE
make terminate unused channels easier.

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -461,6 +461,13 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
     val last = counter.willOverflowIfInc
     return addFragmentLast(last)
   }
+  
+  def setIdle(): this.type = {
+    this.valid.assignDontCare()
+    this.ready.assignDontCare()
+    this.payload.assignDontCare()
+    this
+  }
 
   override def getTypeString = getClass.getSimpleName + "[" + this.payload.getClass.getSimpleName + "]"
 }

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -463,9 +463,13 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
   }
   
   def setIdle(): this.type = {
-    this.valid.assignDontCare()
-    this.ready.assignDontCare()
+    this.valid := False
     this.payload.assignDontCare()
+    this
+  }
+  
+  def setBlocked(): this.type = {
+    this.ready := False
     this
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
@@ -162,15 +162,24 @@ case class Axi4(config: Axi4Config) extends Bundle with IMasterSlave with Axi4Bu
     slave(r,b)
   }
 
-  def toReadOnly(): Axi4ReadOnly ={
+  def toReadOnly(idleOthers: Boolean = false): Axi4ReadOnly ={
     val ret = Axi4ReadOnly(config)
     ret << this
+    if(idleOthers){
+      this.writeCmd.setIdle()
+      this.writeData.setIdle()
+      this.writeRsp.setIdle()
+    }
     ret
   }
 
-  def toWriteOnly(): Axi4WriteOnly ={
+  def toWriteOnly(idleOthers: Boolean = false): Axi4WriteOnly ={
     val ret = Axi4WriteOnly(config)
     ret << this
+    if(idleOthers){
+      this.readCmd.setIdle()
+      this.readRsp.setIdle()
+    }
     ret
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
@@ -183,6 +183,24 @@ case class Axi4(config: Axi4Config) extends Bundle with IMasterSlave with Axi4Bu
     ret
   }
 
+  def setIdle(): this.type = {
+    this.writeCmd.setIdle()
+    this.writeData.setIdle()
+    this.writeRsp.setBlocked()
+    this.readCmd.setIdle()
+    this.readRsp.setBlocked()
+    this
+  }
+
+  def setBlocked(): this.type = {
+    this.writeCmd.setBlocked()
+    this.writeData.setBlocked()
+    this.writeRsp.setIdle()
+    this.readCmd.setBlocked()
+    this.readRsp.setIdle()
+    this
+  }
+
   def toShared() : Axi4Shared = {
     Axi4ToAxi4Shared(this)
   }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
@@ -166,8 +166,8 @@ case class Axi4(config: Axi4Config) extends Bundle with IMasterSlave with Axi4Bu
     val ret = Axi4ReadOnly(config)
     ret << this
     if(idleOthers){
-      this.writeCmd.setIdle()
-      this.writeData.setIdle()
+      this.writeCmd.setBlocked()
+      this.writeData.setBlocked()
       this.writeRsp.setIdle()
     }
     ret
@@ -177,7 +177,7 @@ case class Axi4(config: Axi4Config) extends Bundle with IMasterSlave with Axi4Bu
     val ret = Axi4WriteOnly(config)
     ret << this
     if(idleOthers){
-      this.readCmd.setIdle()
+      this.readCmd.setBlocked()
       this.readRsp.setIdle()
     }
     ret

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ReadOnly.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ReadOnly.scala
@@ -30,6 +30,16 @@ case class Axi4ReadOnly(config: Axi4Config) extends Bundle with IMasterSlave wit
     sink
   }
 
+  def toAxi4(): Axi4 = {
+    val ret = Axi4(config)
+    this >> ret
+  
+    ret.writeCmd.setIdle()
+    ret.writeData.setIdle()
+    ret.writeRsp.setIdle()
+
+    ret
+  }
 
   def toFullConfig(): Axi4ReadOnly = {
     val ret = Axi4ReadOnly(config.toFullConfig())

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ReadOnly.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ReadOnly.scala
@@ -30,6 +30,18 @@ case class Axi4ReadOnly(config: Axi4Config) extends Bundle with IMasterSlave wit
     sink
   }
 
+  def setIdle(): this.type = {
+    this.readCmd.setIdle()
+    this.readRsp.setBlocked()
+    this
+  }
+
+  def setBlocked(): this.type = {
+    this.readCmd.setBlocked()
+    this.readRsp.setIdle()
+    this
+  }
+
   def toAxi4(): Axi4 = {
     val ret = Axi4(config)
     this >> ret

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ReadOnly.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ReadOnly.scala
@@ -36,7 +36,7 @@ case class Axi4ReadOnly(config: Axi4Config) extends Bundle with IMasterSlave wit
   
     ret.writeCmd.setIdle()
     ret.writeData.setIdle()
-    ret.writeRsp.setIdle()
+    ret.writeRsp.setBlocked()
 
     ret
   }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
@@ -42,7 +42,7 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
     this >> ret
   
     ret.readCmd.setIdle()
-    ret.readRsp.setIdle()
+    ret.readRsp.setBlocked()
 
     ret
   }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
@@ -37,6 +37,16 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
     sink
   }
 
+  def toAxi4(): Axi4 = {
+    val ret = Axi4(config)
+    this >> ret
+  
+    ret.readCmd.setIdle()
+    ret.readRsp.setIdle()
+
+    ret
+  }
+
   def toFullConfig(): Axi4WriteOnly = {
     val ret = Axi4WriteOnly(config.toFullConfig())
     ret << this

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
@@ -37,6 +37,20 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
     sink
   }
 
+  def setIdle(): this.type = {
+    this.writeCmd.setIdle()
+    this.writeData.setIdle()
+    this.writeRsp.setBlocked()
+    this
+  }
+
+  def setBlocked(): this.type = {
+    this.writeCmd.setBlocked()
+    this.writeData.setBlocked()
+    this.writeRsp.setIdle()
+    this
+  }
+
   def toAxi4(): Axi4 = {
     val ret = Axi4(config)
     this >> ret


### PR DESCRIPTION
this commit is to fit the gap while connecting Axi4ReadOnly bus to Axi4.
the setIdle function is added by the way, to terminate it.

two situations are covered.
if the master bus is in type Axi4, then user should use toReadOnly function.
if the master bus is in type Axi4ReadOnly, then user should use toAxi4 function.