### PR TITLE
lib: bus: amba4: Axi4ToApb3: Ignore writes without strb

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4SharedToApb3Bridge.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4SharedToApb3Bridge.scala
@@ -91,6 +91,16 @@ case class Axi4SharedToApb3Bridge(addressWidth: Int, dataWidth: Int, idWidth: In
       when(io.axi.sharedCmd.valid && (!io.axi.sharedCmd.write || io.axi.writeData.valid)) {
         phase := ACCESS
         io.apb.PSEL(0) := True
+        if (axiConfig.useStrb) {
+          // Ignore write packages with no strobe signal asserted and overwrite phase + PSEL.
+          when(io.axi.writeData.valid &&
+               io.axi.writeData.strb === B(0, axiConfig.bytePerWord bits)) {
+            phase := RESPONSE
+            io.apb.PSEL(0) := False
+            io.axi.sharedCmd.ready := True
+            io.axi.writeData.ready := True
+          }
+        }
       }
     }
     is(ACCESS){


### PR DESCRIPTION
When downsizing an AXI4 channel to 32 bits, it adds transmission without
strobe asserted to the 32 bit channel. The Apb3 bridge does not check
whether the strobe signals are set or not and forwards wrong
transmissions.

Ignore a write transmission when all strobe signals are deasserted and
simply acknowledge the transmission without forwarding.

Signed-off-by: Daniel Schultz <dnltz@aesc-silicon.de>