### PR TITLE
fix CHeader addrLength=0 bug

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
@@ -25,8 +25,7 @@ final case class CHeaderGenerator(
     val regs : mutable.ListBuffer[RegDescr] = mutable.ListBuffer[RegDescr]()
     val types : mutable.ListBuffer[Type] = mutable.ListBuffer[Type]()
     var regLength : Int = 0
-    var addrLength : Int = 0
-    
+
     def begin(busDataWidth : Int) : Unit = {
 
     }
@@ -37,13 +36,9 @@ final case class CHeaderGenerator(
 
     def visit(descr : RegDescr) : Unit = {
         def nameLen = descr.getName.length()
-        def len = scala.math.log(descr.getAddr) / scala.math.log(16) + 1
 
         if(nameLen > regLength)
             regLength = nameLen
-
-        if(len > addrLength)
-            addrLength = len.toInt
 
         regs += descr
         types += Type(descr.getName, descr.getFieldDescrs)
@@ -68,7 +63,7 @@ final case class CHeaderGenerator(
             pw.write(s"#define ${prefix.toUpperCase()}_${reg.getName.toUpperCase()} ")
             pw.write(" " * (regLength - reg.getName.length))
             pw.write("0x")
-            pw.print(reg.getAddr.formatted(s"%0${addrLength}x"))
+            pw.print(reg.getAddr.formatted(s"%0${4}x"))
             pw.println()
         }
         pw.println()


### PR DESCRIPTION
busif CHeader generator bug fix 
when final address = 0x00
```
[Progress] at 0.092 : Elaborate components
Exception in thread "main" java.util.DuplicateFormatFlagsException: Flags = '0'
	at java.util.Formatter$Flags.parse(Formatter.java:4443)
	at java.util.Formatter$FormatSpecifier.flags(Formatter.java:2640)
	at java.util.Formatter$FormatSpecifier.<init>(Formatter.java:2709)
	at java.util.Formatter.parse(Formatter.java:2560)
	at java.util.Formatter.format(Formatter.java:2501)
	at java.util.Formatter.format(Formatter.java:2455)
	at java.lang.String.format(String.java:2940)
	at scala.collection.immutable.StringLike$class.format(StringLike.scala:319)
	at scala.collection.immutable.StringOps.format(StringOps.scala:29)
	at scala.Predef$StringFormat$.formatted$extension(Predef.scala:269)
	at spinal.lib.bus.regif.Document.CHeaderGenerator$$anonfun$end$1.apply(CHeaderGenerator.scala:71)
	at spinal.lib.bus.regif.Document.CHeaderGenerator$$anonfun$end$1.apply(CHeaderGenerator.scala:67)
```