### PR TITLE
Memory: multiple ports with writeFirst should be permited.

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -1312,7 +1312,6 @@ end
                   emitWrite(b, memReadWrite.mem,s"${emitExpression(memReadWrite.chipSelect)} && ${emitExpression(memReadWrite.writeEnable)} ", memReadWrite.address, memReadWrite.data, memReadWrite.mask, memReadWrite.mem.getMemSymbolCount(), memReadWrite.mem.getMemSymbolWidth(),tab)
                 }, null, tmpBuilder, memReadWrite.clockDomain, false)
               case `writeFirst` =>
-                assert(mem.cldCount == 1)
                 emitClockedProcess((tab, b) => {
                   val symbolCount = memReadWrite.mem.getMemSymbolCount()
                   b ++= s"${tab}if(${emitExpression(memReadWrite.chipSelect)}) begin\n"
@@ -1325,7 +1324,6 @@ end
                   b ++= s"${tab}end\n"
                 }, null, tmpBuilder, memReadWrite.clockDomain, false)
               case `readFirst` =>
-                assert(mem.cldCount == 1)
                 emitClockedProcess((tab, b) => {
                   val symbolCount = memReadWrite.mem.getMemSymbolCount()
                   b ++= s"${tab}if(${emitExpression(memReadWrite.chipSelect)}) begin\n"


### PR DESCRIPTION
This allows logic to be generated that will allow address collisions to be resolved between a write & read port (eg to reduce latency of a FIFO).