### PR TITLE
add extender to extend the input transfer into several outputs.

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1491,3 +1491,62 @@ object StreamFifoMultiChannelBench extends App{
 
   Bench(rtls, targets)
 }
+
+object StreamExtender {
+    def apply[T <: Data](input: Stream[T], count: UInt)(
+        driver: (UInt, T) => T = (_: UInt, p: T) => p
+    ): Stream[T] = {
+        val c = new StreamExtender(input.payloadType, input.payloadType, count.getBitsWidth, driver)
+        c.io.input << input
+        c.io.count := count
+        c.io.output
+    }
+
+    def apply[T <: Data, T2 <: Data](input: Stream[T], output: Stream[T2], count: UInt)(
+        driver: (UInt, T) => T2
+    ): StreamExtender[T, T2] = {
+        val c = new StreamExtender(input.payloadType, output.payloadType, count.getBitsWidth, driver)
+        c.io.input << input
+        c.io.count := count
+        output << c.io.output
+        c
+    }
+}
+
+/* Extend one input transfer into serveral outputs, io.count represent delivering output (count + 1) times. */
+class StreamExtender[T <: Data, T2 <: Data](
+    dataType: HardType[T],
+    outDataType: HardType[T2],
+    countWidth: Int,
+    var driver: (UInt, T) => T2
+) extends Component {
+    val io = new Bundle {
+        val count  = in UInt (countWidth bit)
+        val input  = slave Stream dataType
+        val output = master Stream outDataType
+    }
+
+    val expected = Reg(cloneOf(io.count))
+    val payload  = Reg(io.input.payloadType)
+    val counter  = Counter(io.count.getBitsWidth bits)
+    val lastOne  = counter === expected
+    val outValid = RegInit(False)
+
+    when(io.output.fire) {
+        when(lastOne) {
+            counter.clear()
+            outValid := False
+        }.otherwise {
+            counter.increment()
+        }
+    }
+
+    when(io.input.fire) {
+        expected := io.count
+        payload := io.input.payload
+        outValid := True
+    }
+    io.output.payload := driver(counter, payload)
+    io.output.valid := outValid
+    io.input.ready := (!outValid || (lastOne && io.output.fire))
+}

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1492,11 +1492,11 @@ object StreamFifoMultiChannelBench extends App{
   Bench(rtls, targets)
 }
 
-object StreamExtender {
+object StreamTransactionExtender {
     def apply[T <: Data](input: Stream[T], count: UInt)(
         driver: (UInt, T) => T = (_: UInt, p: T) => p
     ): Stream[T] = {
-        val c = new StreamExtender(input.payloadType, input.payloadType, count.getBitsWidth, driver)
+        val c = new StreamTransactionExtender(input.payloadType, input.payloadType, count.getBitsWidth, driver)
         c.io.input << input
         c.io.count := count
         c.io.output
@@ -1504,8 +1504,8 @@ object StreamExtender {
 
     def apply[T <: Data, T2 <: Data](input: Stream[T], output: Stream[T2], count: UInt)(
         driver: (UInt, T) => T2
-    ): StreamExtender[T, T2] = {
-        val c = new StreamExtender(input.payloadType, output.payloadType, count.getBitsWidth, driver)
+    ): StreamTransactionExtender[T, T2] = {
+        val c = new StreamTransactionExtender(input.payloadType, output.payloadType, count.getBitsWidth, driver)
         c.io.input << input
         c.io.count := count
         output << c.io.output
@@ -1514,7 +1514,7 @@ object StreamExtender {
 }
 
 /* Extend one input transfer into serveral outputs, io.count represent delivering output (count + 1) times. */
-class StreamExtender[T <: Data, T2 <: Data](
+class StreamTransactionExtender[T <: Data, T2 <: Data](
     dataType: HardType[T],
     outDataType: HardType[T2],
     countWidth: Int,

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamExtenderTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamExtenderTester.scala
@@ -11,7 +11,7 @@ import spinal.core.sim._
 
 class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
     def prepare(
-        dut: StreamExtender[UInt, UInt],
+        dut: StreamTransactionExtender[UInt, UInt],
         alwaysInput: Boolean = false,
         alwaysOutput: Boolean = false,
         inQueue: mutable.Queue[BigInt],
@@ -68,7 +68,7 @@ class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
 
     test("testRandomInOut") {
         val compiled = SimConfig.allOptimisation.compile {
-            val dut = new StreamExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
+            val dut = new StreamTransactionExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
             dut
         }
         compiled.doSimUntilVoid { dut =>
@@ -83,7 +83,7 @@ class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
 
     test("testRandomIn") {
         val compiled = SimConfig.allOptimisation.compile {
-            val dut = new StreamExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
+            val dut = new StreamTransactionExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
             dut
         }
         compiled.doSimUntilVoid { dut =>
@@ -98,7 +98,7 @@ class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
 
     test("testRandomOut") {
         val compiled = SimConfig.allOptimisation.compile {
-            val dut = new StreamExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
+            val dut = new StreamTransactionExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
             dut
         }
         compiled.doSimUntilVoid { dut =>
@@ -113,7 +113,7 @@ class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
 
     test("testFullPipeline") {
         val compiled = SimConfig.allOptimisation.compile {
-            val dut = new StreamExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
+            val dut = new StreamTransactionExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
             dut
         }
         compiled.doSimUntilVoid { dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamExtenderTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamExtenderTester.scala
@@ -1,0 +1,128 @@
+package spinal.tester.scalatest
+
+import scala.collection.mutable
+import scala.util.Random
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.sim._
+import spinal.core.sim._
+
+class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
+    def prepare(
+        dut: StreamExtender[UInt, UInt],
+        alwaysInput: Boolean = false,
+        alwaysOutput: Boolean = false,
+        inQueue: mutable.Queue[BigInt],
+        outQueue: mutable.Queue[BigInt],
+        countQueue: mutable.Queue[BigInt]
+    ) {
+        dut.clockDomain.forkStimulus(period = 10)
+        dut.io.input.valid #= false
+
+        if (alwaysOutput) {
+            dut.io.output.ready #= true
+        } else {
+            val randomReady = StreamReadyRandomizer(dut.io.output, dut.clockDomain)
+        }
+
+        val driver = StreamDriver(dut.io.input, dut.clockDomain) { payload =>
+            if (inQueue.nonEmpty) {
+                payload #= inQueue.dequeue()
+                dut.io.count #= countQueue.dequeue()
+                true
+            } else {
+                false
+            }
+        }
+        driver.transactionDelay = () => {
+            if (!alwaysInput) {
+                val x = Random.nextDouble()
+                (x * x * 10).toInt
+            } else {
+                0
+            }
+        }
+
+        val monitor = StreamMonitor(dut.io.output, dut.clockDomain) { payload =>
+            {
+                val address = outQueue.dequeue()
+                // println("##pop out queue:" + address.toString(16))
+                assert(payload.toBigInt == address)
+            }
+        }
+
+        for (j <- 0 until 10000) {
+            val count   = Random.nextInt(20)
+            val address = Random.nextInt(0xffffff)
+
+            inQueue.enqueue(address)
+            countQueue.enqueue(count)
+
+            for (i <- 0 to count) {
+                outQueue.enqueue(address)
+            }
+        }
+    }
+
+    test("testRandomInOut") {
+        val compiled = SimConfig.allOptimisation.compile {
+            val dut = new StreamExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
+            dut
+        }
+        compiled.doSimUntilVoid { dut =>
+            val inQueue    = mutable.Queue[BigInt]()
+            val outQueue   = mutable.Queue[BigInt]()
+            val countQueue = mutable.Queue[BigInt]()
+            prepare(dut, false, false, inQueue, outQueue, countQueue)
+            dut.clockDomain.waitSampling((1 KiB).toInt)
+            simSuccess()
+        }
+    }
+
+    test("testRandomIn") {
+        val compiled = SimConfig.allOptimisation.compile {
+            val dut = new StreamExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
+            dut
+        }
+        compiled.doSimUntilVoid { dut =>
+            val inQueue    = mutable.Queue[BigInt]()
+            val outQueue   = mutable.Queue[BigInt]()
+            val countQueue = mutable.Queue[BigInt]()
+            prepare(dut, false, true, inQueue, outQueue, countQueue)
+            dut.clockDomain.waitSampling((1 KiB).toInt)
+            simSuccess()
+        }
+    }
+
+    test("testRandomOut") {
+        val compiled = SimConfig.allOptimisation.compile {
+            val dut = new StreamExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
+            dut
+        }
+        compiled.doSimUntilVoid { dut =>
+            val inQueue    = mutable.Queue[BigInt]()
+            val outQueue   = mutable.Queue[BigInt]()
+            val countQueue = mutable.Queue[BigInt]()
+            prepare(dut, true, false, inQueue, outQueue, countQueue)
+            dut.clockDomain.waitSampling((1 KiB).toInt)
+            simSuccess()
+        }
+    }
+
+    test("testFullPipeline") {
+        val compiled = SimConfig.allOptimisation.compile {
+            val dut = new StreamExtender(UInt(32 bits), UInt(32 bits), 12, (id, payload: UInt) => payload)
+            dut
+        }
+        compiled.doSimUntilVoid { dut =>
+            val inQueue    = mutable.Queue[BigInt]()
+            val outQueue   = mutable.Queue[BigInt]()
+            val countQueue = mutable.Queue[BigInt]()
+            prepare(dut, true, true, inQueue, outQueue, countQueue)
+            dut.clockDomain.waitSampling((1 KiB).toInt)
+            simSuccess()
+        }
+    }
+}


### PR DESCRIPTION
There are several cases that extend one input transaction into several is required.
For example, some instructions can be executed in multiple times.
The stream extender is designed to fit those needs easily, especially for full pipelined usage.
It's worth noting that the final output trasaction number should be count + 1. 