### PR TITLE
RFC: Axi4S: Make AxiS type a subclass of stream for overrides

### DIFF
--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4StreamTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4StreamTester.scala
@@ -11,7 +11,7 @@ case class Axi4StreamEndianFixture[T <: Data](config: Axi4StreamConfig, outType:
     val s_axis = slave(Axi4Stream(config))
     val m_data = master(Stream(outType))
     val s_data = slave(Stream(outType))
-    val m_axis = master(Axi4Stream(config))
+    val m_axis = master(Axi4Stream(config.copy(useKeep = true)))
   }
 
   io.m_data << io.s_axis.toBitStream().map(_.toDataType(outType())).stage()
@@ -23,7 +23,7 @@ case class Axi4StreamFragmentFixture[T <: Data](config: Axi4StreamConfig, outTyp
     val s_axis = slave(Axi4Stream(config))
     val m_data = master(Stream(Fragment(outType)))
     val s_data = slave(Stream(Fragment(outType)))
-    val m_axis = master(Axi4Stream(config))
+    val m_axis = master(Axi4Stream(config.copy(useKeep = true)))
   }
 
   io.m_data << io.s_axis.toBitStreamFragment().map(f => {


### PR DESCRIPTION
I was working on building an Axi stream component and realized the width resizing methods weren't actually applying.
After some time I found I couldn't get an implicit class to override the connect methods in `Stream`. Using a subclass seems to be the only pattern that works.


I'm just wondering what the thoughts on this change are. This doesn't appear to break using any of the existing `Stream[T]` functions like forks and joins.


I'll also have to add unit tests to make sure the Axi stream connect functions are enforced going forward. I missed this in the original tests.