### PR TITLE
add options support to Axi4 unbursitfy.

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Channel.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Channel.scala
@@ -154,7 +154,7 @@ object Axi4AxUnburstified{
           address = transaction.addr,
           burst   = transaction.burst,
           len     = len,
-          size    = transaction.size,
+          size    = if(stream.config.useSize) transaction.size else U(log2Up(stream.config.bytePerWord), 3 bits),
           bytePerWord = stream.config.bytePerWord
         )
 


### PR DESCRIPTION
if size, len and burst is not available on bus than use default value described in specification.