### PR TITLE
Axi4SlaveFactory: writeHaltRequest stall on last burst txn

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4SlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4SlaveFactory.scala
@@ -16,7 +16,7 @@ class Axi4SlaveFactory(bus: Axi4) extends BusSlaveFactoryDelayed {
   bus.writeRsp << writeRsp.stage()
   when(bus.writeData.last) {
     // backpressure in last beat
-    writeJoinEvent.ready := writeRsp.ready
+    writeJoinEvent.ready := writeRsp.ready && !writeHaltRequest
     writeRsp.valid := writeJoinEvent.fire
   } otherwise {
     // otherwise, stall W channel when writeHaltRequest


### PR DESCRIPTION
While I was working with adding Axi4 write backpressure to a design I noticed that when using single non-burst transactions (always asserting last) the `writeHaltRequest` isn't considered. This should be taken into account even on the last beat of a burst in case some FIFO can't accept the data.