### PR TITLE
VCS advanced features support

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -293,6 +293,7 @@ object SpinalVCSBackend {
     vconfig.logSimProcess = config.enableLogging
     vconfig.vcsLd = config.vcsLd
     vconfig.vcsCC = config.vcsCC
+    vconfig.waveDepth = config.waveDepth
 
     val signalsCollector = SpinalVpiBackend(config, vconfig)
 

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -882,8 +882,6 @@ case class SpinalSimConfig(
         }
 
       case SpinalSimBackendSel.VCS =>
-        println(f"[Progress] VCS compilation started")
-        val startAt = System.nanoTime()
         val vConfig = SpinalVCSBackendConfig[T](
           rtl = report,
           waveFormat = _waveFormat,
@@ -903,8 +901,6 @@ case class SpinalSimConfig(
           runFlags = _vcsUserFlags.runFlags
         )
         val backend = SpinalVCSBackend(vConfig)
-        val deltaTime = (System.nanoTime() - startAt) * 1e-6
-        println(f"[Progress] VCS compilation done in $deltaTime%1.3f ms")
         new SimCompiled(report) {
           override def newSimRaw(name: String, seed: Int): SimRaw = {
             val raw = new SimVpi(backend)

--- a/sim/src/main/scala/spinal/sim/Misc.scala
+++ b/sim/src/main/scala/spinal/sim/Misc.scala
@@ -36,6 +36,7 @@ object WaveFormat{
 
   // VCS only
   object VPD extends WaveFormat("vpd")
+  object FSDB extends WaveFormat("fsdb")
 }
 
 class WaveFormat(val ext : String = "???")

--- a/sim/src/main/scala/spinal/sim/Misc.scala
+++ b/sim/src/main/scala/spinal/sim/Misc.scala
@@ -39,7 +39,11 @@ object WaveFormat{
   object FSDB extends WaveFormat("fsdb")
 }
 
-class WaveFormat(val ext : String = "???")
+sealed class WaveFormat(val ext : String = "???"){
+  override def toString: String = {
+    getClass.getName.split("\\$").last
+  }
+}
 
 
 trait Backend{

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -753,8 +753,12 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       )
     }
 
+    println(f"[Progress] VCS compilation started.")
+    val startAt = System.nanoTime()
     analyzeSource()
     elaborate()
+    val deltaTime = (System.nanoTime() - startAt) * 1e-9
+    println(f"[Progress] VCS compilation done in $deltaTime%1.3f s")
 
   }
 

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -635,6 +635,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       "-debug_access+all",
       "-debug_acc+pp+dmptf",
       "-debug_region=+cell+encrypt",
+      "-l vcs.log",
       "+vpi",
       "+vcs+initreg+random",
       "-load",

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -678,6 +678,13 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       path => FileUtils.copyFileToDirectory(new File(path), new File(workspacePath))
     }
 
+    val fileList = (verilogSourcePaths ++ vhdlSourcePaths).mkString("\n")
+    val fileListFile = new PrintWriter(
+      new File(s"$workspacePath/filelist.f")
+    )
+    fileListFile.write(fileList)
+    fileListFile.close()
+
     val simWaveSource =
       s"""
          |`timescale 1ns/1ps


### PR DESCRIPTION
Hi,

Recently added VCS simulation support is significant progress to SpinalSim, by @name1e5s and @jijingg . Here I added some improvements on the top of the basic VCS support, like
1. Change the previous VCS two-step compilation flow to VCS three-step flow, enabling mixed-HDL simulation.
2. Add `VCSFlags` allowing users to provide customized flags passed to the `vlogan`, `vhdlan`, `vcs` and testbench executable. This is required by several advanced features like multi-thread, SDF back-annotation.
3. Add FSDB wave trace level control. 

Also fixed the dumped fsdb file naming (original naming is always `test.vcd`). 

Currently, the code is tested for only both VCS2020 and VCS2017 versions.