### PR TITLE
fix(sim): fix bad classpath when invoked from Mill

### DIFF
--- a/sim/src/main/java/spinal/sim/DynamicCompiler.java
+++ b/sim/src/main/java/spinal/sim/DynamicCompiler.java
@@ -102,7 +102,10 @@ public class DynamicCompiler {
                 null);
         //specify classes output folder
 //        System.out.println("**********   " + System.getProperty("java.class.path"));
-        Iterable options = Arrays.asList("-d", classOutputFolder/*, "-classpath", System.getProperty("java.class.path")*/);
+        String separator = System.getProperty("path.separator");
+        String myPath = DynamicCompiler.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        String classpath = System.getProperty("java.class.path") + separator + myPath;
+        Iterable options = Arrays.asList("-d", classOutputFolder, "-classpath", classpath);
         JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager,
                 c, options, null,
                 files);
@@ -154,7 +157,7 @@ public class DynamicCompiler {
             URL[] urls = new URL[]{url};
 
             // Create a new class loader with the directory
-            ClassLoader loader = new URLClassLoader(urls);
+            ClassLoader loader = new URLClassLoader(urls, Thread.currentThread().getContextClassLoader());
 
             // Load in the class; Class.childclass should be located in
             // the directory file:/class/demo/


### PR DESCRIPTION
Mill have a mechanism to separate the CP used by testers and and by Mill itself, see [here](https://github.com/com-lihaoyi/mill/blob/main/main/util/src/mill/util/Jvm.scala#L16).

`DynamicCompiler` and `URLClassLoader`  gets the Mill CP from `System.getProperty("java.class.path")`, so they cannot find `spinal.sim` package.

For `DynamicCompiler`, path of SpinalSim JAR is appended to classpath and passed to the compiler as cmdline options.
For `URLClassLoader`, current classloader (created and set by Mill to run testers) is passed as parent classloader in constructor arguments.

This patch should fix #716.