### PR TITLE
[RFC] Add support for multiple CS pin for SDRAM controller

### DIFF
--- a/lib/src/main/scala/spinal/lib/memory/sdram/SdramLayout.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/SdramLayout.scala
@@ -46,10 +46,12 @@ case class SdramLayout( generation : SdramGeneration,
                         bankWidth : Int,
                         columnWidth : Int,
                         rowWidth : Int,
-                        dataWidth : Int){
+                        dataWidth : Int,
+                        csWidth : Int = 1){
   def bytePerWord = dataWidth/8
-  def wordAddressWidth = bankWidth + columnWidth + rowWidth
-  def byteAddressWidth = bankWidth + columnWidth + rowWidth + log2Up(bytePerWord)
+  def csAddressWidth = if (csWidth == 1) 0 else log2Up(csWidth)
+  def wordAddressWidth = bankWidth + columnWidth + rowWidth + csAddressWidth
+  def byteAddressWidth = wordAddressWidth + log2Up(bytePerWord)
   def chipAddressWidth = Math.max(columnWidth,rowWidth)
   def bankCount = 1 << bankWidth
   def capacity = BigInt(1) << byteAddressWidth

--- a/lib/src/main/scala/spinal/lib/memory/sdram/sdr/Sdram.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/sdr/Sdram.scala
@@ -26,7 +26,7 @@ case class SdramInterface(g : SdramLayout) extends Bundle with IMasterSlave{
   val DQM   = Bits(g.bytePerWord bits)
   val CASn  = Bool()
   val CKE   = Bool()
-  val CSn   = Bool()
+  val CSn   = Bits(g.csWidth bits)
   val RASn  = Bool()
   val WEn   = Bool()
 

--- a/lib/src/main/scala/spinal/lib/memory/sdram/sdr/sim/SdramModel.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/sdr/sim/SdramModel.scala
@@ -67,7 +67,7 @@ case class SdramModel(io : SdramInterface,
   }
   def report(msg : String) = println(simTime() + " " + msg)
   clockDomain.onSamplings{
-    if(!io.CSn.toBoolean && ckeLast){
+    if(!io.CSn(0).toBoolean && ckeLast){
       val code = (if(io.RASn.toBoolean) 0x4 else 0) | (if(io.CASn.toBoolean) 0x2 else 0) | (if(io.WEn.toBoolean) 0x1 else 0)
       val ba = io.BA.toInt
       val addr = io.ADDR.toInt


### PR DESCRIPTION
This patch adds support for multiple CS pin, useful if anyone wants 128MB or 256MB with SDRAM. It's tested on a board with 4 IS42S16320F SDRAM chips, forming 32bit x 2CS structure.

Note that it currently only works with the sdr controller, not xdr controller. I'm not sure how to modify xdr controller, so any help is appreciated.