### PR TITLE
rename withPast to pastValid to clearify the target.

### DIFF
--- a/core/src/main/scala/spinal/core/formal/package.scala
+++ b/core/src/main/scala/spinal/core/formal/package.scala
@@ -16,7 +16,7 @@ package object formal {
     ptr
   }
   def past[T <: Data](that : T) : T = past(that, 1)
-  def withPast() : Bool = signalCache("formal.withPast")(past(!ClockDomain.current.isResetActive) init(False) setWeakName("formal_with_past"))
+  def pastValid() : Bool = signalCache("formal.pastValid")(past(!ClockDomain.current.isResetActive) init(False) setWeakName("formal_with_past"))
 
   def rose(that : Bool) : Bool = that.rise(True)
   def fell(that : Bool) : Bool = that.fall(False)

--- a/tester/src/main/scala/spinal/tester/code/Formal.scala
+++ b/tester/src/main/scala/spinal/tester/code/Formal.scala
@@ -99,7 +99,7 @@ object LimitedCounterMoreAssertFormal extends App {
 
     // Check that the value is incrementing.
     // hasPast is used to ensure that the past(dut.value) had at least one sampling out of reset
-    when(withPast() && past(dut.value) =/= 10){
+    when(pastValid() && past(dut.value) =/= 10){
       assert(dut.value === past(dut.value) + 1)
     }
   })


### PR DESCRIPTION
rename withPast to pastValid to clearify the target.