### PR TITLE
add basic support for synopsys vcs

### DIFF
--- a/sim/src/main/resources/VpiPlugin.cpp
+++ b/sim/src/main/resources/VpiPlugin.cpp
@@ -42,6 +42,10 @@ PLI_INT32 ro_cb(p_cb_data);
 PLI_INT32 delay_rw_cb(p_cb_data);
 PLI_INT32 delay_ro_cb(p_cb_data);
 
+#ifdef VPI_PLUGIN
+extern "C" void entry_point_cb();
+#endif
+
 void set_error(string& error_string){
     vpi_printf("%s\n", error_string.c_str());
     shared_struct->data.resize(error_string.size());
@@ -485,9 +489,11 @@ PLI_INT32 delay_ro_cb(p_cb_data){
     return 0;
 }
 
+#ifndef VCS_PLUGIN
 extern "C" {
     void (*vlog_startup_routines[]) () = {
         entry_point_cb,
         0
     };
 }
+#endif

--- a/sim/src/main/resources/VpiPlugin.cpp
+++ b/sim/src/main/resources/VpiPlugin.cpp
@@ -42,7 +42,7 @@ PLI_INT32 ro_cb(p_cb_data);
 PLI_INT32 delay_rw_cb(p_cb_data);
 PLI_INT32 delay_ro_cb(p_cb_data);
 
-#ifdef VPI_PLUGIN
+#ifdef VCS_PLUGIN
 extern "C" void entry_point_cb();
 #endif
 

--- a/sim/src/main/resources/VpiPlugin.cpp
+++ b/sim/src/main/resources/VpiPlugin.cpp
@@ -311,7 +311,7 @@ bool read_cmd_raw(vpiHandle handle){
     for(size_t i = 0; i < valueStrLen; i++){
         char c = value_struct.value.str[i];
         if ((c != '0') && (c != '1')) {
-            vpi_printf("Warning, value '%c' at pisition %d is neither '0' or '1'. value set to '0'.\n", c, i);
+            vpi_printf("Warning, value '%c' at position %d is neither '0' or '1'. value set to '0'.\n", c, i);
         }
     }
 

--- a/sim/src/main/resources/VpiPlugin.cpp
+++ b/sim/src/main/resources/VpiPlugin.cpp
@@ -6,6 +6,10 @@
 #define INITIAL_SEED 0x5EED5EED
 #endif
 
+#if defined(GHDL_PLUGIN)
+    #define BUGGY_RW_SYNCH
+#endif
+
 #include<boost/interprocess/sync/scoped_lock.hpp>
 #include<cassert>
 #include<iostream>
@@ -39,7 +43,7 @@ PLI_INT32 delay_rw_cb(p_cb_data);
 PLI_INT32 delay_ro_cb(p_cb_data);
 
 void set_error(string& error_string){
-    cout << error_string << endl;
+    vpi_printf("%s\n", error_string.c_str());
     shared_struct->data.resize(error_string.size());
     std::copy(error_string.begin(),
             error_string.end(),
@@ -58,7 +62,7 @@ bool check_error(){
             set_error(error_string);
             return true;
         } else {
-            cout << "VPI message : " << err.message << endl;
+            vpi_printf("VPI message : %s\n", err.message);
         }
     }
 
@@ -68,7 +72,6 @@ bool check_error(){
 bool register_cb(PLI_INT32(*f)(p_cb_data),
         PLI_INT32 reason,
         int64_t cycles){
-
     s_cb_data cbData;
     memset(&cbData, 0, sizeof(cbData));
     s_vpi_time simuTime;
@@ -92,19 +95,11 @@ bool register_cb(PLI_INT32(*f)(p_cb_data),
 }
 
 void entry_point_cb() {
-
-    ifstream shmem_file(SHMEM_FILENAME);
-    string shmem_name;
-    getline(shmem_file, shmem_name);
-    cout << "Shared memory key : " << shmem_name << endl;
-    segment = managed_shared_memory(open_only, shmem_name.c_str());
-    auto ret_struct = segment.find<SharedStruct>("SharedStruct");
-    shared_struct = ret_struct.first; 
     register_cb(start_cb, cbStartOfSimulation, -1);
     if(check_error()) return;
     register_cb(end_cb, cbEndOfSimulation, -1);
     if(check_error()) return;
-    #ifndef IVERILOG_PLUGIN
+    #ifdef BUGGY_RW_SYNCH
     register_cb(delay_ro_cb, cbAfterDelay, 0);
     #else
     register_cb(delay_rw_cb, cbAfterDelay, 0);
@@ -114,7 +109,7 @@ void entry_point_cb() {
 
 bool print_net_in_module(vpiHandle module_handle, stringstream &msg_ss){
     char* module_name = vpi_get_str(vpiName, module_handle);
-    cout << " Signals of " << module_name << endl;
+    vpi_printf(" Signals of %s\n", module_name);
     msg_ss << " Signals of " << module_name << endl;
 
     vpiHandle net_iterator = vpi_iterate(vpiNet,module_handle);
@@ -125,7 +120,7 @@ bool print_net_in_module(vpiHandle module_handle, stringstream &msg_ss){
             string net_full_name = vpi_get_str(vpiFullName, net_handle);
             if(check_error()) return true;
 
-            cout << "    " << net_full_name.c_str() << endl;
+            vpi_printf("    %s\n", net_full_name.c_str());
             msg_ss << "    " << net_full_name.c_str() << endl;
 
             vpiHandle net = vpi_handle_by_name(const_cast<char*>(net_full_name.c_str()),
@@ -142,17 +137,16 @@ bool print_net_in_module(vpiHandle module_handle, stringstream &msg_ss){
             vpi_free_object(net_handle);
         }
     } else {
-        cout << "   No handles." << endl;
+        vpi_printf("   No handles.\n");
         msg_ss << "   No handles." << endl;
     }
 
-    cout << endl;
+    vpi_printf("\n");
     msg_ss << endl;
     return false;
 }
 
 bool print_signals_cmd(){
-
     vpiHandle mod_iterator;
     vpiHandle mod_handle, child_mod_handle;
     std::vector<vpiHandle> mod_handles;
@@ -196,7 +190,6 @@ bool print_signals_cmd(){
 }
 
 bool randomize_in_module(vpiHandle module_handle, mt19937& mt_rand){
-
     vpiHandle net_iterator = vpi_iterate(vpiNet, module_handle);
     if(check_error()) return true;
     if(net_iterator){
@@ -239,7 +232,6 @@ bool set_seed_cmd(){
 }
 
 bool randomize_cmd(){
-
     vpiHandle mod_iterator;
     vpiHandle mod_handle, child_mod_handle;
     std::vector<vpiHandle> mod_handles;
@@ -281,7 +273,6 @@ bool randomize_cmd(){
 
 
 bool get_signal_handle_cmd(){
-
     int64_t handle = (int64_t)vpi_handle_by_name((PLI_BYTE8*) shared_struct->data.data(), 
             NULL);
     if(check_error()) return true; 
@@ -306,7 +297,6 @@ void sanitize_byte_str(char* byte_str){
 }
 
 bool read_cmd_raw(vpiHandle handle){
-
     s_vpi_value value_struct;
     value_struct.format = vpiBinStrVal;
     shared_struct->data.clear();
@@ -317,7 +307,7 @@ bool read_cmd_raw(vpiHandle handle){
     for(size_t i = 0; i < valueStrLen; i++){
         char c = value_struct.value.str[i];
         if ((c != '0') && (c != '1')) {
-            cout << "Warning, value '" << c << "' at position "<< i << " is neither '0' or '1'. value set to '0'." << endl;
+            vpi_printf("Warning, value '%c' at pisition %d is neither '0' or '1'. value set to '0'.\n", c, i);
         }
     }
 
@@ -373,7 +363,6 @@ bool read_mem_cmd(){
 }
 
 bool write_cmd_raw(vpiHandle handle){
-
     s_vpi_value value_struct;
     ss.str(std::string());
     ss << setw(8);
@@ -408,8 +397,7 @@ bool write_mem_cmd(){
 }
 
 bool sleep_cmd(){
-
-    #ifndef IVERILOG_PLUGIN
+    #ifdef GHDL_PLUGIN
     register_cb(delay_ro_cb, cbAfterDelay, shared_struct->sleep_cycles*1000000);
     #else
     register_cb(delay_rw_cb, cbAfterDelay, shared_struct->sleep_cycles);
@@ -426,23 +414,28 @@ bool close_cmd(){
 }
 
 PLI_INT32 start_cb(p_cb_data){
-    cout << "Start of simulation" << endl;
+    ifstream shmem_file(SHMEM_FILENAME);
+    string shmem_name;
+    getline(shmem_file, shmem_name);
+    vpi_printf("Shared memory key : %s\n", shmem_name.c_str());
+    segment = managed_shared_memory(open_only, shmem_name.c_str());
+    auto ret_struct = segment.find<SharedStruct>("SharedStruct");
+    shared_struct = ret_struct.first; 
+    vpi_printf("Start of simulation\n");
     return 0;
 }
 
 PLI_INT32 end_cb(p_cb_data){
-
     ProcStatus status = shared_struct->proc_status.load();
     if((status != ProcStatus::closed) && (status != ProcStatus::closed)) {
         string error_str("Unexpected termination of the simulation");
         set_error(error_str);
     }
-    cout << "End of simulation" << endl;
+    vpi_printf("End of simulation\n");
     return 0;
 }
 
 PLI_INT32 rw_cb(p_cb_data){
-
     bool run_simulation;
     do {
         run_simulation = false;
@@ -481,14 +474,12 @@ PLI_INT32 ro_cb(p_cb_data){
 }
 
 PLI_INT32 delay_rw_cb(p_cb_data){
-
     register_cb(rw_cb, cbReadWriteSynch, 0);
     check_error();
     return 0;
 }
 
 PLI_INT32 delay_ro_cb(p_cb_data){
-
     register_cb(ro_cb, cbReadOnlySynch, 0);
     check_error();
     return 0;

--- a/sim/src/main/scala/spinal/sim/Misc.scala
+++ b/sim/src/main/scala/spinal/sim/Misc.scala
@@ -33,6 +33,9 @@ object WaveFormat{
   object LXT2 extends WaveFormat("lxt2")
   object LXT2_SPEED extends WaveFormat("lxt2-speed")
   object LXT2_SPACE extends WaveFormat("lxt2-space")
+
+  // VCS only
+  object VPD extends WaveFormat("vpd")
 }
 
 class WaveFormat(val ext : String = "???")

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -566,7 +566,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       cppSourceFile.write(scala.io.Source.fromInputStream(stream).mkString)
       cppSourceFile.close
     }
-    val vpiCFlags = s"-DVPI_PLUGIN -I$vpiInclude -fPIC -shared"
+    val vpiCFlags = s"-DVCS_PLUGIN -I$vpiInclude -fPIC -shared"
     doCmd(
       Seq(CC,
         CFLAGS,

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -525,5 +525,128 @@ class IVerilogBackend(config: IVerilogBackendConfig) extends VpiBackend(config) 
   override def isBufferedWrite: Boolean = true
 }
 
+class VCSBackendConfig extends VpiBackendConfig {
+  var vcsCC: Option[String] = None
+  var vcsLd: Option[String] = None
+}
 
+class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
+  import Backend._
+  import config._
+  override def isBufferedWrite: Boolean = true
 
+  val availableFormats = Array(WaveFormat.VCD, WaveFormat.VPD, WaveFormat.DEFAULT, WaveFormat.NONE)
+
+  val format = if(availableFormats contains config.waveFormat) {
+    config.waveFormat
+  } else {
+    println("Wave format " + config.waveFormat + " not supported by VCS for now")
+    WaveFormat.NONE
+  }
+
+  val vpiModuleName = "vpi_vcs.so"
+  val vpiModulePath = pluginsPath + "/" + vpiModuleName
+  val vpiModuleAbsPath = new File(vpiModulePath).getAbsolutePath().mkString
+  val vpiInclude = sys.env.get("VCS_HOME") match {
+    case Some(x) => x + "/include"
+    case None => {
+      println("VCS_HOME not found")
+      ""
+    }
+  }
+
+  def compileVPI(): Unit = {
+    if(Files.exists(Paths.get(vpiModulePath))) {
+      return
+    }
+    val vpiPluginSource = Array("/VpiPlugin.cpp", "/SharedStruct.hpp")
+    for(filename <- vpiPluginSource) {
+      val cppSourceFile = new PrintWriter(new File(pluginsPath + "/" + filename))
+      val stream = getClass.getResourceAsStream(filename)
+      cppSourceFile.write(scala.io.Source.fromInputStream(stream).mkString)
+      cppSourceFile.close
+    }
+    val vpiCFlags = s"-DVPI_PLUGIN -I$vpiInclude -fPIC -shared"
+    doCmd(
+      Seq(CC,
+        CFLAGS,
+        vpiCFlags,
+        "VpiPlugin.cpp",
+        "-o",
+        vpiModuleName
+      ).mkString(" "),
+      new File(pluginsPath),
+      s"Compilation of $vpiModuleName failed"
+    )
+  }
+
+  private def vcsFlags(): String = {
+    val commonFlags = List(
+      "-full64",
+      "-quiet",
+      "-timescale=1ns/1ps",
+      "-debug_access+all",
+      "-debug_acc+pp+dmptf",
+      "-debug_region=+cell+encrypt",
+      "+vpi",
+      "+vcs+initreg+random",
+      "-load",
+      s"$vpiModuleAbsPath:entry_point_cb",
+      "-o",
+      toplevelName
+    )
+    val cc = config.vcsCC match {
+      case Some(x) => List("-cc", x)
+      case None => List.empty
+    }
+    val ld = config.vcsLd match {
+      case Some(x) => List("-ld", x)
+      case None => List.empty
+    }
+    val dump = waveFormat match {
+      case WaveFormat.VCD => List(s"+vcs+dumpvars+$toplevelName.vcd")
+      case WaveFormat.VPD => List(s"+vcs+vcdpluson")
+      case _ => List.empty
+    }
+    (commonFlags ++ cc ++ ld ++ dump).mkString(" ")
+  }
+
+  def analyzeRTL(): Unit = {
+    val verilogSourcePaths = rtlSourcesPaths.filter {
+      s => s.endsWith(".v") || s.endsWith(".sv") || s.endsWith(".vl")
+    }.mkString(" ")
+
+    config.rtlSourcesPaths.filter {
+      s => s.endsWith(".bin") || s.endsWith(".mem")
+    }.foreach {
+      path => FileUtils.copyFileToDirectory(new File(path), new File(workspacePath))
+    }
+
+    doCmd(
+      Seq("vcs",
+        vcsFlags(),
+        verilogSourcePaths
+      ).mkString(" "),
+      new File(workspacePath),
+      s"Compilation of $toplevelName failed"
+    )
+  }
+
+  def runSimulation(sharedMemIface: SharedMemIface) : Thread = {
+    val thread = new Thread(new Runnable {
+      val iface = sharedMemIface
+      def run(): Unit = {
+        val retCode = Process(Seq(s"./$toplevelName").mkString(" "),
+          new File(workspacePath)).! (new LoggerPrint())
+        if (retCode != 0) {
+          iface.set_crashed(retCode)
+          println(s"Simulation of $toplevelName failed")
+        }
+      }
+    })
+
+    thread.setDaemon(true)
+    thread.start()
+    thread
+  }
+}

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -26,7 +26,7 @@ case class VpiBackendConfig(
   var runFlags: String       = "",
   var sharedMemSize: Int     = 65536,
   var CC: String             = "g++",
-  var CFLAGS: String         = "-std=c++11 -Wall -Wextra -pedantic -O2 -Wno-strict-aliasing", 
+  var CFLAGS: String         = "-std=c++11 -Wall -Wextra -pedantic -O2 -Wno-strict-aliasing -Wno-write-strings", 
   var LDFLAGS: String        = "-lpthread ", 
   var useCache: Boolean      = false,
   var logSimProcess: Boolean = false
@@ -250,7 +250,7 @@ class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
              "--vpi-compile",
              CC, 
              "-c", 
-             CFLAGS, 
+             CFLAGS + " -DGHDL_PLUGIN", 
              "VpiPlugin.cpp",
              "-o",
              "VpiPlugin.o"
@@ -517,7 +517,6 @@ class IVerilogBackend(config: IVerilogBackendConfig) extends VpiBackend(config) 
       }
     })
 
-//    thread.setUncaughtExceptionHandler(new VpiThreadExceptionHandler)
     thread.setDaemon(true)
     thread.start()
     thread

--- a/sim/src/test/scala/spinal/sim/TestVCS.scala
+++ b/sim/src/test/scala/spinal/sim/TestVCS.scala
@@ -1,0 +1,45 @@
+package spinal.sim
+
+import spinal.sim.vpi._
+
+import scala.collection.JavaConverters._
+
+object TestVCS1 extends App{
+  val config = new VCSBackendConfig()
+  config.rtlSourcesPaths += "adder.v"
+  config.toplevelName = "adder"
+  config.pluginsPath = "simulation_plugins"
+  config.workspacePath = "yolo"
+  config.workspaceName = "yolo"
+  config.wavePath = "test.vcd"
+  config.waveFormat = WaveFormat.VCD
+  config.vcsCC = Some("gcc-4.4")
+  config.vcsLd = Some("g++-4.4")
+
+  val (vcsBackend, _) = new VCSBackend(config).instanciate()
+  println(vcsBackend.print_signals())
+  val nibble1 = vcsBackend.get_signal_handle("adder.nibble1")
+  val nibble2 = vcsBackend.get_signal_handle("adder.nibble2")
+  val sum = vcsBackend.get_signal_handle("adder.sum")
+  vcsBackend.write32(nibble1, 0)
+  vcsBackend.eval
+  vcsBackend.write32(nibble1, 3)
+  vcsBackend.write32(nibble2, 5)
+  println("? = " + vcsBackend.read32(nibble1).toString)
+  vcsBackend.eval
+  println("3 = " + vcsBackend.read32(nibble1).toString)
+  println("3 + 5 = " + vcsBackend.read32(sum).toString)
+  vcsBackend.write64(nibble1, 4)
+  vcsBackend.write64(nibble2, 1)
+  vcsBackend.sleep(3)
+  println("4 + 1 = " + vcsBackend.read64(sum).toString)
+  vcsBackend.write(nibble1, new VectorInt8(BigInt(2).toByteArray))
+  vcsBackend.write(nibble2, new VectorInt8(BigInt(3).toByteArray))
+  vcsBackend.eval
+  println("2 + 3 = " + BigInt(vcsBackend.read(sum)
+    .asScala
+    .toArray
+    .map{x => x.toByte}).toString)
+  vcsBackend.close
+  println("Finished TestVCS1")
+}


### PR DESCRIPTION
Add vcs backend based on #604 . Tested under VCS 2016.
Only VCD and VPD wave formats are supported for now.

Screenshot of test under [SpinalTemplateSbt](https://github.com/SpinalHDL/SpinalTemplateSbt):

![1](https://user-images.githubusercontent.com/15176913/158061625-b7b0ea3e-2d1d-492b-9c49-629a22e37ee4.png)

Update:
Remove failed message when VCS exits by calling `vpi_control(vpiFinish, 0)`.

![20220313224309](https://user-images.githubusercontent.com/15176913/158064959-c588c323-7f9d-458d-8544-068ba236e5c0.png)

