### PR TITLE
regif new filed API support HardType 

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
@@ -1,4 +1,4 @@
-package spinal.lib.bus.regif.Document
+package spinal.lib.bus.regif
 
 import spinal.core.{GlobalData, SpinalError}
 import spinal.lib.bus.regif._

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
@@ -46,7 +46,7 @@ final case class CHeaderGenerator(
     
     def end() : Unit = {
         val pc = GlobalData.get.phaseContext
-        val targetPath = s"${pc.config.targetDirectory}/${fileName}"
+        val targetPath = s"${pc.config.targetDirectory}/${fileName}.h"
         val pw = new PrintWriter(targetPath)
 
         pw.write(

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
@@ -60,7 +60,7 @@ final case class CHeaderGenerator(
                 |""".stripMargin)
         
         for(reg <- regs) {
-            pw.write(s"#define ${prefix.toUpperCase()}_${reg.getName.toUpperCase()} ")
+            pw.write(s"#define ${reg.getName.toUpperCase()} ")
             pw.write(" " * (regLength - reg.getName.length))
             pw.write("0x")
             pw.print(reg.getAddr.formatted(s"%0${4}x"))
@@ -92,7 +92,7 @@ final case class CHeaderGenerator(
             })
 
             pw.println("\t} reg;")
-            pw.println(s"} ${prefix.toLowerCase}_${t.name.toLowerCase()}_t;\n")
+            pw.println(s"} ${t.name.toLowerCase()}_t;\n")
         }
         
         pw.write(s"#endif /* ${guardName} */")

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/HtmlGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/HtmlGenerator.scala
@@ -1,4 +1,4 @@
-package spinal.lib.bus.regif.Document
+package spinal.lib.bus.regif
 
 import spinal.core.GlobalData
 import spinal.lib.bus.regif._

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/HtmlGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/HtmlGenerator.scala
@@ -4,7 +4,7 @@ import spinal.core.GlobalData
 import spinal.lib.bus.regif._
 import java.io.PrintWriter
 
-final case class HtmlGenerator(fileName : String, name : String) extends BusIfVisitor {
+final case class HtmlGenerator(fileName : String, title : String) extends BusIfVisitor {
     val sb : StringBuilder = new StringBuilder("")
     var dataWidth : Int = 32
 
@@ -53,10 +53,10 @@ final case class HtmlGenerator(fileName : String, name : String) extends BusIfVi
 
     def end() : Unit = {
         val pc = GlobalData.get.phaseContext
-        val targetPath = s"${pc.config.targetDirectory}/${fileName}"
+        val targetPath = s"${pc.config.targetDirectory}/${fileName}.html"
         val pw = new PrintWriter(targetPath)
 
-        pw.write(DocTemplate.getHTML(name, sb.toString()))
+        pw.write(DocTemplate.getHTML(title, sb.toString()))
 
         pw.close()
     }

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
@@ -54,7 +54,7 @@ final case class JsonGenerator(fileName : String) extends BusIfVisitor {
     
     def end() : Unit = {
         val pc = GlobalData.get.phaseContext
-        val targetPath = s"${pc.config.targetDirectory}/${fileName}"
+        val targetPath = s"${pc.config.targetDirectory}/${fileName}.json"
         val pw = new PrintWriter(targetPath)
 
         sb ++= "]\n"

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
@@ -1,4 +1,4 @@
-package spinal.lib.bus.regif.Document
+package spinal.lib.bus.regif
 
 import spinal.core.GlobalData
 import spinal.lib.bus.regif._

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/RalfGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/RalfGenerator.scala
@@ -43,7 +43,7 @@ final case class RalfGenerator(name: String) extends BusIfVisitor {
     sb ++= "\n"
 
     sb ++=
-      s"  }".stripMargin
+      s"  }\n".stripMargin
   }
 
   def end() : Unit = {

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/RalfGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/RalfGenerator.scala
@@ -1,0 +1,59 @@
+package spinal.lib.bus.regif
+
+import spinal.core.GlobalData
+import spinal.lib.bus.regif.{BusIfVisitor, FifoDescr, RegDescr}
+
+import java.io.PrintWriter
+
+final case class RalfGenerator(name: String) extends BusIfVisitor {
+  val sb : StringBuilder = new StringBuilder
+  var prefix = ""
+
+  def clean(str : String) : String = {
+    str.replace("\n","\\n").replace("\r","\\r")
+  }
+
+  def begin(busDataWidth : Int) : Unit = {
+    sb ++=
+      s"""block ${name}{
+         |  endian little;
+         |  bytes ${scala.math.ceil(busDataWidth/4).toInt};
+         |""".stripMargin
+  }
+
+  def visit(descr : FifoDescr)  : Unit = {
+
+  }
+
+  def visit(descr : RegDescr) : Unit = {
+    sb ++= prefix
+
+    sb ++=
+      s"  register ${descr.getName()} @'h${descr.getAddr().toHexString} {\n"
+
+    descr.getFieldDescrs().foreach(f =>{
+      sb ++=
+        s"""|    field ${f.getName()} @${f.getSection().last} {
+            |      bits ${f.getWidth()} ;
+            |      access ${f.getAccessType().toString.toLowerCase()} ;
+            |      reset  ${f.getWidth()}'h${f.getResetValue().toHexString};
+            |     }
+            |""".stripMargin
+    })
+    sb ++= "\n"
+
+    sb ++=
+      s"  }".stripMargin
+  }
+
+  def end() : Unit = {
+    val pc = GlobalData.get.phaseContext
+    val targetPath = s"${pc.config.targetDirectory}/${name}.ralf"
+    val pw = new PrintWriter(targetPath)
+
+    sb ++= "}\n"
+    pw.write(sb.toString())
+
+    pw.close()
+  }
+}

--- a/lib/src/main/scala/spinal/lib/bus/regif/Field.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Field.scala
@@ -9,11 +9,13 @@ case class Field(name: String,
                  resetValue: Long,
                  readError: Boolean,
                  doc: String) extends FieldDescr {
+  private var _name = name
 
   def tailBitPos = section.max
 
   // FieldDescr implementation
-  def getName()       : String     = name
+  def getName()       : String     = _name
+  def setName(name: String): Field = {_name = name ; this}
   def getWidth()      : Int        = hardbit.getWidth
   def getSection()    : Range      = section
   def getAccessType() : AccessType = accType

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -176,7 +176,7 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
     } else {
       symbol.name
     }
-    val nameRemoveNA = if(acc == AccessType.NA) "--" else signame
+    val nameRemoveNA = if(acc == AccessType.NA) "RESERVED" else signame
     fields   += Field(nameRemoveNA, ret, section, acc, resetValue, Rerror, newdoc)
     fieldPtr += bc.value
     ret

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -78,7 +78,14 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
     fields.map(_.accType == AccessType.NA).foldLeft(true)(_&&_)
   }
 
-  def fieldAt(pos: Int, bc: BitCount, acc: AccessType, resetValue: Long = 0, doc: String = "")(implicit symbol: SymbolName): Bits = {
+  @deprecated(message = "fieldAt(pos, Bits/UInt/SInt(n bit)/Bool, acc) recommend", since = "2022-12-31")
+  def fieldAt(pos: Int, bc: BitCount, acc: AccessType)(implicit symbol: SymbolName): Bits = fieldAt(pos, bc, acc, resetValue = 0, doc = "")(symbol)
+  @deprecated(message = "fieldAt(pos, Bits/UInt/SInt(n bit)/Bool, acc) recommend", since = "2022-12-31")
+  def fieldAt(pos: Int, bc: BitCount, acc: AccessType, doc: String)(implicit symbol: SymbolName): Bits = fieldAt(pos, bc, acc, resetValue = 0, doc = doc)(symbol)
+  @deprecated(message = "fieldAt(pos, Bits/UInt/SInt(n bit)/Bool, acc) recommend", since = "2022-12-31")
+  def fieldAt(pos: Int, bc: BitCount, acc: AccessType, resetValue: Long)(implicit symbol: SymbolName): Bits = fieldAt(pos, bc, acc, resetValue, doc = "")(symbol)
+  @deprecated(message = "fieldAt(pos, Bits/UInt/SInt(n bit)/Bool, acc) recommend", since = "2022-12-31")
+  def fieldAt(pos: Int, bc: BitCount, acc: AccessType, resetValue: Long, doc: String)(implicit symbol: SymbolName): Bits = {
     val sectionNext: Section = pos+bc.value-1 downto pos
     val sectionExists: Section = fieldPtr downto 0
     val ret = pos match {
@@ -104,9 +111,13 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
     regfield
   }
 
+  @deprecated(message = "field(Bits/UInt/SInt(n bit)/Bool, acc) recommend", since = "2022-12-31")
   def field(bc: BitCount, acc: AccessType)(implicit symbol: SymbolName): Bits = field(bc, acc, resetValue = 0, doc = "")(symbol)
+  @deprecated(message = "field(Bits/UInt/SInt(n bit)/Bool, acc) recommend", since = "2022-12-31")
   def field(bc: BitCount, acc: AccessType, doc: String)(implicit symbol: SymbolName): Bits = field(bc, acc, resetValue = 0, doc = doc)(symbol)
+  @deprecated(message = "field(Bits/UInt/SInt(n bit)/Bool, acc) recommend", since = "2022-12-31")
   def field(bc: BitCount, acc: AccessType, resetValue: Long)(implicit symbol: SymbolName): Bits = field(bc, acc, resetValue, doc = "")(symbol)
+  @deprecated(message = "field(Bits/UInt/SInt(n bit)/Bool, acc) recommend", since = "2022-12-31")
   def field(bc: BitCount, acc: AccessType, resetValue: Long, doc: String)(implicit symbol: SymbolName): Bits = {
     val section: Range = fieldPtr+bc.value-1 downto fieldPtr
     val ret: Bits = acc match {

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -41,21 +41,29 @@ case class RamInst(name: String, sizeMap: SizeMapping, busif: BusIf) extends Ram
   // RamDescr implementation
   def getName()        : String = name
   def getDoc()         : String = ""
+
 }
 
 class FIFOInst(name: String, addr: Long, doc:String, busif: BusIf) extends RegBase(name,addr,doc,busif) with FifoDescr {
 
   // FifoDescr implementation
-  def getName()        : String = name
   def getAddr()        : Long   = addr
   def getDoc()         : String = doc
-
+  def setName(name: String): FIFOInst = {
+    _name = name
+    this
+  }
   def accept(vs : BusIfVisitor) = {
       vs.visit(this)
   }
 }
 
 case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends RegBase(name, addr, doc, busif) with RegDescr {
+  def setName(name: String): RegInst = {
+    _name = name
+    this
+  }
+
   def checkLast={
     val spareNumbers = if(fields.isEmpty) busif.busDataWidth else busif.busDataWidth-1 - fields.last.tailBitPos
     spareNumbers match {
@@ -136,7 +144,6 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
   }
 
   // RegDescr implementation
-  def getName()        : String           = name
   def getAddr()        : Long             = addr
   def getDoc()         : String           = doc
   def getFieldDescrs() : List[FieldDescr] = getFields
@@ -157,7 +164,7 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
         counts(name) = 0
         name
       }
-      fd.copy(name = newname)
+      fd.setName(newname)
     }
     fields.clear()
     fields ++= ret
@@ -165,9 +172,13 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
 }
 
 abstract class RegBase(name: String, addr: Long, doc: String, busif: BusIf) {
+  protected var _name = name
   protected val fields = ListBuffer[Field]()
   protected var fieldPtr: Int = 0
   protected var Rerror: Boolean = false
+
+  def getName(): String = _name
+  def setName(name: String): RegBase
 
   def readErrorTag = Rerror
   def getFields = fields.toList

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -4,6 +4,7 @@ import spinal.core._
 import spinal.lib.bus.misc.SizeMapping
 
 import scala.collection.mutable.ListBuffer
+import AccessType._
 
 class Section(val max: Int, val min: Int){
   override def toString(): String = {
@@ -126,7 +127,10 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
   def field[T <: BaseType](bt: HardType[T], acc: AccessType, resetValue:Long , doc: String)(implicit symbol: SymbolName): T = {
     val regfield = bt()
     val ret = field(bt.getBitsWidth bit, acc, resetValue, doc)(symbol)
-    regfield.assignFromBits(ret)
+    acc match {
+      case AccessType.RO => ret := regfield.asBits
+      case _ => regfield.assignFromBits(ret)
+    }
     regfield
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -79,9 +79,9 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
     fields.map(_.accType == AccessType.NA).foldLeft(true)(_&&_)
   }
 
-  def fieldAt[T <: BaseType](pos: Int, bt: HardType[T], acc: AccessType)(implicit symbol: SymbolName): T = field(bt, acc, resetValue = 0, doc = "")
-  def fieldAt[T <: BaseType](pos: Int, bt: HardType[T], acc: AccessType, doc: String)(implicit symbol: SymbolName): T = field(bt, acc, resetValue = 0, doc = doc)
-  def fieldAt[T <: BaseType](pos: Int, bt: HardType[T], acc: AccessType, resetValue:Long)(implicit symbol: SymbolName): T = field(bt, acc, resetValue, doc = "")
+  def fieldAt[T <: BaseType](pos: Int, bt: HardType[T], acc: AccessType)(implicit symbol: SymbolName): T = fieldAt(pos, bt, acc, resetValue = 0, doc = "")
+  def fieldAt[T <: BaseType](pos: Int, bt: HardType[T], acc: AccessType, doc: String)(implicit symbol: SymbolName): T = fieldAt(pos, bt, acc, resetValue = 0, doc = doc)
+  def fieldAt[T <: BaseType](pos: Int, bt: HardType[T], acc: AccessType, resetValue:Long)(implicit symbol: SymbolName): T = fieldAt(pos, bt, acc, resetValue, doc = "")
   def fieldAt[T <: BaseType](pos: Int, bt: HardType[T], acc: AccessType, resetValue:Long , doc: String)(implicit symbol: SymbolName): T = {
     val sectionNext: Section = pos + bt.getBitsWidth-1 downto pos
     val sectionExists: Section = fieldPtr downto 0
@@ -180,7 +180,7 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
     } else {
       symbol.name
     }
-    val nameRemoveNA = if(acc == AccessType.NA) "RESERVED" else signame
+    val nameRemoveNA = if(acc == AccessType.NA) "--" else signame
     fields   += Field(nameRemoveNA, ret, section, acc, resetValue, Rerror, newdoc)
     fieldPtr += bc.value
     ret
@@ -211,7 +211,10 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
         counts(name) = 0
         name
       }
-      fd.setName(newname)
+      if(name != "--") {//dont touch RESERVED name
+        fd.setName(newname)
+      }
+      fd
     }
     fields.clear()
     fields ++= ret

--- a/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
+++ b/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
@@ -18,42 +18,42 @@ class RegIfExample extends Component {
   val busif = BusInterface(io.apb,(0x000,1 KiB), 0, regPre = "AP")
 
   val M_TURBO_EARLY_QUIT    = busif.newReg(doc = "Turbo Hardware-mode register1")
-  val early_quit  = M_TURBO_EARLY_QUIT.field(1 bit, RW, 0, doc = "CRC validate early quit enable").asOutput()
-  val early_count = M_TURBO_EARLY_QUIT.field(2 bit, RW, 2, doc = "CRC validate early quit enable").asOutput()
+  val early_quit  = M_TURBO_EARLY_QUIT.field(Bool(), RW, 0, doc = "CRC validate early quit enable").asOutput()
+  val early_count = M_TURBO_EARLY_QUIT.field(Bits(2 bit), RW, 2, doc = "CRC validate early quit enable").asOutput()
   val M_TURBO_THETA         = busif.newReg(doc = "Turbo Hardware-mode register2")
-  val theta       = M_TURBO_THETA.field(4 bit, RW, 0x6, doc = "Back-Weight, UQ(4,3), default 0.75").asOutput()
-  val bib_order   = M_TURBO_THETA.field(1 bit, RW, 1, doc = "bib in Byte, defalut. \n 0:[76543210] \n 1:[01234567]").asOutput()
+  val theta       = M_TURBO_THETA.field(Bits(4 bit), RW, 0x6, doc = "Back-Weight, UQ(4,3), default 0.75").asOutput()
+  val bib_order   = M_TURBO_THETA.field(Bool(), RW, 1, doc = "bib in Byte, defalut. \n 0:[76543210] \n 1:[01234567]").asOutput()
   val M_TURBO_START         = busif.newReg(doc = "Turbo Start register")
-  val turbo_start = M_TURBO_START.field(1 bit, W1P, 0, doc = "turbo start pulse").asOutput()
+  val turbo_start = M_TURBO_START.field(Bool(), W1P, 0, doc = "turbo start pulse").asOutput()
   val M_TURBO_MOD           = busif.newReg(doc = "Turbo Mode")
-  val umts_on   = M_TURBO_MOD.field(1 bit, RW, 1, doc = "1: umts mode\n0: emtc mode").asOutput()
+  val umts_on   = M_TURBO_MOD.field(Bool(), RW, 1, doc = "1: umts mode\n0: emtc mode").asOutput()
   val M_TURBO_CRC_POLY      = busif.newReg(doc = "Turbo CRC Poly")
-  val crc_mode  = M_TURBO_CRC_POLY.field(1 bit, RW, 1, doc = "0: CRC24; 1: CRC16").asOutput()
-  val crc_poly  = M_TURBO_CRC_POLY.field(24 bit, RW, 0x864cfb, doc = "(D24+D23+D18+D17+D14+D11+D10+D7+D6+D5+D4+D3+D+1)").asOutput()
+  val crc_mode  = M_TURBO_CRC_POLY.field(Bool(), RW, 1, doc = "0: CRC24; 1: CRC16").asOutput()
+  val crc_poly  = M_TURBO_CRC_POLY.field(Bits(24 bit), RW, 0x864cfb, doc = "(D24+D23+D18+D17+D14+D11+D10+D7+D6+D5+D4+D3+D+1)").asOutput()
   val M_TURBO_K             = busif.newReg(doc = "Turbo block size")
-  val K         = M_TURBO_K.field(12 bit, RW, 32, doc="decode block size \n max: 4032").asOutput()
+  val K         = M_TURBO_K.field(Bits(12 bit), RW, 32, doc="decode block size \n max: 4032").asOutput()
   val M_TURBO_F1F2          = busif.newReg(doc = "Turbo Interleave Parameter")
-  val f1        = M_TURBO_F1F2.field(9 bit, RW, 0x2f, doc="turbo interleave parameter f1").asOutput()
+  val f1        = M_TURBO_F1F2.field(Bits(9 bit), RW, 0x2f, doc="turbo interleave parameter f1").asOutput()
   M_TURBO_F1F2.reserved(7 bits)
-  val f2        = M_TURBO_F1F2.field(9 bit, RW, 0x2f, doc="turbo interleave parameter f2").asOutput()
+  val f2        = M_TURBO_F1F2.field(Bits(9 bit), RW, 0x2f, doc="turbo interleave parameter f2").asOutput()
   val M_TURBO_MAX_ITER      = busif.newReg(doc = "Turbo Max Iter Times")
-  val max_iter  = M_TURBO_MAX_ITER.field(6 bits, RW, 0, doc="Max iter times 1~63 avaliable").asOutput()
+  val max_iter  = M_TURBO_MAX_ITER.field(Bits(6 bits), RW, 0, doc="Max iter times 1~63 avaliable").asOutput()
   val M_TURBO_FILL_NUM      = busif.newReg(doc = "Turbo block-head fill number")
-  val fill_num  = M_TURBO_FILL_NUM.field(6 bits, RW, 0, doc="0~63 avaliable, Head fill Number").asOutput()
+  val fill_num  = M_TURBO_FILL_NUM.field(Bits(6 bit), RW, 0, doc="0~63 avaliable, Head fill Number").asOutput()
   val M_TURBO_3G_INTER_PV   = busif.newReg(doc = "Turbo UMTS Interleave Parameter P,V")
-  val p     =  M_TURBO_3G_INTER_PV.field(9 bits, RW, 0,doc="parameter of prime").asOutput()
+  val p     =  M_TURBO_3G_INTER_PV.field(Bits(9 bit), RW, 0,doc="parameter of prime").asOutput()
   M_TURBO_3G_INTER_PV.reserved(7 bits)
-  val v     =  M_TURBO_3G_INTER_PV.field(5 bits, RW, 0,doc="Primitive root v").asOutput()
+  val v     =  M_TURBO_3G_INTER_PV.field(Bits(5 bit), RW, 0,doc="Primitive root v").asOutput()
   val M_TURBO_3G_INTER_CRP  = busif.newReg(doc = "Turbo UMTS Interleave Parameter C,R,p")
-  val Rtype     =  M_TURBO_3G_INTER_CRP.field(2 bits, RW, 0,doc="inter Row number\n0:5,1:10,2:20,3:20other").asOutput()
-  val CPtype    =  M_TURBO_3G_INTER_CRP.field(2 bits, RW, 0,doc="CP relation\n0: C=P-1\n1: C=p\n2: C=p+1").asOutput()
-  val KeqRxC    =  M_TURBO_3G_INTER_CRP.field(1 bits, RW, 0,doc="1:K=R*C else 0").asOutput()
+  val Rtype     =  M_TURBO_3G_INTER_CRP.field(UInt(2 bits), RW, 0,doc="inter Row number\n0:5,1:10,2:20,3:20other").asOutput()
+  val CPtype    =  M_TURBO_3G_INTER_CRP.field(SInt(2 bits), RW, 0,doc="CP relation\n0: C=P-1\n1: C=p\n2: C=p+1").asOutput()
+  val KeqRxC    =  M_TURBO_3G_INTER_CRP.field(Bool(), RW, 0,doc="1:K=R*C else 0").asOutput()
   M_TURBO_3G_INTER_CRP.reserved(3 bits)
-  val C         =  M_TURBO_3G_INTER_CRP.field(9 bits, RW, 0x7,doc="interlave Max Column Number").asOutput()
+  val C         =  M_TURBO_3G_INTER_CRP.field(UInt(9 bit), RW, 0x7,doc="interlave Max Column Number").asOutput()
   val M_TURBO_3G_INTER_FILL = busif.newReg(doc = "Turbo UMTS Interleave Fill number")
-  val fillPos   =  M_TURBO_3G_INTER_FILL.field(9 bits, RW, doc="interlave start Column of fill Number").asOutput()
+  val fillPos   =  M_TURBO_3G_INTER_FILL.field(UInt(9 bit), RW, doc="interlave start Column of fill Number").asOutput()
   M_TURBO_3G_INTER_FILL.reserved(7 bits)
-  val fillRow   =  M_TURBO_3G_INTER_FILL.field(2 bits, RW, doc="interlave fill Row number, 0~2 avaliable\n n+1 row").asOutput()
+  val fillRow   =  M_TURBO_3G_INTER_FILL.field(Bits(9 bit), RW, doc="interlave fill Row number, 0~2 avaliable\n n+1 row").asOutput()
 }
 
 class RegIfExample2 extends Component {
@@ -93,39 +93,39 @@ class InterruptRegIf extends Component {
   val busif = Apb3BusInterface(io.apb, (0x000, 100 Byte))
 
   val M_SRCH_INT_EN   = busif.newReg(doc="srch int enable register")
-  val psc_int_en      = M_SRCH_INT_EN.field(1 bits, RW, doc="psc interrupt enable register")
-  val pth_int_en      = M_SRCH_INT_EN.field(1 bits, RW, doc="pth interrupt enable register")
-  val ssc_int_en      = M_SRCH_INT_EN.field(1 bits, RW, doc="ssc interrupt enable register")
-  val grp_int_en      = M_SRCH_INT_EN.field(1 bits, RW, doc="grp interrupt enable register")
-  val scd_int_en      = M_SRCH_INT_EN.field(1 bits, RW, doc="scd interrupt enable register")
-  val srch_finish_en  = M_SRCH_INT_EN.field(1 bits, RW, doc="srch finish interrupt enable register")
+  val psc_int_en      = M_SRCH_INT_EN.field(Bool(), RW, doc="psc interrupt enable register")
+  val pth_int_en      = M_SRCH_INT_EN.field(Bool(), RW, doc="pth interrupt enable register")
+  val ssc_int_en      = M_SRCH_INT_EN.field(Bool(), RW, doc="ssc interrupt enable register")
+  val grp_int_en      = M_SRCH_INT_EN.field(Bool(), RW, doc="grp interrupt enable register")
+  val scd_int_en      = M_SRCH_INT_EN.field(Bool(), RW, doc="scd interrupt enable register")
+  val srch_finish_en  = M_SRCH_INT_EN.field(Bool(), RW, doc="srch finish interrupt enable register")
 
   val M_SRCH_INT_MASK  = busif.newReg(doc="srch int mask register")
-  val psc_int_mask     = M_SRCH_INT_MASK.field(1 bits, RW, doc="psc interrupt mask register")
-  val pth_int_mask     = M_SRCH_INT_MASK.field(1 bits, RW, doc="pth interrupt mask register")
-  val ssc_int_mask     = M_SRCH_INT_MASK.field(1 bits, RW, doc="ssc interrupt mask register")
-  val grp_int_mask     = M_SRCH_INT_MASK.field(1 bits, RW, doc="grp interrupt mask register")
-  val scd_int_mask     = M_SRCH_INT_MASK.field(1 bits, RW, doc="scd interrupt mask register")
-  val srch_finish_mask = M_SRCH_INT_MASK.field(1 bits, RW, doc="srch finish interrupt mask register")
+  val psc_int_mask     = M_SRCH_INT_MASK.field(Bool(), RW, doc="psc interrupt mask register")
+  val pth_int_mask     = M_SRCH_INT_MASK.field(Bool(), RW, doc="pth interrupt mask register")
+  val ssc_int_mask     = M_SRCH_INT_MASK.field(Bool(), RW, doc="ssc interrupt mask register")
+  val grp_int_mask     = M_SRCH_INT_MASK.field(Bool(), RW, doc="grp interrupt mask register")
+  val scd_int_mask     = M_SRCH_INT_MASK.field(Bool(), RW, doc="scd interrupt mask register")
+  val srch_finish_mask = M_SRCH_INT_MASK.field(Bool(), RW, doc="srch finish interrupt mask register")
 
   val M_SRCH_INT_STATUS = busif.newReg(doc="srch int status register")
 
-  val psc_int_status     = M_SRCH_INT_STATUS.field(1 bits, RC, doc="psc interrupt status register")
-  val pth_int_status     = M_SRCH_INT_STATUS.field(1 bits, RC, doc="pth interrupt status register")
-  val ssc_int_status     = M_SRCH_INT_STATUS.field(1 bits, RC, doc="ssc interrupt status register")
-  val grp_int_status     = M_SRCH_INT_STATUS.field(1 bits, RC, doc="grp interrupt status register")
-  val scd_int_status     = M_SRCH_INT_STATUS.field(1 bits, RC, doc="scd interrupt status register")
-  val srch_finish_status = M_SRCH_INT_STATUS.field(1 bits, RC, doc="srch finish interrupt status register")
+  val psc_int_status     = M_SRCH_INT_STATUS.field(Bool(), RC, doc="psc interrupt status register")
+  val pth_int_status     = M_SRCH_INT_STATUS.field(Bool(), RC, doc="pth interrupt status register")
+  val ssc_int_status     = M_SRCH_INT_STATUS.field(Bool(), RC, doc="ssc interrupt status register")
+  val grp_int_status     = M_SRCH_INT_STATUS.field(Bool(), RC, doc="grp interrupt status register")
+  val scd_int_status     = M_SRCH_INT_STATUS.field(Bool(), RC, doc="scd interrupt status register")
+  val srch_finish_status = M_SRCH_INT_STATUS.field(Bool(), RC, doc="srch finish interrupt status register")
 
-  when(io.psc_done && psc_int_en.asBool){psc_int_status(0).set()}
-  when(io.pth_done && pth_int_en.asBool){pth_int_status(0).set()}
-  when(io.ssc_done && ssc_int_en.asBool){ssc_int_status(0).set()}
-  when(io.grp_done && grp_int_en.asBool){grp_int_status(0).set()}
-  when(io.scd_done && scd_int_en.asBool){scd_int_status(0).set()}
-  when(io.srch_finish && srch_finish_en.asBool){srch_finish_status(0).set()}
+  when(io.psc_done && psc_int_en){psc_int_status.set()}
+  when(io.pth_done && pth_int_en){pth_int_status.set()}
+  when(io.ssc_done && ssc_int_en){ssc_int_status.set()}
+  when(io.grp_done && grp_int_en){grp_int_status.set()}
+  when(io.scd_done && scd_int_en){scd_int_status.set()}
+  when(io.srch_finish && srch_finish_en){srch_finish_status(0)}
 
   io.interrupt := (psc_int_status & pth_int_status & ssc_int_status &
-                   grp_int_status & scd_int_status & srch_finish_status).lsb
+                   grp_int_status & scd_int_status & srch_finish_status)
 }
 class InterruptRegIf3 extends Component {
   val io = new Bundle {
@@ -150,25 +150,25 @@ class cpInterruptExample extends Component {
   val busif = Apb3BusInterface(io.apb, (0x000, 100 Byte))
 
   val M_CP_INT_EN    = busif.newReg(doc="cp int enable register")
-  val tx_int_en      = M_CP_INT_EN.field(1 bits, RW, doc="tx interrupt enable register")
-  val rx_int_en      = M_CP_INT_EN.field(1 bits, RW, doc="rx interrupt enable register")
-  val frame_int_en   = M_CP_INT_EN.field(1 bits, RW, doc="frame interrupt enable register")
+  val tx_int_en      = M_CP_INT_EN.field(Bool(), RW, doc="tx interrupt enable register")
+  val rx_int_en      = M_CP_INT_EN.field(Bool(), RW, doc="rx interrupt enable register")
+  val frame_int_en   = M_CP_INT_EN.field(Bool(), RW, doc="frame interrupt enable register")
   val M_CP_INT_MASK  = busif.newReg(doc="cp int mask register")
-  val tx_int_mask      = M_CP_INT_MASK.field(1 bits, RW, doc="tx interrupt mask register")
-  val rx_int_mask      = M_CP_INT_MASK.field(1 bits, RW, doc="rx interrupt mask register")
-  val frame_int_mask   = M_CP_INT_MASK.field(1 bits, RW, doc="frame interrupt mask register")
+  val tx_int_mask      = M_CP_INT_MASK.field(Bool(), RW, doc="tx interrupt mask register")
+  val rx_int_mask      = M_CP_INT_MASK.field(Bool(), RW, doc="rx interrupt mask register")
+  val frame_int_mask   = M_CP_INT_MASK.field(Bool(), RW, doc="frame interrupt mask register")
   val M_CP_INT_STATE   = busif.newReg(doc="cp int state register")
-  val tx_int_state      = M_CP_INT_STATE.field(1 bits, RW, doc="tx interrupt state register")
-  val rx_int_state      = M_CP_INT_STATE.field(1 bits, RW, doc="rx interrupt state register")
-  val frame_int_state   = M_CP_INT_STATE.field(1 bits, RW, doc="frame interrupt state register")
+  val tx_int_state      = M_CP_INT_STATE.field(Bool(), RW, doc="tx interrupt state register")
+  val rx_int_state      = M_CP_INT_STATE.field(Bool(), RW, doc="rx interrupt state register")
+  val frame_int_state   = M_CP_INT_STATE.field(Bool(), RW, doc="frame interrupt state register")
 
-  when(io.rx_done && rx_int_en(0)){tx_int_state(0).set()}
-  when(io.tx_done && tx_int_en(0)){tx_int_state(0).set()}
-  when(io.frame_end && frame_int_en(0)){tx_int_state(0).set()}
+  when(io.rx_done && rx_int_en){tx_int_state.set()}
+  when(io.tx_done && tx_int_en){tx_int_state.set()}
+  when(io.frame_end && frame_int_en){tx_int_state.set()}
 
-  io.interrupt := (tx_int_mask(0) && tx_int_state(0)  ||
-    rx_int_mask(0) && rx_int_state(0) ||
-    frame_int_mask(0) && frame_int_state(0))
+  io.interrupt := (tx_int_mask && tx_int_state  ||
+    rx_int_mask && rx_int_state ||
+    frame_int_mask && frame_int_state)
 }
 
 class cpInterruptFactoryExample extends Component {

--- a/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
+++ b/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
@@ -6,9 +6,6 @@ import spinal.lib.bus.amba3.apb._
 import spinal.lib.bus.misc.SizeMapping
 import spinal.lib.bus.regif.AccessType._
 import spinal.lib.bus.regif._
-import spinal.lib.bus.regif.Document.CHeaderGenerator
-import spinal.lib.bus.regif.Document.HtmlGenerator
-import spinal.lib.bus.regif.Document.JsonGenerator
 
 class RegIfExample extends Component {
   val io = new Bundle{

--- a/tester/src/main/scala/spinal/tester/code/RegIfInterrupt.scala
+++ b/tester/src/main/scala/spinal/tester/code/RegIfInterrupt.scala
@@ -6,9 +6,6 @@ import spinal.lib._
 import spinal.lib.bus.amba3.apb._
 import spinal.lib.bus.amba3.apb.sim.Apb3Driver
 import spinal.lib.bus.regif._
-import spinal.lib.bus.regif.Document.CHeaderGenerator
-import spinal.lib.bus.regif.Document.HtmlGenerator
-import spinal.lib.bus.regif.Document.JsonGenerator
 
 class RegFileIntrExample extends Component{
   val io = new Bundle{


### PR DESCRIPTION
here 4 update for regif 
1. RegInst with `setName()`
For more convenient naming of some extreme use scenarios
```scala 
val manyRegs3 = (0 to 10).map(i => busif.newReg(doc= "tt").setName(s"Name${i}").fieldAt(Bits(32 bit), AccessType.WO, doc = "hello")(SymbolName(s"reg3_${I}"))
  
```
2. RegInst with new field API support HardType parameter

new way:
```scala 
    val REG0 = busif.newReg("MyReg0")
    val start = REG5.field(Bool(), acc= AccessType.RW, 0, doc ="xxx")
    val para0 = REG5.field(UInt(4 bit), acc= AccessType.RW, 0, doc ="xxx")
    val para1 = REG5.fieldAt(8, SInt(8 bit), acc= AccessType.RW, 0, doc ="xxx")
```
old way:
```scala
    val REG0 = busif.newReg("MyReg0")
    val start = REG5.field(1 bit, acc= AccessType.RW, 0, doc ="xxx").lsb
    val para0 = REG5.field(4 bit, acc= AccessType.RW, 0, doc ="xxx").asUInt
    val para1 = REG5.fieldAt(8, 8 bit, acc= AccessType.RW, 0, doc ="xxx").asSInt
```
the old ways still exist with ` @deprecated(message = "field(Bits/UInt/SInt(n bit)/Bool, acc) recommend", since = "2022-12-31")` comment

3. add RalfGenerator [http://www.subwaysparkle.com/wp-content/uploads/2021/01/uvm_ralgen_ug.pdf](UVM Register Abstraction Layer Generator)
```scala
busif.accept(RalfGenerator("V400_intr_hub"))
```

4. remove regif.Document hierarchy 

**Note** mabe compile error will be reported. Just remove `import spinal.lib.bus.regif.Document.XXX` ,
use `import spinal.lib.bus.regif._` instead
