### PR TITLE
patches to adopt Axi4 options in a wide range.

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/Agent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/Agent.scala
@@ -239,7 +239,8 @@ class Axi4WriteOnlySlaveAgent(aw : Stream[Axi4Aw], w : Stream[Axi4W], b : Stream
   val busConfig = aw.config
   val awQueue = mutable.Queue[Int]()
   var wCount = 0
-  val bQueue = Array.fill(1 << busConfig.idWidth)(mutable.Queue[() => Unit]())
+  val idCount = if(busConfig.useId) (1 << busConfig.idWidth) else 1
+  val bQueue = Array.fill(idCount)(mutable.Queue[() => Unit]())
 
   def update(): Unit ={
     if(awQueue.nonEmpty && wCount > 0){
@@ -287,7 +288,8 @@ class Axi4ReadOnlySlaveAgent(ar : Stream[Axi4Ar], r : Stream[Axi4R], clockDomain
     this(bus.ar, bus.r, clockDomain);
   }
   val busConfig = ar.config
-  val rQueue = Array.fill(1 << busConfig.idWidth)(mutable.Queue[() => Unit]())
+  val idCount = if(busConfig.useId) (1 << busConfig.idWidth) else 1
+  val rQueue = Array.fill(idCount)(mutable.Queue[() => Unit]())
   def readByte(address : BigInt) : Byte = Random.nextInt().toByte
 
   val arMonitor = StreamMonitor(ar, clockDomain){ar =>

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/Agent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/Agent.scala
@@ -42,7 +42,7 @@ abstract class Axi4WriteOnlyMasterAgent(aw : Stream[Axi4Aw], w : Stream[Axi4W], 
   def genCmd() : Unit = {
     if(!allowGen) return
     val region = if(busConfig.useRegion) aw.region.randomizedInt() else 0
-    val burst = bursts(Random.nextInt(bursts.size))
+    val burst = if(busConfig.useBurst) bursts(Random.nextInt(bursts.size)) else 1
     val len = if(burst == 2) List(2,4,8,16)(Random.nextInt(4))-1 else Random.nextInt(64)
     val lenBeat = len + 1
     val size = Random.nextInt(log2Up(busConfig.bytePerWord) + 1)
@@ -159,7 +159,7 @@ abstract class Axi4ReadOnlyMasterAgent(ar : Stream[Axi4Ar], r : Stream[Axi4R], c
   def genCmd() : Unit = {
     if(!allowGen) return
     val region = if(busConfig.useRegion) ar.region.randomizedInt() else 0
-    val burst = bursts(Random.nextInt(bursts.size))
+    val burst = if(busConfig.useBurst) bursts(Random.nextInt(bursts.size)) else 1
     val len = if(burst == 2) List(2,4,8,16)(Random.nextInt(4))-1 else Random.nextInt(16)
     val lenBeat = len + 1
     val size = Random.nextInt(log2Up(busConfig.bytePerWord) + 1)
@@ -311,7 +311,7 @@ class Axi4ReadOnlySlaveAgent(ar : Stream[Axi4Ar], r : Stream[Axi4R], clockDomain
     val size = if(busConfig.useSize) ar.size.toInt else log2Up(busConfig.dataWidth / 8)
     val len = if(busConfig.useLen) ar.len.toInt else 0
     val id = if(busConfig.useId) ar.id.toInt else 0
-    val burst = if(busConfig.useBurst) ar.burst.toInt else 0
+    val burst = if(busConfig.useBurst) ar.burst.toInt else 1
     val addr = ar.addr.toBigInt
     val bytePerBeat = (1 << size)
     val bytes = (len + 1) * bytePerBeat
@@ -380,7 +380,7 @@ abstract class Axi4WriteOnlyMonitor(aw : Stream[Axi4Aw], w : Stream[Axi4W], b : 
   val awMonitor = StreamMonitor(aw, clockDomain){_ =>
     val size = if(busConfig.useSize) aw.size.toInt else log2Up(busConfig.bytePerWord)
     val len = if(busConfig.useLen) aw.len.toInt else 0
-    val burst = if(busConfig.useBurst) aw.burst.toInt else 0
+    val burst = if(busConfig.useBurst) aw.burst.toInt else 1
     val addr = aw.addr.toBigInt
     val bytePerBeat = (1 << size)
     val bytes = (len + 1) * bytePerBeat
@@ -439,7 +439,7 @@ abstract class Axi4ReadOnlyMonitor(ar : Stream[Axi4Ar], r : Stream[Axi4R], clock
     val size = if(busConfig.useSize) ar.size.toInt else log2Up(busConfig.dataWidth / 8)
     val len = if(busConfig.useLen) ar.len.toInt else 0
     val id = if(busConfig.useId) ar.id.toInt else 0
-    val burst = if(busConfig.useBurst) ar.burst.toInt else 0
+    val burst = if(busConfig.useBurst) ar.burst.toInt else 1
     val addr = ar.addr.toBigInt
     val bytePerBeat = (1 << size)
     val bytes = (len + 1) * bytePerBeat

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/Agent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/Agent.scala
@@ -97,12 +97,10 @@ abstract class Axi4WriteOnlyMasterAgent(aw : Stream[Axi4Aw], w : Stream[Axi4W], 
     var beatOffset = (address & (busConfig.bytePerWord-1)).toInt
     for (beat <- 0 until lenBeat) {
       val beatOffsetCache = beatOffset
-//      println(beatOffsetCache)
       wQueue.enqueue { () =>
         w.data.randomize()
         val bytesInBeat = sizeByte - (beatOffsetCache % sizeByte)
         if(busConfig.useStrb)  w.strb #= ((Random.nextInt(1 << bytesInBeat)) << beatOffsetCache) & ((1 << busConfig.bytePerWord)-1)
-//        if(busConfig.useStrb)  w.strb #= (((1 << bytesInBeat)-1) << beatOffsetCache) & ((1 << busConfig.bytePerWord)-1)
         if(busConfig.useWUser) w.user.randomize()
         if(busConfig.useLast)  w.last #= beat == lenBeat-1
       }

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4SimAgentTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4SimAgentTester.scala
@@ -1,0 +1,215 @@
+package spinal.tester.scalatest
+
+import spinal.core._
+import spinal.core.sim._
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core.sim.SimCompiled
+import spinal.lib._
+import spinal.lib.bus.amba4.axi.sim.{
+    Axi4ReadOnlyMasterAgent,
+    Axi4ReadOnlyMonitor,
+    Axi4ReadOnlySlaveAgent,
+    Axi4WriteOnlyMasterAgent,
+    Axi4WriteOnlyMonitor,
+    Axi4WriteOnlySlaveAgent
+}
+import spinal.lib.bus.amba4.axi.{Axi4, Axi4Config}
+import spinal.lib.bus.misc.SizeMapping
+
+import scala.collection.mutable
+import scala.util.Random
+
+case class Axi4PassthroughFixture(config: Axi4Config) extends Component {
+    val io = new Bundle {
+        val input  = slave(Axi4(config))
+        val output = master(Axi4(config))
+    }
+    io.input.aw >-> io.output.aw
+    io.input.ar >-> io.output.ar
+    io.input.w >-> io.output.w
+    io.output.r >> io.input.r
+    io.output.b >> io.input.b
+}
+
+class Axi4SimAgentTester extends AnyFunSuite {
+
+    def writeTester(dut: Axi4PassthroughFixture): Unit = {
+        dut.clockDomain.forkStimulus(10)
+
+        val regions = mutable.Set[SizeMapping]()
+        val inputAgent = new Axi4WriteOnlyMasterAgent(dut.io.input, dut.clockDomain) {
+            override def genAddress(): BigInt = Random.nextInt(1 << 19) // & 0xFFF00) | 6
+
+            override def bursts: List[Int] = List(1)
+
+            override def mappingAllocate(mapping: SizeMapping): Boolean = {
+                if (regions.exists(_.overlap(mapping))) return false
+                regions += mapping
+                true
+            }
+
+            override def mappingFree(mapping: SizeMapping): Unit = regions.remove(mapping)
+        }
+        val outputAgent = new Axi4WriteOnlySlaveAgent(dut.io.output, dut.clockDomain)
+
+        val writes = mutable.HashMap[BigInt, Byte]()
+        val inputMonitor = new Axi4WriteOnlyMonitor(dut.io.input, dut.clockDomain) {
+            override def onWriteByte(address: BigInt, data: Byte): Unit = {
+                // println(s"I $address -> $data")
+                writes(address) = data
+            }
+        }
+
+        val outputMonitor = new Axi4WriteOnlyMonitor(dut.io.output, dut.clockDomain) {
+            override def onWriteByte(address: BigInt, data: Byte): Unit = {
+                // println(s"O $address -> $data")
+                assert(writes(address) == data)
+                writes.remove(address)
+            }
+        }
+
+        dut.clockDomain.waitSamplingWhere(inputAgent.rspCounter > 10000)
+        inputAgent.allowGen = false
+        dut.clockDomain.waitSamplingWhere(!inputAgent.pending)
+        dut.clockDomain.waitSampling(100)
+        assert(writes.isEmpty)
+        println("done")
+    }
+
+    test("writeOnly") {
+        SimConfig.compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4))).doSim("test", 42)(writeTester)
+    }
+
+    test("writeOnly_disable_strb") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useStrb = false)))
+            .doSim("test", 42)(writeTester)
+    }
+
+    test("writeOnly_disable_id") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useId = false)))
+            .doSim("test", 42)(writeTester)
+    }
+
+    test("writeOnly_disable_size") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useSize = false)))
+            .doSim("test", 42)(writeTester)
+    }
+
+    test("writeOnly_disable_resp") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useResp = false)))
+            .doSim("test", 42)(writeTester)
+    }
+
+    test("writeOnly_disable_last") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useLast = false)))
+            .doSim("test", 42)(writeTester)
+    }
+
+    test("writeOnly_disable_burst") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useBurst = false)))
+            .doSim("test", 42)(writeTester)
+    }
+
+    test("writeOnly_disable_len") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useLen = false)))
+            .doSim("test", 42)(writeTester)
+    }
+
+    def readTester(dut: Axi4PassthroughFixture): Unit = {
+        dut.clockDomain.forkStimulus(10)
+
+        val regions = mutable.Set[SizeMapping]()
+        val inputAgent = new Axi4ReadOnlyMasterAgent(dut.io.input, dut.clockDomain) {
+            override def genAddress(): BigInt = Random.nextInt(1 << 19)
+            override def bursts: List[Int]    = List(1)
+            override def mappingAllocate(mapping: SizeMapping): Boolean = {
+                if (regions.exists(_.overlap(mapping))) return false
+                regions += mapping
+                true
+            }
+
+            override def mappingFree(mapping: SizeMapping): Unit = regions.remove(mapping)
+        }
+
+        val outputAgent = new Axi4ReadOnlySlaveAgent(dut.io.output, dut.clockDomain)
+
+        val reads = mutable.HashMap[BigInt, Byte]()
+        val inputMonitor = new Axi4ReadOnlyMonitor(dut.io.input, dut.clockDomain) {
+            override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
+                reads(address) = data
+            }
+            override def onLast(id: Int): Unit = {}
+        }
+
+        val outputMonitor = new Axi4ReadOnlyMonitor(dut.io.output, dut.clockDomain) {
+            override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
+                if (reads.contains(address)) {
+                    assert(reads(address) == data)
+                    reads.remove(address)
+                }
+            }
+
+            override def onLast(id: Int): Unit = assert(reads.isEmpty)
+        }
+
+        dut.clockDomain.waitSamplingWhere(inputAgent.rspCounter > 10000)
+        inputAgent.allowGen = false
+        dut.clockDomain.waitSamplingWhere(!inputAgent.pending)
+        dut.clockDomain.waitSampling(100)
+        assert(reads.isEmpty)
+        println("done")
+    }
+
+    test("readOnly") {
+        SimConfig.compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4))).doSim("test", 42)(readTester)
+    }
+
+    test("readOnly_disable_strb") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useStrb = false)))
+            .doSim("test", 42)(readTester)
+    }
+
+    test("readOnly_disable_id") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useId = false)))
+            .doSim("test", 42)(readTester)
+    }
+
+    test("readOnly_disable_size") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useSize = false)))
+            .doSim("test", 42)(readTester)
+    }
+
+    test("readOnly_disable_resp") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useResp = false)))
+            .doSim("test", 42)(readTester)
+    }
+
+    test("readOnly_disable_last") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useLast = false)))
+            .doSim("test", 42)(readTester)
+    }
+
+    test("readOnly_disable_burst") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useBurst = false)))
+            .doSim("test", 42)(readTester)
+    }
+
+    test("readOnly_disable_len") {
+        SimConfig
+            .compile(Axi4PassthroughFixture(Axi4Config(20, 32, 4, useLen = false)))
+            .doSim("test", 42)(readTester)
+    }
+}


### PR DESCRIPTION
The configuration with useLen = false works only when the last signal is not sensitive. It cannot run a variable-length transaction determined by the last signal.