### PR TITLE
RegIf: Restructure descriptors

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
@@ -30,7 +30,7 @@ trait BusIfBase extends Area{
 trait BusIf extends BusIfBase {
   type B <: this.type
   private val RegInsts = ListBuffer[RegInst]()
-  private var regPtr: Int = 0
+  private var regPtr: BigInt = 0
 
   def getModuleName: String
   val regPre: String
@@ -59,7 +59,7 @@ trait BusIf extends BusIfBase {
     readGenerator()
   })
 
-  def newRegAt(address:Int, doc: String)(implicit symbol: SymbolName) = {
+  def newRegAt(address: BigInt, doc: String)(implicit symbol: SymbolName) = {
     assert(address % wordAddressInc == 0, s"located Position not align by wordAddressInc: ${wordAddressInc}")
     assert(address >= regPtr, s"located Position conflict to Pre allocated Address: ${regPtr}")
     regPtr = address + wordAddressInc
@@ -72,13 +72,13 @@ trait BusIf extends BusIfBase {
     res
   }
 
-  def creatReg(name: String, addr: Long, doc: String) = {
+  def creatReg(name: String, addr: BigInt, doc: String) = {
     val ret = new RegInst(name, addr, doc, this)
     RegInsts += ret
     ret
   }
 
-  def newRAM(name: String, addr: Long, size: Long, doc: String) = {
+  def newRAM(name: String, addr: BigInt, size: BigInt, doc: String) = {
     class bmi extends Bundle{
       val wr     = Bool()
       val waddr  = UInt()
@@ -119,7 +119,7 @@ trait BusIf extends BusIfBase {
     interrupt with Raw/Force/Mask/Status 4 Register Interface
     **/
   def interruptFactory(regNamePre: String, triggers: Bool*): Bool = interruptFactoryAt(regPtr, regNamePre, triggers:_*)
-  def interruptFactoryAt(addrOffset: Int, regNamePre: String, triggers: Bool*): Bool = {
+  def interruptFactoryAt(addrOffset: BigInt, regNamePre: String, triggers: Bool*): Bool = {
     require(triggers.size > 0)
     val groups = triggers.grouped(this.busDataWidth).toList
     val ret = groups.zipWithIndex.map{case (trigs, i) =>
@@ -135,7 +135,7 @@ trait BusIf extends BusIfBase {
     interrupt with Raw/Mask/Status 3 Register Interface
     **/
   def interruptFactoryNoForce(regNamePre: String, triggers: Bool*): Bool = interruptFactoryNoForceAt(regPtr, regNamePre, triggers:_*)
-  def interruptFactoryNoForceAt(addrOffset: Int, regNamePre: String, triggers: Bool*): Bool = {
+  def interruptFactoryNoForceAt(addrOffset: BigInt, regNamePre: String, triggers: Bool*): Bool = {
     require(triggers.size > 0)
     val groups = triggers.grouped(this.busDataWidth).toList
     val ret = groups.zipWithIndex.map{case (trigs, i) =>
@@ -152,7 +152,7 @@ trait BusIf extends BusIfBase {
     always used for sys_level_int merge
     **/
   def interruptLevelFactory(regNamePre: String, levels: Bool*): Bool = interruptLevelFactoryAt(regPtr, regNamePre, levels:_*)
-  def interruptLevelFactoryAt(addrOffset: Int, regNamePre: String, levels: Bool*): Bool = {
+  def interruptLevelFactoryAt(addrOffset: BigInt, regNamePre: String, levels: Bool*): Bool = {
     require(levels.size > 0)
     val groups = levels.grouped(this.busDataWidth).toList
     val ret = groups.zipWithIndex.map{case (trigs, i) =>
@@ -167,7 +167,7 @@ trait BusIf extends BusIfBase {
   /*
   interrupt with Raw/Force/Mask/Status Register Interface
   **/
-  protected def int_RFMS(offset: Int, regNamePre: String, triggers: Bool*): Bool = {
+  protected def int_RFMS(offset: BigInt, regNamePre: String, triggers: Bool*): Bool = {
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
     require(triggers.size <= this.busDataWidth )
     val RAW    = this.newRegAt(offset,"Interrupt Raw status Register\n set when event \n clear when write 1")(SymbolName(s"${regNamePre_}INT_RAW"))
@@ -191,7 +191,7 @@ trait BusIf extends BusIfBase {
   /*
     interrupt with Force/Mask/Status Register Interface
     * */
-  protected def int_RMS(offset: Int,regNamePre: String, triggers: Bool*): Bool = {
+  protected def int_RMS(offset: BigInt,regNamePre: String, triggers: Bool*): Bool = {
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
     require(triggers.size <= this.busDataWidth )
     val RAW    = this.newRegAt(offset,"Interrupt Raw status Register\n set when event \n clear when write 1")(SymbolName(s"${regNamePre_}INT_RAW"))
@@ -213,7 +213,7 @@ trait BusIf extends BusIfBase {
   /*
     interrupt with Mask/Status Register Interface
     * */
-  protected def int_MS(offset: Int, regNamePre: String, int_levels: Bool*): Bool = {
+  protected def int_MS(offset: BigInt, regNamePre: String, int_levels: Bool*): Bool = {
     val regNamePre_ = if (regNamePre != "") regNamePre+"_" else ""
     require(int_levels.size <= this.busDataWidth )
     val MASK   = this.newRegAt(offset, "Interrupt Mask   Register\n1: int off\n0: int open\n default 1, int off")(SymbolName(s"${regNamePre_}INT_MASK"))

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfVisitor.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfVisitor.scala
@@ -7,6 +7,8 @@ trait BaseDescriptor {
 
 trait MemoryMappedDescriptor extends BaseDescriptor {
   def getAddr()        : BigInt
+
+  def accept(visitor: BusIfVisitor): Unit = visitor.visit(this)
 }
 
 trait RamDescr extends MemoryMappedDescriptor {

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfVisitor.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfVisitor.scala
@@ -1,35 +1,33 @@
 package spinal.lib.bus.regif
 
-trait RamDescr {
+trait BaseDescriptor {
   def getName()        : String
   def getDoc()         : String
 }
 
-trait FifoDescr {
-  def getName()        : String
-  def getAddr()        : Long
-  def getDoc()         : String
+trait MemoryMappedDescriptor extends BaseDescriptor {
+  def getAddr()        : BigInt
 }
 
-trait RegDescr {
-  def getName()        : String
-  def getAddr()        : Long
-  def getDoc()         : String
+trait RamDescr extends MemoryMappedDescriptor {
+  def getSize()        : BigInt
+}
+
+trait FifoDescr extends MemoryMappedDescriptor {}
+
+trait RegDescr extends MemoryMappedDescriptor {
   def getFieldDescrs() : List[FieldDescr]
 }
 
-trait FieldDescr {
-  def getName()       : String
+trait FieldDescr extends BaseDescriptor {
   def getWidth()      : Int
   def getSection()    : Range
   def getAccessType() : AccessType
   def getResetValue() : Long
-  def getDoc()        : String
 }
 
 trait  BusIfVisitor {
-  def begin(busDataWidth : Int) : Unit
-  def visit(descr : FifoDescr)  : Unit  
-  def visit(descr : RegDescr)   : Unit
-  def end()                     : Unit
+  def begin(busDataWidth : Int)      : Unit
+  def visit(descr : BaseDescriptor)  : Unit
+  def end()                          : Unit
 }

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfVisitor.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfVisitor.scala
@@ -7,13 +7,12 @@ trait BaseDescriptor {
 
 trait MemoryMappedDescriptor extends BaseDescriptor {
   def getAddr()        : BigInt
+  def getSize()        : BigInt
 
   def accept(visitor: BusIfVisitor): Unit = visitor.visit(this)
 }
 
-trait RamDescr extends MemoryMappedDescriptor {
-  def getSize()        : BigInt
-}
+trait RamDescr extends MemoryMappedDescriptor {}
 
 trait FifoDescr extends MemoryMappedDescriptor {}
 

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
@@ -30,18 +30,18 @@ final case class CHeaderGenerator(
 
     }
 
-    def visit(descr : FifoDescr)  : Unit = {
+    def visit(descr : BaseDescriptor) : Unit = {
+        descr match {
+            case descr: RegDescr => {
+                def nameLen = descr.getName.length()
 
-    }
+                if(nameLen > regLength)
+                    regLength = nameLen
 
-    def visit(descr : RegDescr) : Unit = {
-        def nameLen = descr.getName.length()
-
-        if(nameLen > regLength)
-            regLength = nameLen
-
-        regs += descr
-        types += Type(descr.getName, descr.getFieldDescrs)
+                regs += descr
+                types += Type(descr.getName, descr.getFieldDescrs)
+            }
+        }
     }
     
     def end() : Unit = {

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
@@ -41,6 +41,7 @@ final case class CHeaderGenerator(
                 regs += descr
                 types += Type(descr.getName, descr.getFieldDescrs)
             }
+            case _ => ???
         }
     }
     

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/DocTemplate.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/DocTemplate.scala
@@ -35,7 +35,7 @@ object DocTemplate {
       """
         |      .theme-spring{
         |          border-collapse: collapse;
-        |          font-size: 1.em;
+        |          font-size: 1.0em;
         |          min-width: 800px;
         |          border-radius: 5px 5px 0 0 ;
         |          overflow: hidden;
@@ -61,7 +61,7 @@ object DocTemplate {
         |          border-bottom: 3px solid #009879;
         |      }
         |      .theme-spring tbody tr.active-row {
-        |          font-weight: blod;
+        |          font-weight: bold;
         |          color: #009879;
         |      }
         |      .theme-spring tbody td.reserved{

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/HtmlGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/HtmlGenerator.scala
@@ -48,6 +48,7 @@ final case class HtmlGenerator(fileName : String, title : String) extends BusIfV
 
                 descr.getFieldDescrs().reverse.tail.foreach(sb ++= genTr(_))
             }
+            case _ => ???
         }
     }
 

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/HtmlGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/HtmlGenerator.scala
@@ -12,10 +12,6 @@ final case class HtmlGenerator(fileName : String, title : String) extends BusIfV
         dataWidth = busDataWidth
     }
 
-    def visit(descr : FifoDescr)  : Unit = {
-        
-    }
-
     def formatResetValue(value: BigInt, bitCount: Int):String = {
         val hexCount = scala.math.ceil(bitCount/4.0).toInt
         val unsignedValue = if(value >= 0) value else ((BigInt(1) << bitCount) + value)
@@ -37,18 +33,22 @@ final case class HtmlGenerator(fileName : String, title : String) extends BusIfV
                       </tr>""".stripMargin
     }
 
-    def visit(descr : RegDescr) : Unit = {
-        val fieldsNumbers = descr.getFieldDescrs.size
-        sb ++=
-        s"""          <tr class="reg" align="left">
-           |            <td align="center" rowspan="${fieldsNumbers}">0x${descr.getAddr.toHexString}</td>
-           |            <td align="left" rowspan="${fieldsNumbers}">${(descr.getName).toUpperCase()}</td>
-           |            <td class="fixWidth" align="center" rowspan="${fieldsNumbers}">${descr.getDoc} </td>
-           |            <td align="center" rowspan="${fieldsNumbers}">${dataWidth}</td>
-           |${genTds(descr.getFieldDescrs.last)}
-           |          </tr>""".stripMargin
+    def visit(descr : BaseDescriptor) : Unit = {
+        descr match {
+            case descr: RegDescr => {
+                val fieldsNumbers = descr.getFieldDescrs.size
+                sb ++=
+                  s"""          <tr class="reg" align="left">
+                     |            <td align="center" rowspan="${fieldsNumbers}">0x${descr.getAddr.toString(16).toUpperCase}</td>
+                     |            <td align="left" rowspan="${fieldsNumbers}">${(descr.getName).toUpperCase()}</td>
+                     |            <td class="fixWidth" align="center" rowspan="${fieldsNumbers}">${descr.getDoc} </td>
+                     |            <td align="center" rowspan="${fieldsNumbers}">${dataWidth}</td>
+                     |${genTds(descr.getFieldDescrs.last)}
+                     |          </tr>""".stripMargin
 
-        descr.getFieldDescrs().reverse.tail.foreach(sb ++= genTr(_))
+                descr.getFieldDescrs().reverse.tail.foreach(sb ++= genTr(_))
+            }
+        }
     }
 
     def end() : Unit = {

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
@@ -49,6 +49,7 @@ final case class JsonGenerator(fileName : String) extends BusIfVisitor {
 
                 prefix = ",\n"
             }
+            case _ => ???
         }
     }
     

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
@@ -16,40 +16,40 @@ final case class JsonGenerator(fileName : String) extends BusIfVisitor {
         sb ++= "["
     }
 
-    def visit(descr : FifoDescr)  : Unit = {
+    def visit(descr : BaseDescriptor) : Unit = {
+        descr match {
+            case descr: RegDescr => {
+                sb ++= prefix
 
-    }
+                sb ++=
+                  s"""|{
+                      |   "addr"   : ${descr.getAddr()},
+                      |   "name"   : "${descr.getName()}",
+                      |   "doc"    : "${clean(descr.getDoc())}",
+                      |   "fields" :[\n""".stripMargin
 
-    def visit(descr : RegDescr) : Unit = {
-        sb ++= prefix
+                var fieldPrefix = ""
+                descr.getFieldDescrs().foreach(f =>{
+                    sb ++= fieldPrefix
+                    sb ++=
+                      s"""|       {
+                          |           "accType" : "${f.getAccessType()}",
+                          |           "name"    : "${f.getName()}",
+                          |           "width"   : ${f.getWidth()},
+                          |           "reset"   : ${f.getResetValue()},
+                          |           "doc"     : "${clean(f.getDoc())}"
+                          |       }""".stripMargin
+                    fieldPrefix = ",\n"
+                })
+                sb ++= "\n"
 
-        sb ++=
-            s"""|{
-                |   "addr"   : ${descr.getAddr()},
-                |   "name"   : "${descr.getName()}",
-                |   "doc"    : "${clean(descr.getDoc())}",
-                |   "fields" :[\n""".stripMargin
+                sb ++=
+                  s"""|   ]
+                      |}""".stripMargin
 
-        var fieldPrefix = ""
-        descr.getFieldDescrs().foreach(f =>{
-            sb ++= fieldPrefix
-            sb ++=
-                s"""|       {
-                    |           "accType" : "${f.getAccessType()}",
-                    |           "name"    : "${f.getName()}",
-                    |           "width"   : ${f.getWidth()},
-                    |           "reset"   : ${f.getResetValue()},
-                    |           "doc"     : "${clean(f.getDoc())}"
-                    |       }""".stripMargin
-            fieldPrefix = ",\n"
-        })
-        sb ++= "\n"
-
-        sb ++=
-            s"""|   ]
-                |}""".stripMargin
-        
-        prefix = ",\n"
+                prefix = ",\n"
+            }
+        }
     }
     
     def end() : Unit = {

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/RalfGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/RalfGenerator.scala
@@ -53,6 +53,7 @@ final case class RalfGenerator(fileName : String) extends BusIfVisitor {
 
         sb ++= ret
       }
+      case _ => ???
     }
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -22,7 +22,7 @@ object Section{
 }
 
 
-case class RamInst(name: String, sizeMap: SizeMapping, busif: BusIf) extends RamDescr {
+case class RamInst(name: String, sizeMap: SizeMapping, doc: String, busif: BusIf) extends RamDescr {
   private var Rerror: Boolean = false
   def readErrorTag = Rerror
 
@@ -41,7 +41,7 @@ case class RamInst(name: String, sizeMap: SizeMapping, busif: BusIf) extends Ram
 
   // RamDescr implementation
   def getName()        : String = name
-  def getDoc()         : String = ""
+  def getDoc()         : String = doc
   def getAddr()        : BigInt = sizeMap.base
   def getSize()        : BigInt = sizeMap.size
 
@@ -55,9 +55,6 @@ class FIFOInst(name: String, addr: BigInt, doc:String, busif: BusIf) extends Reg
   def setName(name: String): FIFOInst = {
     _name = name
     this
-  }
-  def accept(vs : BusIfVisitor) = {
-      vs.visit(this)
   }
 }
 
@@ -281,7 +278,7 @@ case class RegInst(name: String, addr: BigInt, doc: String, busif: BusIf) extend
   def getDoc()         : String           = doc
   def getFieldDescrs() : List[FieldDescr] = getFields
 
-  def accept(vs : BusIfVisitor) = {
+  override def accept(vs : BusIfVisitor) = {
     duplicateRenaming()
     vs.visit(this)
   }
@@ -656,6 +653,4 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf) {
   protected def NA(bc: BitCount): Bits = {
     Bits(bc).clearAll()
   }
-
-  def accept(vs : BusIfVisitor)
 }

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -51,6 +51,7 @@ class FIFOInst(name: String, addr: BigInt, doc:String, busif: BusIf) extends Reg
 
   // FifoDescr implementation
   def getAddr()        : BigInt = addr
+  def getSize()        : BigInt = busif.wordAddressInc
   def getDoc()         : String = doc
   def setName(name: String): FIFOInst = {
     _name = name
@@ -275,6 +276,7 @@ case class RegInst(name: String, addr: BigInt, doc: String, busif: BusIf) extend
 
   // RegDescr implementation
   def getAddr()        : BigInt           = addr
+  def getSize()        : BigInt           = busif.wordAddressInc
   def getDoc()         : String           = doc
   def getFieldDescrs() : List[FieldDescr] = getFields
 

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -42,13 +42,15 @@ case class RamInst(name: String, sizeMap: SizeMapping, busif: BusIf) extends Ram
   // RamDescr implementation
   def getName()        : String = name
   def getDoc()         : String = ""
+  def getAddr()        : BigInt = sizeMap.base
+  def getSize()        : BigInt = sizeMap.size
 
 }
 
-class FIFOInst(name: String, addr: Long, doc:String, busif: BusIf) extends RegBase(name,addr,doc,busif) with FifoDescr {
+class FIFOInst(name: String, addr: BigInt, doc:String, busif: BusIf) extends RegBase(name,addr,doc,busif) with FifoDescr {
 
   // FifoDescr implementation
-  def getAddr()        : Long   = addr
+  def getAddr()        : BigInt = addr
   def getDoc()         : String = doc
   def setName(name: String): FIFOInst = {
     _name = name
@@ -59,7 +61,7 @@ class FIFOInst(name: String, addr: Long, doc:String, busif: BusIf) extends RegBa
   }
 }
 
-case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends RegBase(name, addr, doc, busif) with RegDescr {
+case class RegInst(name: String, addr: BigInt, doc: String, busif: BusIf) extends RegBase(name, addr, doc, busif) with RegDescr {
   def setName(name: String): RegInst = {
     _name = name
     this
@@ -275,7 +277,7 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
   }
 
   // RegDescr implementation
-  def getAddr()        : Long             = addr
+  def getAddr()        : BigInt           = addr
   def getDoc()         : String           = doc
   def getFieldDescrs() : List[FieldDescr] = getFields
 
@@ -305,7 +307,7 @@ case class RegInst(name: String, addr: Long, doc: String, busif: BusIf) extends 
   }
 }
 
-abstract class RegBase(name: String, addr: Long, doc: String, busif: BusIf) {
+abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf) {
   protected var _name = name
   protected val fields = ListBuffer[Field]()
   protected var fieldPtr: Int = 0


### PR DESCRIPTION
Rework RegIf descriptor traits to support additional types easier.

I pushed all the visitor types into match statements but those can be refactored into private functions down the road.
