### PR TITLE
Call compositAssignFrom on Vec elements to propagate compositeAssign hook

### DIFF
--- a/core/src/main/scala/spinal/core/Vec.scala
+++ b/core/src/main/scala/spinal/core/Vec.scala
@@ -279,7 +279,7 @@ class Vec[T <: Data](var _dataType : HardType[T], val vec: Vector[T]) extends Mu
       case that: Vec[T] =>
         if (that.vec.size != this.vec.size) throw new Exception("Can't assign Vec with a different size")
         for ((to, from) <- (this.vec, that.vec).zipped) {
-          to.assignFromImpl(from, to, kind)
+          to.compositAssignFrom(from, to, kind)
         }
       case _            => throw new Exception("Undefined assignment")
     }


### PR DESCRIPTION
A `compositeAssign` hook currently has no effect on the elements of a `Vec` because `Vec::assignFromImpl` calls `assignFromImpl` on its elements directly rather than via `compositAssignFrom`.  
This change aligns `Vec`'s behaviour with that of [`Bundle::assignFromImpl`](https://github.com/SpinalHDL/SpinalHDL/blob/dev/core/src/main/scala/spinal/core/Bundle.scala#L164).

I believe this fixes #748.