### PR TITLE
XSim: Add missing t_fp_xsi_get_time type

### DIFF
--- a/sim/src/main/resources/xsi_loader.h
+++ b/sim/src/main/resources/xsi_loader.h
@@ -7,6 +7,10 @@
 #include <string>
 #include <exception>
 
+extern "C" {
+    typedef XSI_INT64 (*t_fp_xsi_get_time)(xsiHandle);
+}
+
 namespace Xsi {
 
 class LoaderException : public std::exception {


### PR DESCRIPTION
This adds a missing function pointer type for XSI's `get_time`. Don't see how this slipped through because my copy of `xsi.h` has the following date code:
```
// $Id: xsi.h,v 1.3 2011/04/19 21:26:27 kumar Exp $
```
My Vivado is 2021.1:
```
Vivado v2021.1 (64-bit)
SW Build: 3247384 on Thu Jun 10 19:36:33 MDT 2021
IP Build: 3246043 on Fri Jun 11 00:30:35 MDT 2021
```
Also maybe it should be made clear somewhere that the sim launch `PATH` needs `%VIVADO_HOME%/bin` and `%VIVADO_HOME%/lib/<machine>` to work. Took me way too long to figure out why `xsimk.dll` wouldn't load. Oops.