### PR TITLE
verilator++

### DIFF
--- a/tools.sh
+++ b/tools.sh
@@ -6,7 +6,7 @@ install_verilator(){
   unset VERILATOR_ROOT  # For bash
   cd verilator
   git pull        # Make sure we're up-to-date
-  git checkout v4.216
+  git checkout v4.218
   autoconf        # Create ./configure script
   ./configure --prefix ~/tools
   make -j$(nproc)


### PR DESCRIPTION
v4.218 has a patch included [1] to fix "inout" ports. Current version
(4.216) is not able to simulate these port types.

1: https://github.com/verilator/verilator/commit/4e5f30858bc130dcc2d6934aacf3ace562855e12

Signed-off-by: Daniel Schultz <daniel.schultz@aesc-silicon.de>