### PR TITLE
Add `synopsys_sim.setup` and other environment setup support

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -646,6 +646,7 @@ case class SpinalSimConfig(
 
   def withVCSSimSetup(setupFile: String, beforeAnalysis: () => Unit): this.type = {
     _vcsSimSetupFile = setupFile
+    _vcsEnvSetup = beforeAnalysis
     this
   }
 


### PR DESCRIPTION
1. Now user can provide a `synopsys_sim.setup` file to VCS;
2. Customized scripts or functions can be executed before the VCS analysis step now.