### PR TITLE
Interrupt Register Interface on regif  redesign

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
@@ -100,12 +100,13 @@ trait BusIf extends BusIfBase {
   /*
     interrupt with Raw/Force/Mask/Status 4 Register Interface
     **/
-  def interruptFactory(regNamePre: String, triggers: Bool*): Bool = {
+  def interruptFactory(regNamePre: String, triggers: Bool*): Bool = interruptFactoryAt(regPtr, regNamePre, triggers:_*)
+  def interruptFactoryAt(addrOffset: Int, regNamePre: String, triggers: Bool*): Bool = {
     require(triggers.size > 0)
     val groups = triggers.grouped(this.busDataWidth).toList
     val ret = groups.zipWithIndex.map{case (trigs, i) =>
       val namePre = if (groups.size == 1) regNamePre else regNamePre + i
-      int_RFMS(namePre, trigs:_*)
+      int_RFMS(addrOffset, namePre, trigs:_*)
     }
     val intr = Vec(ret).asBits.orR
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
@@ -115,12 +116,13 @@ trait BusIf extends BusIfBase {
   /*
     interrupt with Raw/Mask/Status 3 Register Interface
     **/
-  def interruptFactoryNoForce(regNamePre: String, triggers: Bool*): Bool = {
+  def interruptFactoryNoForce(regNamePre: String, triggers: Bool*): Bool = interruptFactoryNoForceAt(regPtr, regNamePre, triggers:_*)
+  def interruptFactoryNoForceAt(addrOffset: Int, regNamePre: String, triggers: Bool*): Bool = {
     require(triggers.size > 0)
     val groups = triggers.grouped(this.busDataWidth).toList
     val ret = groups.zipWithIndex.map{case (trigs, i) =>
       val namePre = if (groups.size == 1) regNamePre else regNamePre + i
-      int_RMS(namePre, trigs:_*)
+      int_RMS(addrOffset, namePre, trigs:_*)
     }
     val intr = Vec(ret).asBits.orR
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
@@ -131,12 +133,13 @@ trait BusIf extends BusIfBase {
     interrupt with Mask/Status 2 Register Interface
     always used for sys_level_int merge
     **/
-  def interruptLevelFactory(regNamePre: String, levels: Bool*): Bool = {
+  def interruptLevelFactory(regNamePre: String, levels: Bool*): Bool = interruptLevelFactoryAt(regPtr, regNamePre, levels:_*)
+  def interruptLevelFactoryAt(addrOffset: Int, regNamePre: String, levels: Bool*): Bool = {
     require(levels.size > 0)
     val groups = levels.grouped(this.busDataWidth).toList
     val ret = groups.zipWithIndex.map{case (trigs, i) =>
       val namePre = if (groups.size == 1) regNamePre else regNamePre + i
-      int_MS(namePre, trigs:_*)
+      int_MS(addrOffset, namePre, trigs:_*)
     }
     val intr = Vec(ret).asBits.orR
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
@@ -146,10 +149,10 @@ trait BusIf extends BusIfBase {
   /*
   interrupt with Raw/Force/Mask/Status Register Interface
   **/
-  protected def int_RFMS(regNamePre: String, triggers: Bool*): Bool = {
+  protected def int_RFMS(offset: Int, regNamePre: String, triggers: Bool*): Bool = {
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
     require(triggers.size <= this.busDataWidth )
-    val RAW    = this.newReg("Interrupt Raw status Register\n set when event \n clear when write 1")(SymbolName(s"${regNamePre_}INT_RAW"))
+    val RAW    = this.newRegAt(offset,"Interrupt Raw status Register\n set when event \n clear when write 1")(SymbolName(s"${regNamePre_}INT_RAW"))
     val FORCE  = this.newReg("Interrupt Force  Register\n for SW debug use")(SymbolName(s"${regNamePre_}INT_FORCE"))
     val MASK   = this.newReg("Interrupt Mask   Register\n1: int off\n0: int open\n default 1, int off")(SymbolName(s"${regNamePre_}INT_MASK"))
     val STATUS = this.newReg("Interrupt status Register\n status = (raw || force) && (!mask)")(SymbolName(s"${regNamePre_}INT_STATUS"))
@@ -170,10 +173,10 @@ trait BusIf extends BusIfBase {
   /*
     interrupt with Force/Mask/Status Register Interface
     * */
-  protected def int_RMS(regNamePre: String, triggers: Bool*): Bool = {
+  protected def int_RMS(offset: Int,regNamePre: String, triggers: Bool*): Bool = {
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
     require(triggers.size <= this.busDataWidth )
-    val RAW    = this.newReg("Interrupt Raw status Register\n set when event \n clear when write 1")(SymbolName(s"${regNamePre_}INT_RAW"))
+    val RAW    = this.newRegAt(offset,"Interrupt Raw status Register\n set when event \n clear when write 1")(SymbolName(s"${regNamePre_}INT_RAW"))
     val MASK   = this.newReg("Interrupt Mask   Register\n1: int off\n0: int open\n default 1, int off")(SymbolName(s"${regNamePre_}INT_MASK"))
     val STATUS = this.newReg("Interrupt status Register\n  status = raw && (!mask)")(SymbolName(s"${regNamePre_}INT_STATUS"))
     val ret = triggers.map{ event =>
@@ -192,10 +195,10 @@ trait BusIf extends BusIfBase {
   /*
     interrupt with Mask/Status Register Interface
     * */
-  protected def int_MS(regNamePre: String, int_levels: Bool*): Bool = {
+  protected def int_MS(offset: Int, regNamePre: String, int_levels: Bool*): Bool = {
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
     require(int_levels.size <= this.busDataWidth )
-    val MASK   = this.newReg("Interrupt Mask   Register\n1: int off\n0: int open\n default 1, int off")(SymbolName(s"${regNamePre_}INT_MASK"))
+    val MASK   = this.newRegAt(offset, "Interrupt Mask   Register\n1: int off\n0: int open\n default 1, int off")(SymbolName(s"${regNamePre_}INT_MASK"))
     val STATUS = this.newReg("Interrupt status Register\n status = int_level && (!mask)")(SymbolName(s"${regNamePre_}INT_STATUS"))
     val ret = int_levels.map{ level =>
       val nm = level.getPartialName()

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
@@ -100,7 +100,7 @@ trait BusIf extends BusIfBase {
 
   def interruptFactory(regNamePre: String, triggers: Bool*): Bool = {
     require(triggers.size > 0)
-    val groups = triggers.grouped(this.busDataWidth)
+    val groups = triggers.grouped(this.busDataWidth).toList
     val ret = groups.zipWithIndex.map{case (trigs, i) =>
       val namePre = if (groups.size == 1) regNamePre else regNamePre + i
       int_RFMS(namePre, trigs:_*)
@@ -175,7 +175,7 @@ trait BusIf extends BusIfBase {
   protected def int_MS(regNamePre: String, int_levels: Bool*): Bool = {
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
     require(int_levels.size <= this.busDataWidth )
-    val MASK   = this.newReg("Interrupt Mask   Register\n1: int off\n0: int open\n default 0xFFFF")
+    val MASK   = this.newReg("Interrupt Mask   Register\n1: int off\n0: int open\n default 0xFFFF")(SymbolName(s"${regNamePre_}_RAW"))
     val STATUS = this.newReg("Interrupt status Register\n the final int out")(SymbolName(s"${regNamePre_}_STATUS"))
     val ret = int_levels.map{ level =>
       val nm = level.getName()

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
@@ -139,11 +139,11 @@ trait BusIf extends BusIfBase {
       val force = FORCE.field(1 bit, AccessType.RW,   resetValue = 0, doc = s"${nm}_force" )(SymbolName(s"${nm}_force")).lsb
       val mask  = MASK.field(1 bit, AccessType.RW,    resetValue = 1, doc = s"${nm}_mask" )(SymbolName(s"${nm}_mask")).lsb
       val status= STATUS.field(1 bit, AccessType.RO,  resetValue = 0, doc = s"${nm}_stauts" )(SymbolName(s"${nm}_status")).lsb
-      raw.clearWhen(event)
+      raw.setWhen(event)
       status := (raw || force) && mask
       status
     }.reduceLeft(_ || _)
-    ret.setName(s"${regNamePre_.toLowerCase()}intr")
+    ret.setName(s"${regNamePre_.toLowerCase()}intr", weak = true)
     ret
   }
 
@@ -161,11 +161,11 @@ trait BusIf extends BusIfBase {
       val raw   = RAW.field(1 bit, AccessType.W1C,    resetValue = 0, doc = s"${nm}_raw" )(SymbolName(s"${nm}_raw")).lsb
       val mask  = MASK.field(1 bit, AccessType.RW,    resetValue = 1, doc = s"${nm}_mask" )(SymbolName(s"${nm}_mask")).lsb
       val status= STATUS.field(1 bit, AccessType.RO,  resetValue = 0, doc = s"${nm}_stauts" )(SymbolName(s"${nm}_status")).lsb
-      raw.clearWhen(event)
+      raw.setWhen(event)
       status := raw && mask
       status
     }.reduceLeft(_ || _)
-    ret.setName(s"${regNamePre_.toLowerCase()}_int")
+    ret.setName(s"${regNamePre_.toLowerCase()}intr")
     ret
   }
 
@@ -184,7 +184,7 @@ trait BusIf extends BusIfBase {
       status := level && mask
       status
     }.reduceLeft(_ || _)
-    ret.setName(s"${regNamePre_.toLowerCase()}_int")
+    ret.setName(s"${regNamePre_.toLowerCase()}intr")
     ret
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/regif/Factory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Factory.scala
@@ -4,5 +4,6 @@ import language.experimental.macros
 import spinal.core.Bool
 
 object InterruptFactory{
+  @deprecated(message = "busif.interruptFactory() is recommended", since = "2022-12-31")
   def apply(busif: BusIf, regNamePre: String, triggers: Bool*): Bool = macro Macros.interruptFactoryImpl
 }

--- a/tester/src/main/scala/spinal/tester/code/RegIfInterrupt.scala
+++ b/tester/src/main/scala/spinal/tester/code/RegIfInterrupt.scala
@@ -1,0 +1,116 @@
+package spinal.tester.code
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+import spinal.lib.bus.regif._
+import spinal.lib.bus.regif.Document.CHeaderGenerator
+import spinal.lib.bus.regif.Document.HtmlGenerator
+import spinal.lib.bus.regif.Document.JsonGenerator
+
+class RegFileIntrExample extends Component{
+  val io = new Bundle{
+    val apb = slave(Apb3(Apb3Config(16,32)))
+    val int_pulse0, int_pulse1, int_pulse2 = in Bool()
+    val int_level0, int_level1 = in Bool()
+    val sys_int = out Bool()
+    val s2 = out Bool()
+    val gpio_int = out Bool()
+
+  }
+
+  val busif = BusInterface(io.apb,  (0x000,1 KiB), 0, regPre = "AP")
+  io.sys_int  := busif.interruptFactory("SYS",io.int_pulse0, io.int_pulse1, io.int_pulse2)
+  io.s2  := busif.interruptFactory("SYS",io.int_pulse0, io.int_pulse1, io.int_pulse2)
+  io.gpio_int := busif.interruptLevelFactory("GPIO",io.s2, io.sys_int, io.int_level0, io.int_level1,io.sys_int)
+
+  def genDoc() = {
+    busif.accept(CHeaderGenerator("intrreg.html","Intr"))
+    busif.accept(HtmlGenerator("intrreg.html", "Interupt Example"))
+    busif.accept(JsonGenerator("intrreg.json"))
+    this
+  }
+}
+
+class RegFileIntrSim extends RegFileIntrExample{
+  def Init() = {
+    this.clockDomain.forkStimulus(2)
+    this.reset()
+    this.io.int_pulse0  #= false
+    this.io.int_pulse1  #= false
+    this.io.int_pulse2  #= false
+    this.io.int_level0  #= false
+    this.io.int_level1  #= false
+  }
+
+  def reset() = {
+    this.clockDomain.assertReset()
+    sleep(10)
+    this.clockDomain.deassertReset()
+  }
+
+  def write(address: Long, data: Long) = {
+    val apbDriver = Apb3Driver(this.io.apb, this.clockDomain)
+    apbDriver.write(address, data)
+  }
+
+  def read(address: Long): BigInt = {
+    val apbDriver = Apb3Driver(this.io.apb, this.clockDomain)
+    apbDriver.read(address)
+  }
+
+  def trigger(x: Bool) = {
+    x #= true
+    this.clockDomain.waitSampling()
+    x #= false
+  }
+
+  def testPulse() = {
+    this.trigger(io.int_pulse1)
+    this.clockDomain.waitSampling(40)
+    this.write(0x000, 0xFFFF)
+    this.clockDomain.waitSampling(20)
+    this.trigger(io.int_pulse1)
+    this.write(0x008, 0x0000)
+    this.write(0x018, 0x0000) //OPEN MASK
+    this.clockDomain.waitSampling(40)
+    this.write(0x000, 0xFFFF) //W1C
+    this.clockDomain.waitSampling(40)
+    this.write(0x004, 0x0002)
+    this.clockDomain.waitSampling(20)
+    this.write(0x004, 0x0000)
+    this.clockDomain.waitSampling(20)
+    this.trigger(io.int_pulse0)
+  }
+
+  def testLevel()  = {
+    this.io.int_level1  #= true
+    this.write(0x020, 0x0000)  //OPEN MASK
+    this.clockDomain.waitSampling(20)
+    this.write(0x010, 0xFFFF) //W1C
+    this.write(0x020, 0xFFFF) //CLOSE MASK
+    this.clockDomain.waitSampling(20)
+    this.write(0x020, 0x0000)  //OPEN MASK
+    this.clockDomain.waitSampling(20)
+    this.write(0x000, 0xFFFF) //W1C
+    this.clockDomain.waitSampling(40)
+    this.io.int_level1  #= false
+    this.clockDomain.waitSampling(20)
+  }
+}
+
+object regintSim extends App{
+  SpinalSimConfig()
+    .withFstWave
+    .compile(new RegFileIntrSim()) .doSimUntilVoid("xx"){ dut =>
+    dut.genDoc()
+    dut.Init
+    dut.clockDomain.waitSampling(10)
+    dut.testPulse()
+    dut.testLevel()
+    dut.clockDomain.waitSampling(200)
+    simSuccess()
+  }
+}


### PR DESCRIPTION
Referring to  common practices, the interrupt register interface is redesigned

It is mainly divided into two categories

**1.  Pulse event trigger, record and merge**  
- RAW  
- FORCE
- MASK  
- STATUS
```scala 
io.sys_int  := busif.interruptFactory("SYS",io.int_pulse0, io.int_pulse1, io.int_pulse2, io.int_pulse2)
```
 
![123](https://user-images.githubusercontent.com/6213885/163201556-7ff55b44-b2ed-45de-a3a4-8e1363efaebe.svg)



**2. Interrupt level merge**    
- MASK  
- STATUS
```
io.gpio_int := busif.interruptLevelFactory("GPIO",io.int_level0, io.int_level1,io.int_level1,io.int_level1,)
```
![MS2](https://user-images.githubusercontent.com/6213885/163012090-0a8934b1-2c9b-4f6e-b74a-66a0cef2f500.svg)


**Example** ：
```scala 
class RegFileIntrExample extends Component{
  val io = new Bundle{
    val apb = slave(Apb3(Apb3Config(16,32)))
    val int_pulse0, int_pulse1, int_pulse2, int_pulse3 = in Bool()
    val int_level0, int_level1, int_level2 = in Bool()
    val sys_int = out Bool()
    val gpio_int = out Bool()
  }

  val busif = BusInterface(io.apb,  (0x000,1 KiB), 0, regPre = "AP")
  io.sys_int  := busif.interruptFactory("SYS",io.int_pulse0, io.int_pulse1, io.int_pulse2, io.int_pulse3)
  io.gpio_int := busif.interruptLevelFactory("GPIO",io.int_level0, io.int_level1, io.int_level2, io.sys_int)

  def genDoc() = {
    busif.accept(CHeaderGenerator("intrreg.h","Intr"))
    busif.accept(HtmlGenerator("intrreg.html", "Interupt Example"))
    busif.accept(JsonGenerator("intrreg.json"))
    this
  }

  this.genDoc()
}
```
<img width="859" alt="截屏2022-04-13 上午1 34 57" src="https://user-images.githubusercontent.com/6213885/163025203-9b701430-0275-4a19-93a6-4a88d56ff106.png">


