### PR TITLE
Add a `check` method to Stream.

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -506,7 +506,14 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
 
   override def getTypeString = getClass.getSimpleName + "[" + this.payload.getClass.getSimpleName + "]"
 
-  def check(payloadInvariance: Boolean = false): this.type = {
+  /**
+   * Assert that this stream conforms to the stream semantics:
+   * https://spinalhdl.github.io/SpinalDoc-RTD/dev/SpinalHDL/Libraries/stream.html#semantics
+   * - After being asserted, valid may only be deasserted once the current payload was acknowleged.
+   * 
+   * @param payloadInvariance Check that the payload does not change when valid is high and ready is low.
+   */
+  def withAsserts(payloadInvariance: Boolean = false): this.type = {
     val rValid = RegInit(False) setWhen(this.valid) clearWhen(this.fire)
     val rData = RegNextWhen(this.payload, this.valid && !rValid)
 

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -507,10 +507,8 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
   override def getTypeString = getClass.getSimpleName + "[" + this.payload.getClass.getSimpleName + "]"
 
   def check(payloadInvariance: Boolean = false): this.type = {
-    val rValid = RegInit(False) 
+    val rValid = RegInit(False) setWhen(this.valid) clearWhen(this.fire)
     val rData = RegNextWhen(this.payload, this.valid && !rValid)
-
-    rValid setWhen(this.valid && !rValid) clearWhen(this.fire)
 
     val stack = Thread.currentThread().getStackTrace().mkString
     assert(!(!this.valid && rValid), "Stream transaction disappeared: " + stack)

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -510,12 +510,12 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
     val rValid = RegInit(False) setWhen(this.valid) clearWhen(this.fire)
     val rData = RegNextWhen(this.payload, this.valid && !rValid)
 
-    val stack =  ScalaLocated.long.replace("\n", "\\n")
-    assert(!(!this.valid && rValid), "Stream transaction disappeared:\\n" + stack)
+    val stack = ScalaLocated.long
+    assert(!(!this.valid && rValid), "Stream transaction disappeared:\n" + stack)
     if (payloadInvariance) {
       assert(
         !rValid || rData === this.payload,
-        "Stream transaction payload changed:\\n" + stack
+        "Stream transaction payload changed:\n" + stack
       )
     }
 

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -510,12 +510,12 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
     val rValid = RegInit(False) setWhen(this.valid) clearWhen(this.fire)
     val rData = RegNextWhen(this.payload, this.valid && !rValid)
 
-    val stack = Thread.currentThread().getStackTrace().mkString
-    assert(!(!this.valid && rValid), "Stream transaction disappeared:\\n" + ScalaLocated.long.replace("\n", "\\n"))
+    val stack =  ScalaLocated.long.replace("\n", "\\n")
+    assert(!(!this.valid && rValid), "Stream transaction disappeared:\\n" + stack)
     if (payloadInvariance) {
       assert(
         !rValid || rData === this.payload,
-        "Stream transaction payload changed:\\n" + ScalaLocated.long.replace("\n", "\\n")
+        "Stream transaction payload changed:\\n" + stack
       )
     }
 

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -511,11 +511,11 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
     val rData = RegNextWhen(this.payload, this.valid && !rValid)
 
     val stack = Thread.currentThread().getStackTrace().mkString
-    assert(!(!this.valid && rValid), "Stream transaction disappeared: " + stack)
+    assert(!(!this.valid && rValid), "Stream transaction disappeared:\\n" + ScalaLocated.long.replace("\n", "\\n"))
     if (payloadInvariance) {
       assert(
         !rValid || rData === this.payload,
-        "Stream transaction payload changed: " + stack
+        "Stream transaction payload changed:\\n" + ScalaLocated.long.replace("\n", "\\n")
       )
     }
 


### PR DESCRIPTION
This PR adds a `check` method to `Stream` that enforces [Stream semantics](https://spinalhdl.github.io/SpinalDoc-RTD/dev/SpinalHDL/Libraries/stream.html#semantics) using assertions.