### PR TITLE
Fix assertion in wishbone `>>` operator

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
@@ -144,7 +144,7 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
     * @example{{{wishboneMaster >> wishboneSlave}}}
     */
   def >> (that : Wishbone) : Unit = {
-    assert(that.config.addressWidth >= this.config.addressWidth)
+    assert(that.config.addressWidth <= this.config.addressWidth)
     assert(that.config.dataWidth == this.config.dataWidth)
     /////////////////////
     // MINIMAL SIGNALS //


### PR DESCRIPTION
According to docs, `master >> slave` should allow for slaves with address widths
<= master, however this assertion fires in that particular case.