### PR TITLE
Remove whitespaces in generated verilog files

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -374,7 +374,7 @@ class ComponentEmitterVerilog(
           case spinal.core.inout                         => "~"
           case _  => SpinalError("Not founded IO type")
         }
-        s"    .${portAlign}    (${wireAlign}  )${comma} //${dirtag}\n"
+        s"    .${portAlign} (${wireAlign})${comma} //${dirtag}\n"
       }.mkString
 
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -351,7 +351,7 @@ class ComponentEmitterVerilog(
               case _                            => SpinalError(s"The generic type ${"\""}${e._1} - ${e._2}${"\""} of the blackbox ${"\""}${bb.definitionName}${"\""} is not supported in Verilog")
             }
           }
-          logics.setCharAt(logics.size - 2, ' ')
+          logics.replace(logics.length - 2, logics.length, "\n")
           logics ++= s"  ) "
         }
       }

--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -42,7 +42,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
       outFile = new java.io.FileWriter(targetPath)
       outFile.write(VhdlVerilogBase.getHeader("//", pc.config.rtlHeader, topLevel, config.headerWithDate, config.headerWithRepoHash))
 
-      outFile.write("`timescale 1ns/1ps ")
+      outFile.write("`timescale 1ns/1ps")
 
       emitEnumPackage(outFile)
 


### PR DESCRIPTION

```
Legend:
  $ = end-of-line
  ~ = trailing whitespaces

Before:
  IBUF #($
    .IBUF_LOW_PWR("TRUE"),$
    .IOSTANDARD("DEFAULT")~$     <--- comma replaced with whitespace
  ) iBUF_1 ($
    .I    (io_clock_PAD  ), //i$     <---- whitespaces in ports
    .O    (iBUF_1_O      )  //o$    <----
  );$

After:
  IBUF #($
    .IBUF_LOW_PWR("TRUE"),$
    .IOSTANDARD("DEFAULT")$
  ) iBUF_1 ($
    .I (io_clock_PAD), //i$
    .O (iBUF_1_O    )  //o$
  );$
```

@Dolu1990 - I'm not sure if there is a reason behind the whitespaces in the Verilog port connection. Please let me know if I should drop https://github.com/SpinalHDL/SpinalHDL/commit/7e331e7358f3bfcf559ba9ac2a63a494e68b572f