### PR TITLE
VCS FSDB-wave dump supported

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -558,6 +558,7 @@ case class SpinalSimConfig(
     this
   }
 
+  def withVcs : this.type = withVCS
   def withVCS : this.type = {
     _backend = SpinalSimBackendSel.VCS
     this
@@ -578,6 +579,16 @@ case class SpinalSimConfig(
 
   def withFstWave : this.type = {
     _waveFormat = WaveFormat.FST
+    this
+  }
+
+  def withFsdbWave : this.type = {
+    _waveFormat = WaveFormat.FSDB
+    this
+  }
+
+  def withVpdWave : this.type = {
+    _waveFormat = WaveFormat.VPD
     this
   }
 

--- a/sim/src/main/scala/spinal/sim/Misc.scala
+++ b/sim/src/main/scala/spinal/sim/Misc.scala
@@ -15,27 +15,28 @@ object SimError{
 
 object WaveFormat{
   //Common waveformat options
-  object VCD extends WaveFormat("vcd")
-  object FST extends WaveFormat("fst")
-  object DEFAULT extends WaveFormat
-  object NONE extends WaveFormat
+  case object VCD extends WaveFormat("vcd")
+  case object FST extends WaveFormat("fst")
+  case object DEFAULT extends WaveFormat
+  case object NONE extends WaveFormat
  
   //GHDL only
-  object VCDGZ extends WaveFormat("vcdgz")
-  object GHW extends WaveFormat("ghw")
+  case object VCDGZ extends WaveFormat("vcdgz")
+  case object GHW extends WaveFormat("ghw")
 
   //Icarus Verilator only
-  object FST_SPEED extends WaveFormat("fst-speed")
-  object FST_SPACE extends WaveFormat("fst-space")
-  object LXT extends WaveFormat("lxt")
-  object LXT_SPEED extends WaveFormat("lxt-speed")
-  object LXT_SPACE extends WaveFormat("lxt-space")
-  object LXT2 extends WaveFormat("lxt2")
-  object LXT2_SPEED extends WaveFormat("lxt2-speed")
-  object LXT2_SPACE extends WaveFormat("lxt2-space")
+  case object FST_SPEED extends WaveFormat("fst-speed")
+  case object FST_SPACE extends WaveFormat("fst-space")
+  case object LXT extends WaveFormat("lxt")
+  case object LXT_SPEED extends WaveFormat("lxt-speed")
+  case object LXT_SPACE extends WaveFormat("lxt-space")
+  case object LXT2 extends WaveFormat("lxt2")
+  case object LXT2_SPEED extends WaveFormat("lxt2-speed")
+  case object LXT2_SPACE extends WaveFormat("lxt2-space")
 
   // VCS only
   object VPD extends WaveFormat("vpd")
+  object FSDB extends WaveFormat("fsdb")
 }
 
 class WaveFormat(val ext : String = "???")

--- a/sim/src/main/scala/spinal/sim/Misc.scala
+++ b/sim/src/main/scala/spinal/sim/Misc.scala
@@ -15,31 +15,35 @@ object SimError{
 
 object WaveFormat{
   //Common waveformat options
-  case object VCD extends WaveFormat("vcd")
-  case object FST extends WaveFormat("fst")
-  case object DEFAULT extends WaveFormat
-  case object NONE extends WaveFormat
+  object VCD extends WaveFormat("vcd")
+  object FST extends WaveFormat("fst")
+  object DEFAULT extends WaveFormat
+  object NONE extends WaveFormat
  
   //GHDL only
-  case object VCDGZ extends WaveFormat("vcdgz")
-  case object GHW extends WaveFormat("ghw")
+  object VCDGZ extends WaveFormat("vcdgz")
+  object GHW extends WaveFormat("ghw")
 
   //Icarus Verilator only
-  case object FST_SPEED extends WaveFormat("fst-speed")
-  case object FST_SPACE extends WaveFormat("fst-space")
-  case object LXT extends WaveFormat("lxt")
-  case object LXT_SPEED extends WaveFormat("lxt-speed")
-  case object LXT_SPACE extends WaveFormat("lxt-space")
-  case object LXT2 extends WaveFormat("lxt2")
-  case object LXT2_SPEED extends WaveFormat("lxt2-speed")
-  case object LXT2_SPACE extends WaveFormat("lxt2-space")
+  object FST_SPEED extends WaveFormat("fst-speed")
+  object FST_SPACE extends WaveFormat("fst-space")
+  object LXT extends WaveFormat("lxt")
+  object LXT_SPEED extends WaveFormat("lxt-speed")
+  object LXT_SPACE extends WaveFormat("lxt-space")
+  object LXT2 extends WaveFormat("lxt2")
+  object LXT2_SPEED extends WaveFormat("lxt2-speed")
+  object LXT2_SPACE extends WaveFormat("lxt2-space")
 
   // VCS only
-  case object VPD extends WaveFormat("vpd")
-  case object FSDB extends WaveFormat("fsdb")
+  object VPD extends WaveFormat("vpd")
+  object FSDB extends WaveFormat("fsdb")
 }
 
-class WaveFormat(val ext : String = "???")
+sealed class WaveFormat(val ext : String = "???"){
+  override def toString: String = {
+    getClass().getName().split("\\$").last
+  }
+}
 
 
 trait Backend{

--- a/sim/src/main/scala/spinal/sim/Misc.scala
+++ b/sim/src/main/scala/spinal/sim/Misc.scala
@@ -35,8 +35,8 @@ object WaveFormat{
   case object LXT2_SPACE extends WaveFormat("lxt2-space")
 
   // VCS only
-  object VPD extends WaveFormat("vpd")
-  object FSDB extends WaveFormat("fsdb")
+  case object VPD extends WaveFormat("vpd")
+  case object FSDB extends WaveFormat("fsdb")
 }
 
 class WaveFormat(val ext : String = "???")

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -146,7 +146,7 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
 
     System.load(pwd + "/" + sharedMemIfacePath)
     compileVPI()
-    analyzeRTL() 
+    analyzeRTL()
   }
 
   def clean() : Unit = {
@@ -535,7 +535,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
   import config._
   override def isBufferedWrite: Boolean = true
 
-  val availableFormats = Array(WaveFormat.VCD, WaveFormat.VPD, WaveFormat.DEFAULT, WaveFormat.NONE)
+  val availableFormats = Array(WaveFormat.VCD, WaveFormat.VPD, WaveFormat.DEFAULT, WaveFormat.FSDB, WaveFormat.NONE)
 
   val format = if(availableFormats contains config.waveFormat) {
     config.waveFormat
@@ -552,6 +552,20 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
     case None => {
       println("VCS_HOME not found")
       ""
+    }
+  }
+
+  val verdi_home = sys.env.get("VERDI_HOME") match {
+    case Some(x) => x
+    case None => {
+      if(config.waveFormat == WaveFormat.FSDB){
+        var info = "$VERDI_HOME not found"
+        if(sys.env.get("LD_LIBRARY_PATH") == None) {
+          info += "\n $LD_LIBRARY_PATH not found"
+        }
+        println(s"[Error]: ${}")
+        " "
+      }
     }
   }
 
@@ -603,12 +617,17 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       case Some(x) => List("-ld", x)
       case None => List.empty
     }
+    println("ERROR ${VERDI_HOME}")
     val dump = waveFormat match {
       case WaveFormat.VCD => List(s"+vcs+dumpvars+$toplevelName.vcd")
       case WaveFormat.VPD => List(s"+vcs+vcdpluson")
+      case WaveFormat.FSDB => List(s"-P ${verdi_home}/share/PLI/VCS/LINUX64/novas.tab ",
+        s" ${verdi_home}/share/PLI/VCS/LINUX64/pli.a" )
       case _ => List.empty
     }
-    (commonFlags ++ cc ++ ld ++ dump).mkString(" ")
+    val cmd = (commonFlags ++ cc ++ ld ++ dump).mkString(" ")
+    println(s"[Info] ${cmd}")
+    cmd
   }
 
   def analyzeRTL(): Unit = {
@@ -622,11 +641,35 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       path => FileUtils.copyFileToDirectory(new File(path), new File(workspacePath))
     }
 
+    val simWaveSource =
+      s"""
+         |`timescale 1ns/100ps
+         |module __simulation_def;
+         |initial begin
+         |    $$fsdbDumpfile("$wavePath") ;
+         |    $$fsdbDumpvars(0, $toplevelName);
+         |    $$fsdbDumpflush;
+         |end
+         |endmodule""".stripMargin
+    val simulationDefSourceFile = new PrintWriter(new File(s"${workspacePath}/rtl/" ++
+      "__simulation_def.v"))
+    simulationDefSourceFile.write(simWaveSource)
+    simulationDefSourceFile.close
+
+    val fsdbv = waveFormat match{
+      case WaveFormat.FSDB => " ./rtl/__simulation_def.v"
+      case _  =>  " "
+    }
+
+    val vcspost = Seq("vcs",
+      vcsFlags(),
+      verilogSourcePaths + fsdbv
+    ).mkString(" ")
+
+    println(s"[Info] ${vcspost}")
+
     doCmd(
-      Seq("vcs",
-        vcsFlags(),
-        verilogSourcePaths
-      ).mkString(" "),
+      vcspost,
       new File(workspacePath),
       s"Compilation of $toplevelName failed"
     )

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -563,7 +563,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
         if(sys.env.get("LD_LIBRARY_PATH") == None) {
           info += "\n $LD_LIBRARY_PATH not found"
         }
-        println(s"[Error]: ${}")
+        println(s"[Error]: ${info}")
         " "
       }
     }
@@ -617,7 +617,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       case Some(x) => List("-ld", x)
       case None => List.empty
     }
-    println("ERROR ${VERDI_HOME}")
+
     val dump = waveFormat match {
       case WaveFormat.VCD => List(s"+vcs+dumpvars+$toplevelName.vcd")
       case WaveFormat.VPD => List(s"+vcs+vcdpluson")
@@ -626,7 +626,6 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       case _ => List.empty
     }
     val cmd = (commonFlags ++ cc ++ ld ++ dump).mkString(" ")
-    println(s"[Info] ${cmd}")
     cmd
   }
 
@@ -666,7 +665,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       verilogSourcePaths + fsdbv
     ).mkString(" ")
 
-    println(s"[Info] ${vcspost}")
+    println(s"[VCS] ${vcspost}")
 
     doCmd(
       vcspost,

--- a/sim/src/test/scala/spinal/sim/TestVCS.scala
+++ b/sim/src/test/scala/spinal/sim/TestVCS.scala
@@ -4,6 +4,16 @@ import spinal.sim.vpi._
 
 import scala.collection.JavaConverters._
 
+/*
+# you need setup synopsys tools env first, Example:
+
+export VCS_HOME=/tools/eda/synopsys/vcs/vcs-mx/O-2018.09-SP2/
+export PATH=$VCS_HOME/bin:$PATH
+export VERDI_HOME=/tools/eda/synopsys/verdi/verdi/Verdi_O-2018.09-SP2/
+export PATH=$VERDI_HOME/bin:$PATH
+export LD_LIBRARY_PATH=$VERDI_HOME/share/PLI/VCS/LINUX64
+ */
+
 object TestVCS1 extends App{
   val config = new VCSBackendConfig()
   config.rtlSourcesPaths += "adder.v"
@@ -12,7 +22,7 @@ object TestVCS1 extends App{
   config.workspacePath = "yolo"
   config.workspaceName = "yolo"
   config.wavePath = "test.vcd"
-  config.waveFormat = WaveFormat.FSDB
+  config.waveFormat = WaveFormat.VCD
 //  config.vcsCC = Some("gcc-4.4")
 //  config.vcsLd = Some("g++-4.4")
 

--- a/sim/src/test/scala/spinal/sim/TestVCS.scala
+++ b/sim/src/test/scala/spinal/sim/TestVCS.scala
@@ -12,9 +12,9 @@ object TestVCS1 extends App{
   config.workspacePath = "yolo"
   config.workspaceName = "yolo"
   config.wavePath = "test.vcd"
-  config.waveFormat = WaveFormat.VCD
-  config.vcsCC = Some("gcc-4.4")
-  config.vcsLd = Some("g++-4.4")
+  config.waveFormat = WaveFormat.FSDB
+//  config.vcsCC = Some("gcc-4.4")
+//  config.vcsLd = Some("g++-4.4")
 
   val (vcsBackend, _) = new VCSBackend(config).instanciate()
   println(vcsBackend.print_signals())


### PR DESCRIPTION
hi @Dolu1990 @name1e5s , the FSDB dump now  is ready

FSDB dump need  setup  `$VERDI_HOME`  and `$LD_LIBRARY_PATH` before use `SpinalSimConfig().withVcs.withFsdbWave`
```sh
#vim .bashrc
export VCS_HOME=/tools/eda/synopsys/vcs/vcs-mx/O-2018.09-SP2/
export PATH=$VCS_HOME/bin:$PATH

export VERDI_HOME=/tools/eda/synopsys/verdi/verdi/Verdi_O-2018.09-SP2/
export PATH=$VERDI_HOME/bin:$PATH

export LD_LIBRARY_PATH=$VERDI_HOME/share/PLI/VCS/LINUX64
```

![image](https://user-images.githubusercontent.com/6213885/158737638-7c327fb5-d2d7-48fc-b023-779406627d69.png)
![image](https://user-images.githubusercontent.com/6213885/158738651-0051253a-5cc2-43f2-83a5-75d12bee3c5d.png)

