### PR TITLE
Don't generate VHDL port list when there are no ports defined

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -72,19 +72,22 @@ class ComponentEmitterVhdl(
 
 
     ret ++= s"\nentity ${c.definitionName} is\n"
-    ret ++= s"  port("
-    var first = true
 
-    for(portMap <- portMaps){
-      if(first){
-        ret ++= s"\n    $portMap"
-        first = false
-      } else {
-        ret ++= s";\n    $portMap"
+    if (portMaps.length > 0) {
+      ret ++= s"  port("
+      var first = true
+
+      for (portMap <- portMaps) {
+        if (first) {
+          ret ++= s"\n    $portMap"
+          first = false
+        } else {
+          ret ++= s";\n    $portMap"
+        }
       }
-    }
 
-    ret ++= "\n  );\n"
+      ret ++= "\n  );\n"
+    }
 
     ret ++= s"end ${c.definitionName};\n"
     ret ++= s"\n"


### PR DESCRIPTION
Components without any signals in the IO bundle still generate a port list but without elements. The VHDL spec doesn't allow an empty list so we shouldn't emit one if it's empty.