### PR TITLE
Prove for fifo.

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1038,12 +1038,12 @@ class StreamFifo[T <: Data](dataType: HardType[T], depth: Int) extends Component
     }
   }
   
-  def withAssumes() = {
+  def withAssumes() = this.rework {
     import spinal.core.formal._
     assume(io.pop.payload === past(logic.ram(logic.popPtr)))
   }
 
-  def formalCheck(cond: T => Bool): Vec[Bool] = {
+  def formalCheck(cond: T => Bool): Vec[Bool] = this.rework {
     val pushBound = logic.pushPtr.value + depth
     val check = Vec(False, depth)
     for (i <- 0 until depth) {
@@ -1059,17 +1059,17 @@ class StreamFifo[T <: Data](dataType: HardType[T], depth: Int) extends Component
     check
   }
 
-  def formalContains(word: T): Bool = {
-    formalCheck(_ === word).reduce(_ || _)
+  def formalContains(word: T): Bool = this.rework {
+    formalCheck(_ === word.pull()).reduce(_ || _)
   }
-  def formalContains(cond: T => Bool): Bool = {
+  def formalContains(cond: T => Bool): Bool = this.rework {
     formalCheck(cond).reduce(_ || _)
   }
 
-  def formalCount(word: T): UInt = {
-    CountOne(formalCheck(_ === word))
+  def formalCount(word: T): UInt = this.rework {
+    CountOne(formalCheck(_ === word.pull()))
   }
-  def formalCount(cond: T => Bool): UInt = {
+  def formalCount(cond: T => Bool): UInt = this.rework {
     CountOne(formalCheck(cond))
   }
 }

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -533,18 +533,6 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
     }
     this
   }
-
-
-
-  // this could be more generic.
-  def formalCreateEvent(getCond: Stream[T] => Bool): Bool = {
-    import spinal.core.formal._
-    val event = RegInit(False)
-    when(getCond(this)) {
-      assume(event === True)
-    }
-    event
-  }
 }
 
 object StreamArbiter {

--- a/tester/src/main/scala/spinal/tester/PlayDev.scala
+++ b/tester/src/main/scala/spinal/tester/PlayDev.scala
@@ -1714,24 +1714,16 @@ object PlayFormalFifo extends App {
       // when(dut.io.push.fire && dut.io.push.payload === d1) {
       //   assume(d1_in === True)
       // }
-      val d1_in = dut.io.push.formalCreateEvent{x => 
-        x.fire && x.payload===d1
-      }     
-      val d1_out = dut.io.pop.formalCreateEvent{x => 
-        x.fire && x.payload===d1
-      }
+      val d1_in = RegInit(False) setWhen (dut.io.push.fire && d1 === dut.io.push.payload)
+      val d1_out = RegInit(False) setWhen (dut.io.pop.fire && d1 === dut.io.pop.payload)
 
       when(d1_out) {
         assert(d1_in === True)
       }
 
       val d2 = anyconst(UInt(7 bits))
-      val d2_in = dut.io.push.formalCreateEvent{x => 
-        x.fire && x.payload===d2
-      }
-      val d2_out = dut.io.pop.formalCreateEvent{x => 
-        x.fire && x.payload===d2
-      }
+      val d2_in = RegInit(False) setWhen (dut.io.push.fire && d2 === dut.io.push.payload)
+      val d2_out = RegInit(False) setWhen (dut.io.pop.fire && d2 === dut.io.pop.payload)
 
       when(d2_out) {
         assert(d2_in === True)

--- a/tester/src/main/scala/spinal/tester/code/Formal.scala
+++ b/tester/src/main/scala/spinal/tester/code/Formal.scala
@@ -105,19 +105,6 @@ object LimitedCounterMoreAssertFormal extends App {
   })
 }
 
-object LimitedCounterProveFormal extends App {
-  import spinal.core.formal._
-
-  FormalConfig.withProve(15).doVerify(new Component {
-    val dut = FormalDut(new LimitedCounter())
-
-    assumeInitial(ClockDomain.current.isResetActive)
-
-    assert(dut.value >= 2)
-    assert(dut.value <= 10)
-  })
-}
-
 object LimitedCounterCoverFormal extends App {
   import spinal.core.formal._
 

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalFifo.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalFifo.scala
@@ -160,18 +160,20 @@ object FormalFifo {
         dut.io.pop.withAsserts()
         dut.dut.withAssumes()
 
-        val (d1, d1_in, d1_out) = prepareData(dut.io.push, dut.io.pop)
+        val d1 = anyconst(UInt(7 bits))
+        val d2 = anyconst(UInt(7 bits))        
         dut.io.d1 := d1
+        dut.io.d2 := d2
+
+        val (d1_in, d2_in) = dut.io.push.withOrderAssumes(d1, d2)
+        val (d1_out, d2_out) = dut.io.pop.withOrderAsserts(d1, d2)
+
         when(!d1_in) { assume(!dut.dut.formalContains(d1)) }
         when(d1_in && !d1_out) { assert(dut.dut.formalCount(d1) === 1) }
 
-        val (d2, d2_in, d2_out) = prepareData(dut.io.push, dut.io.pop)
-        dut.io.d2 := d2
         when(!d2_in) { assume(!dut.dut.formalContains(d2)) }
         when(d2_in && !d2_out) { assert(dut.dut.formalCount(d2) === 1) }
 
-        assume(d1 =/= d2)
-        when(!d1_in) { assume(!d2_in) }
         when(d1_in && d2_in && !d1_out) { assert(!d2_out) }
       })
   }

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalFifo.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalFifo.scala
@@ -1,69 +1,68 @@
 package spinal.tester.scalatest
 
-
 import spinal.core.formal._
 import spinal.core._
 import spinal.lib.{Stream, StreamFifo, Timeout, master, slave, CountOne}
 
 object FormalFifo {
   val Error = new AreaRoot {
-    val DROP_PUSH = new Nameable{}
-    val DROP_POP = new Nameable{}
-    val DUPLICATE = new Nameable{}
-    val CORRUPT = new Nameable{}
-    val LOCK_PUSH = new Nameable{}
-    val LOCK_POP = new Nameable{}
+    val DROP_PUSH = new Nameable {}
+    val DROP_POP = new Nameable {}
+    val DUPLICATE = new Nameable {}
+    val CORRUPT = new Nameable {}
+    val LOCK_PUSH = new Nameable {}
+    val LOCK_POP = new Nameable {}
     def all = List(DROP_PUSH, DROP_POP, DUPLICATE, CORRUPT, LOCK_PUSH, LOCK_POP)
   }
   val Trigger = new AreaRoot {
-    val D1 =  new Nameable{}
-    val D2  = new Nameable{}
-    val ANY = new Nameable{}
+    val D1 = new Nameable {}
+    val D2 = new Nameable {}
+    val ANY = new Nameable {}
     def all = List(D1, D2, ANY)
   }
 
-  class StreamFifoWrapper(error : Any, trigger : Any) extends Component {
+  class StreamFifoWrapper(error: Any, trigger: Any) extends Component {
     val io = new Bundle {
       val push = slave Stream (UInt(7 bits))
       val pop = master Stream (UInt(7 bits))
-      val d1, d2 = in UInt(7 bits)
+      val d1, d2 = in UInt (7 bits)
     }
 
     val dut = StreamFifo(UInt(7 bits), 4)
 
-    val condPush = trigger match{
-      case Trigger.D1 => io.push.payload === io.d1
-      case Trigger.D2 => io.push.payload === io.d2
+    val condPush = trigger match {
+      case Trigger.D1  => io.push.payload === io.d1
+      case Trigger.D2  => io.push.payload === io.d2
       case Trigger.ANY => anyseq(Bool())
     }
-    val condPop = trigger match{
-      case Trigger.D1 => io.pop.payload === io.d1
-      case Trigger.D2 => io.pop.payload === io.d2
+    val condPop = trigger match {
+      case Trigger.D1  => io.pop.payload === io.d1
+      case Trigger.D2  => io.pop.payload === io.d2
       case Trigger.ANY => anyseq(Bool())
     }
     error match {
-      case Error.DROP_PUSH =>{
+      case Error.DROP_PUSH => {
         dut.io.push << io.push.throwWhen(condPush)
         dut.io.pop >> io.pop
       }
-      case Error.DROP_POP =>{
+      case Error.DROP_POP => {
         dut.io.push << io.push
         dut.io.pop.throwWhen(condPop) >> io.pop
       }
-      case Error.DUPLICATE =>{
+      case Error.DUPLICATE => {
         dut.io.push << io.push.s2mPipe().forkSerial(condPush)
         dut.io.pop >> io.pop
       }
-      case Error.CORRUPT =>{
+      case Error.CORRUPT => {
         dut.io.push << io.push.translateWith(io.push.payload ^ condPush.asUInt(7 bits))
         assume(io.d1 =/= (io.d2 ^ 1))
         dut.io.pop >> io.pop
       }
-      case Error.LOCK_PUSH =>{
+      case Error.LOCK_PUSH => {
         dut.io.push << io.push.haltWhen(condPush)
         dut.io.pop >> io.pop
       }
-      case Error.LOCK_POP =>{
+      case Error.LOCK_POP => {
         dut.io.push << io.push
         dut.io.pop.haltWhen(condPop) >> io.pop
       }
@@ -74,8 +73,10 @@ object FormalFifo {
     }
   }
 
-  def fifoBmcTest(error: Any, trigger : Any, depth : Int = 12) = {
-    FormalConfig.withBMC(depth).doVerify(new Component {
+  def fifoBmcTest(error: Any, trigger: Any, depth: Int = 12) = {
+    FormalConfig
+      .withBMC(depth)
+      .doVerify(new Component {
         val dut = new StreamFifoWrapper(error, trigger)
         val reset = ClockDomain.current.isResetActive
 
@@ -85,7 +86,7 @@ object FormalFifo {
         anyseq(dut.io.push.valid)
         anyseq(dut.io.pop.ready)
 
-        when(past(dut.io.push.isStall) init(False)){
+        when(past(dut.io.push.isStall) init (False)) {
           assume(dut.io.push.valid)
           assume(stable(dut.io.push.payload))
         }
@@ -100,27 +101,29 @@ object FormalFifo {
         val d1_in = hit(dut.io.push, d1)
         val d2_in = hit(dut.io.push, d2)
         when(dut.io.push.valid) {
-          assume(!(dut.io.push.payload === d1 && d1_in)) //Enforce only one d1
-          assume(!(dut.io.push.payload === d2 && (!d1_in || d2_in))) //Enforce only one d2, and after d1
+          assume(!(dut.io.push.payload === d1 && d1_in)) // Enforce only one d1
+          assume(!(dut.io.push.payload === d2 && (!d1_in || d2_in))) // Enforce only one d2, and after d1
         }
 
         val d1_out = hit(dut.io.pop, d1)
         val d2_out = hit(dut.io.pop, d2)
-        assert(!(dut.io.pop.valid && dut.io.pop.payload === d1 && d1_out)) //Check no duplication
-        assert(!(d2_out && !d1_out)) //Check ordering
+        assert(!(dut.io.pop.valid && dut.io.pop.payload === d1 && d1_out)) // Check no duplication
+        assert(!(d2_out && !d1_out)) // Check ordering
 
-        //Check looks
+        // Check looks
         val timeout = Timeout(3)
-        when(!dut.io.push.isStall || dut.io.pop.valid){
+        when(!dut.io.push.isStall || dut.io.pop.valid) {
           timeout.clear()
         }
         assert(!timeout.state)
-      }
-    )
+      })
   }
 
-  def fifoProveTest(error: Any, trigger : Any) = {
-    def prepareData(inStream: Stream[UInt], outStream: Stream[UInt], ram: Vec[UInt], push: UInt, pop: UInt): Tuple3[UInt, Bool, Bool] = {
+  def fifoProveTest(error: Any, trigger: Any) = {
+    def prepareData(
+        inStream: Stream[UInt],
+        outStream: Stream[UInt]
+    ): Tuple3[UInt, Bool, Bool] = {
       val data = anyconst(UInt(7 bits))
       assume(data =/= 0)
 
@@ -128,38 +131,14 @@ object FormalFifo {
       val data_out = RegInit(False) setWhen (outStream.fire && data === outStream.payload)
       when(data_in) { assume(inStream.payload =/= data) }
       when(!data_in) { assert(!data_out) }
-      
-      when(!data_in) {assume(ram.map(_ =/= data).reduce(_ && _))}
-      // when(rose(data_in)) {assert(ram(past(push)) === data)}
-      val pushBound = push + 4
-      val check = Vec(False, 4)
-      when(data_in && !data_out) {
-        for (i <- 0 until 4){
-          val pop_i = pop.resize(3 bits) + i
-          when(pop < push) {
-            when(pop_i < push){ check(i) := ram(pop_i.resized) === data }
-          }.elsewhen(pop > push) {
-            when(pop_i < pushBound) { check(i) := ram(pop_i.resized) === data}
-          }.elsewhen(pop === push && outStream.valid) {
-            check(i) := ram(i) === data
-          }
-        }
-        assert(CountOne(check) === 1)
-      }
-      assume(outStream.payload === past(ram(pop)))
-      // when(data_out) { assert(data_in === True) }
-      // when(outStream.valid && data === outStream.payload) { assert(data_in === True) }
+
       cover(data_out)
-
-      // val data_cnt = Counter(0, 4)
-      // when(!data_in) { data_cnt.clear() }
-      // when(data_in && outStream.fire && data_cnt.value < 4) { data_cnt.increment() }
-      // when(data_in && data_cnt.value === 4) { assert(data_out) }
-
       (data, data_in, data_out)
     }
 
-    FormalConfig.withProve(10).doVerify(new Component {
+    FormalConfig
+      .withProve(10)
+      .doVerify(new Component {
         val dut = FormalDut(new StreamFifoWrapper(error, trigger))
         val reset = ClockDomain.current.isResetActive
 
@@ -179,35 +158,21 @@ object FormalFifo {
 
         dut.io.push.withAssumes()
         dut.io.pop.withAsserts()
+        dut.dut.withAssumes()
 
-        val fifoRam = Vec(UInt(7 bits), 4)
-        for(i <- 0 until 4){
-          fifoRam(i) := dut.dut.logic.ram(i)
-        }
-        val fifoPush = dut.dut.logic.pushPtr
-        val fifoPop = dut.dut.logic.popPtr
-
-        val (d1, d1_in, d1_out) = prepareData(dut.io.push, dut.io.pop, fifoRam, fifoPush, fifoPop)
+        val (d1, d1_in, d1_out) = prepareData(dut.io.push, dut.io.pop)
         dut.io.d1 := d1
+        when(!d1_in) { assume(!dut.dut.formalContains(d1)) }
+        when(d1_in && !d1_out) { assert(dut.dut.formalCount(d1) === 1) }
 
-        val (d2, d2_in, d2_out) = prepareData(dut.io.push, dut.io.pop, fifoRam, fifoPush, fifoPop)
+        val (d2, d2_in, d2_out) = prepareData(dut.io.push, dut.io.pop)
         dut.io.d2 := d2
-                
-        // when(d2_out) {
-        //   d1_in := False
-        //   d1_out := False
-        //   when(dut.io.pop.fire) {
-        //     d2_in := False
-        //     d2_out := False
-        //   }
-        // }
+        when(!d2_in) { assume(!dut.dut.formalContains(d2)) }
+        when(d2_in && !d2_out) { assert(dut.dut.formalCount(d2) === 1) }
 
-        assume(d1 =/= d2)        
+        assume(d1 =/= d2)
         when(!d1_in) { assume(!d2_in) }
         when(d1_in && d2_in && !d1_out) { assert(!d2_out) }
-        // when(d2_in) { assume(d1_in) }
-        // when(d2_out && d2_in) { assert(d1_out) }
-      }
-    )
+      })
   }
 }


### PR DESCRIPTION
It's weird that when I move some formal code to fifo, then "HIERARCHY VIOLATION ..." and "OLD NETLIST RE-USED : Memory port Mem.readAsync(x) ..." errors take place.

The only thing I have done is move formalContains checking into StreamFifo, which act a little different while prove then ram.