### PR TITLE
fix speed of the Verilog component emitter

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -73,14 +73,13 @@ class ComponentEmitterVerilog(
 
 
   def emitEntity(): Unit = {
-    component.getOrdredNodeIo
-      .filterNot(_.isSuffix)
-      .foreach{baseType =>
+    val ios = component.getOrdredNodeIo.filterNot(_.isSuffix)
+    ios.foreach{baseType =>
       val syntax     = s"${emitSyntaxAttributes(baseType.instanceAttributes)}"
       val dir        = s"${emitDirection(baseType)}"
       val section    = s"${emitType(baseType)}"
       val name       = s"${baseType.getName()}"
-      val comma      = if(baseType == component.getOrdredNodeIo.filterNot(_.isSuffix).last) "" else ","
+      val comma      = if(baseType == ios.last) "" else ","
       val EDAcomment = s"${emitCommentAttributes(baseType.instanceAttributes)}"  //like "/* verilator public */"
 
       if(outputsToBufferize.contains(baseType) || baseType.isInput){
@@ -367,12 +366,11 @@ class ComponentEmitterVerilog(
 
       logics ++= s"${child.getName()} (\n"
 
-      val instports: String = child.getOrdredNodeIo
-        .filterNot(_.isSuffix)
-        .map{ data =>
+      val ios = child.getOrdredNodeIo.filterNot(_.isSuffix)
+      val instports: String = ios.map{ data =>
         val portAlign  = s"%-${maxNameLength}s".format(emitReferenceNoOverrides(data))
         val wireAlign  = s"%-${maxNameLengthCon}s".format(netsWithSection(data))
-        val comma      = if (data == child.getOrdredNodeIo.filterNot(_.isSuffix).last) " " else ","
+        val comma      = if (data == ios.last) " " else ","
         val dirtag: String = data.dir match{
           case spinal.core.in  | spinal.core.inWithNull  => "i"
           case spinal.core.out | spinal.core.outWithNull => "o"


### PR DESCRIPTION
Nested foreach causes `O(n^2)` complexity in the Verilog generation. This bug did not affect VHDL. For my design this fix reduces the time from ~1h to ~3.5min. VHDL generation is still faster (~2min vs. ~3.5min), so further Verilog generation speedup may be possible.