### PR TITLE
fix axiMemorySim data.drop() bug

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/AxiMemorySim.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/AxiMemorySim.scala
@@ -136,11 +136,13 @@ case class SparseMemory() {
     val endPageIndex = getPageIndex(address + data.length - 1)
     var offset = getOffset(address)
     
-    for(i <- startPageIndex to endPageIndex) {
-      val page = getElseAllocPage(i)
-      val bytesWritten = page.writeArray(offset, data)
-      data.drop(bytesWritten)
-      offset = 0
+    List.tabulate(endPageIndex - startPageIndex + 1)(_ + startPageIndex).foldLeft(data){
+      (writeData,pageIndex) => {
+          val page = getElseAllocPage(pageIndex)
+          val bytesWritten = page.writeArray(offset, writeData)
+          offset = 0
+          writeData.drop(bytesWritten)
+      }
     }
   }
 


### PR DESCRIPTION
In AxiMemorySim.scala  the  `writeArray` function got fault result when write data to multi-page, since the `data.drop(bytesWritten)` didn't change object data, but return a new object, so, the second page will be written by the origin data.