### PR TITLE
rename formal functions to distinct Master and Slave ends.

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -582,7 +582,7 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
   def withTimeoutAsserts(maxStallCycles : Int = 0) : this.type = {
     import spinal.core.formal._
     if (maxStallCycles > 0) {
-      val counter = Counter(maxStallCycles, this.isStall)
+      val counter = Counter(maxStallCycles, this.isStall).setCompositeName(this, "timeoutCounter", true)
       when(this.fire) { counter.clear()} 
       .otherwise { assert(!counter.willOverflow) }
     }
@@ -592,7 +592,7 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
   def withTimeoutAssumes(maxStallCycles : Int = 0) : this.type = {
     import spinal.core.formal._
     if (maxStallCycles > 0) {
-      val counter = Counter(maxStallCycles, this.isStall)
+      val counter = Counter(maxStallCycles, this.isStall).setCompositeName(this, "timeoutCounter", true)
       when(this.fire) { counter.clear() } 
       .elsewhen(counter.willOverflow) { assume(this.ready === True) }
     }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ReadOnly.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ReadOnly.scala
@@ -154,34 +154,40 @@ case class Axi4ReadOnly(config: Axi4Config) extends Bundle with IMasterSlave wit
       histInput.valid := True
     }
 
-    def withAsserts(maxStallCycles: Int = 0) = {
+    def withMasterAsserts(maxStallCycles: Int = 0) = {
       ar.withAsserts()
-      ar.withTimeoutAssumes(maxStallCycles)
-      r.withAssumes()
       r.withTimeoutAsserts(maxStallCycles)
 
       when(ar.valid) {
         addrChecker.withAsserts()
       }
+    }
+
+    def withMasterAssumes(maxStallCycles: Int = 0) = {
+      ar.withTimeoutAssumes(maxStallCycles)
+      r.withAssumes()
 
       assume(!errors.DataNumberDonotFitLen)
       assume(!errors.NoAddrRequest)
       assume(!errors.WrongResponseForExAccesss)
     }
 
-    def withAssumes(maxStallCycles: Int = 0) = {
-      ar.withAssumes()
+    def withSlaveAsserts(maxStallCycles: Int = 0) = {
       ar.withTimeoutAsserts(maxStallCycles)
       r.withAsserts()
+
+      assert(!errors.DataNumberDonotFitLen)
+      assert(!errors.NoAddrRequest)
+      assert(!errors.WrongResponseForExAccesss)
+    }
+
+    def withSlaveAssumes(maxStallCycles: Int = 0) = {
+      ar.withAssumes()
       r.withTimeoutAssumes(maxStallCycles)
 
       when(ar.valid) {
         addrChecker.withAssumes()
       }
-
-      assert(!errors.DataNumberDonotFitLen)
-      assert(!errors.NoAddrRequest)
-      assert(!errors.WrongResponseForExAccesss)
     }
 
     def withCovers() = {

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
@@ -201,12 +201,9 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
       val DataNumberDonotFitLen = dataErrors.reduce(_ | _)
     }
 
-    def withAsserts(maxStallCycles: Int = 0) = new Area {
+    def withMasterAsserts(maxStallCycles: Int = 0) = new Area {
       aw.withAsserts()
-      aw.withTimeoutAssumes(maxStallCycles)
       w.withAsserts()
-      w.withTimeoutAssumes(maxStallCycles)
-      b.withAssumes()
       b.withTimeoutAsserts(maxStallCycles)
 
       when(aw.valid) {
@@ -214,18 +211,31 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
       }
 
       assert(!errors.DataNumberDonotFitLen)
-      assume(!errors.WrongResponse)
       assert(!errors.WrongStrb)
       assert(!errors.ValidWhileReset)
-      assume(!errors.RespWhileReset)
     }
 
-    def withAssumes(maxStallCycles: Int = 0) = new Area {
-      aw.withAssumes()
+    def withMasterAssumes(maxStallCycles: Int = 0) = new Area {
+      aw.withTimeoutAssumes(maxStallCycles)
+      w.withTimeoutAssumes(maxStallCycles)
+      b.withAssumes()
+
+      assume(!errors.WrongResponse)
+      assume(!errors.RespWhileReset)
+    }
+    
+    def withSlaveAsserts(maxStallCycles: Int = 0) = new Area {
       aw.withTimeoutAsserts(maxStallCycles)
-      w.withAssumes()
       w.withTimeoutAsserts(maxStallCycles)
       b.withAsserts()
+
+      assert(!errors.WrongResponse)
+      assert(!errors.RespWhileReset)
+    }
+
+    def withSlaveAssumes(maxStallCycles: Int = 0) = new Area {
+      aw.withAssumes()
+      w.withAssumes()
       b.withTimeoutAssumes(maxStallCycles)
 
       when(aw.valid) {
@@ -233,10 +243,8 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
       }
 
       assume(!errors.DataNumberDonotFitLen)
-      assert(!errors.WrongResponse)
       assume(!errors.WrongStrb)
       assume(!errors.ValidWhileReset)
-      assert(!errors.RespWhileReset)
     }
 
     def withCovers() = {

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4WriteOnly.scala
@@ -201,7 +201,7 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
       val DataNumberDonotFitLen = dataErrors.reduce(_ | _)
     }
 
-    def withMasterAsserts(maxStallCycles: Int = 0) = new Area {
+    def withMasterAsserts(maxStallCycles: Int = 0) = {
       aw.withAsserts()
       w.withAsserts()
       b.withTimeoutAsserts(maxStallCycles)
@@ -215,7 +215,7 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
       assert(!errors.ValidWhileReset)
     }
 
-    def withMasterAssumes(maxStallCycles: Int = 0) = new Area {
+    def withMasterAssumes(maxStallCycles: Int = 0) = {
       aw.withTimeoutAssumes(maxStallCycles)
       w.withTimeoutAssumes(maxStallCycles)
       b.withAssumes()
@@ -224,7 +224,7 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
       assume(!errors.RespWhileReset)
     }
     
-    def withSlaveAsserts(maxStallCycles: Int = 0) = new Area {
+    def withSlaveAsserts(maxStallCycles: Int = 0) = {
       aw.withTimeoutAsserts(maxStallCycles)
       w.withTimeoutAsserts(maxStallCycles)
       b.withAsserts()
@@ -233,7 +233,7 @@ case class Axi4WriteOnly(config: Axi4Config) extends Bundle with IMasterSlave wi
       assert(!errors.RespWhileReset)
     }
 
-    def withSlaveAssumes(maxStallCycles: Int = 0) = new Area {
+    def withSlaveAssumes(maxStallCycles: Int = 0) = {
       aw.withAssumes()
       w.withAssumes()
       b.withTimeoutAssumes(maxStallCycles)

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalAxi4DownsizerTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalAxi4DownsizerTester.scala
@@ -47,9 +47,11 @@ class FormalAxi4DownsizerTester extends SpinalFormalFunSuite {
 
         val maxStall = 16
         val inputChecker = input.formalContext(4, 4)
-        inputChecker.withAssumes(maxStall)
+        inputChecker.withSlaveAsserts(maxStall)
+        inputChecker.withSlaveAssumes(maxStall)
         val outputChecker = output.formalContext(4, 4)
-        outputChecker.withAsserts(maxStall)
+        outputChecker.withMasterAsserts(maxStall)
+        outputChecker.withMasterAssumes(maxStall)
 
         when(inHist.io.input.valid) {
           val inputSelected = inputChecker.hist.io.outStreams(inputChecker.wId)
@@ -101,9 +103,11 @@ class FormalAxi4DownsizerTester extends SpinalFormalFunSuite {
 
         val maxStall = 16
         val inputChecker = input.formalContext(4)
-        inputChecker.withAssumes(maxStall)
+        inputChecker.withSlaveAsserts(maxStall)
+        inputChecker.withSlaveAssumes(maxStall)
         val outputChecker = output.formalContext(4)
-        outputChecker.withAsserts(maxStall)
+        outputChecker.withMasterAsserts(maxStall)
+        outputChecker.withMasterAssumes(maxStall)
 
         outputChecker.withCovers()
         inputChecker.withCovers()


### PR DESCRIPTION
withXXXAsserts should include only assert properties, and also withXXXAssumes.
The Master and Slave replace XXX above can specify the target that asserts and assume is target to.