### PR TITLE
Add AvalonST basic support

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
@@ -28,18 +28,18 @@ case class AvalonSTConfig(dataWidth: Int,
 }
 
 case class AvalonSTPayload(config: AvalonSTConfig) extends Bundle {
-  val data: Bits    = if (config.useData) Bits(config.dataWidth bit) else null
-  val channel: UInt = if (config.useChannels) UInt(config.channelWidth bit) else null
-  val error: Bits   = if (config.useError) Bits(config.errorWidth bit) else null
-  val empty: UInt   = if (config.useEmpty) UInt(config.emptyWidth bit) else null
-  val eop: Bool     = if (config.useEOP) Bool() else null
-  val sop: Bool     = if (config.useSOP) Bool() else null
+  val data: Bits    = config.useData generate Bits(config.dataWidth bit)
+  val channel: UInt = config.useChannels generate UInt(config.channelWidth bit)
+  val error: Bits   = config.useError generate Bits(config.errorWidth bit)
+  val empty: UInt   = config.useEmpty generate UInt(config.emptyWidth bit)
+  val eop: Bool     = config.useEOP generate Bool()
+  val sop: Bool     = config.useSOP generate Bool()
 }
 
 case class AvalonST(config: AvalonSTConfig) extends Bundle with IMasterSlave {
 
-  val ready: Bool = if (config.useReady) Bool() else null
-  val valid: Bool = if (config.useValid) Bool() else null
+  val ready: Bool = config.useReady generate Bool()
+  val valid: Bool = config.useValid generate Bool()
   val payload: AvalonSTPayload = AvalonSTPayload(config)
 
   lazy val latencyDelay: Bool = Delay(this.ready, config.readyLatency)

--- a/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
@@ -42,13 +42,17 @@ case class AvalonST(config: AvalonSTConfig) extends Bundle with IMasterSlave {
   val valid: Bool = config.useValid generate Bool()
   val payload: AvalonSTPayload = AvalonSTPayload(config)
 
-  lazy val latencyDelay: Bool = Delay(this.ready, config.readyLatency)
-  lazy val allowanceDelay: Bool = Delay(latencyDelay, config.readyAllowance)
+  def latencyDelay: Bool = signalCache.apply(this, "latencyDelay") {
+    Delay(this.ready, config.readyLatency)
+  }
+  def allowanceDelay: Bool = signalCache.apply(this, "allowanceDelay") {
+    Delay(latencyDelay, config.readyAllowance)
+  }
 
   // Logical ready accounting for ready latency and allowance
-  lazy val logicalReady: Bool = latencyDelay || allowanceDelay
+  def logicalReady: Bool = latencyDelay || allowanceDelay
 
-  lazy val fire: Bool = valid && logicalReady
+  def fire: Bool = valid && logicalReady
 
   override def clone: AvalonST = AvalonST(config)
 

--- a/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
@@ -76,6 +76,8 @@ case class AvalonST(config: AvalonSTConfig) extends Bundle with IMasterSlave {
   }
 
   def <<(that: AvalonST): AvalonST = {
+    assert(that.config.readyAllowance <= config.readyAllowance, "Sink stream ready allowance must be <= than that of the source stream")
+    assert(that.config.readyLatency >= config.readyLatency, "Sink stream ready latency must be >= than that of the source stream")
     arbitrateFrom(that)
     this.payload := that.payload
 
@@ -192,8 +194,8 @@ class AvalonSTDelayAdapter(config: AvalonSTConfig,
                            newReadyAllowance: Int,
                            depth: Int = 31) extends Component {
   val io = new Bundle {
-    val m = master(AvalonST(config))
-    val s = slave(AvalonST(config.copy(readyLatency = newReadyLatency, readyAllowance = newReadyAllowance)))
+    val m = master(AvalonST(config.copy(readyLatency = newReadyLatency, readyAllowance = newReadyAllowance)))
+    val s = slave(AvalonST(config))
   }
 
   val fifo = new StreamFifo(AvalonSTPayload(config), depth)

--- a/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
@@ -118,10 +118,10 @@ case class AvalonST(config: AvalonSTConfig) extends Bundle with IMasterSlave {
   def stage(): AvalonST = this.m2sPipe()
 
   /**
-   * Cuts the valid/payload data path with a register and increments required ready allowance
+   * Cuts the valid/payload data path with a register
    */
   def m2sPipe(flush: Bool = null, holdPayload : Boolean = false): AvalonST = new Composite(this) {
-      val m2sPipe = AvalonST(config.copy(readyAllowance = config.readyAllowance+1))
+      val m2sPipe = AvalonST(config)
 
       val rPayload = RegNextWhen(self.payload, if (holdPayload && config.useValid) self.valid else True)
 

--- a/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
@@ -113,7 +113,23 @@ case class AvalonST(config: AvalonSTConfig) extends Bundle with IMasterSlave {
     that
   }
 
+  def pipelined(m2s: Boolean,
+                s2m: Boolean): AvalonST = {
+    (m2s, s2m) match {
+      case (false, false) => this.combStage()
+      case (true, false) => this.m2sPipe()
+      case (false, true) => this.s2mPipe()
+      case (true, true) => this.s2mPipe().m2sPipe()
+    }
+  }
+
   def stage(): AvalonST = this.m2sPipe()
+
+  def combStage(): AvalonST = {
+    val ret = AvalonST(config).setCompositeName(this, "combStage", true)
+    ret << this
+    ret
+  }
 
   /**
    * Cuts the valid/payload data path with a register

--- a/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/AvalonST.scala
@@ -1,0 +1,158 @@
+package spinal.lib.bus.avalon
+
+import spinal.core._
+import spinal.lib._
+
+case class AvalonSTConfig(dataWidth: Int,
+                          useData: Boolean = true,
+                          useChannels: Boolean = false,
+                          channelWidth: Int = -1,
+                          useError: Boolean = false,
+                          errorWidth: Int = -1,
+                          useReady: Boolean = true,
+                          useValid: Boolean = true,
+                          useEmpty: Boolean = false,
+                          emptyWidth: Int = -1,
+                          useEOP: Boolean = false,
+                          useSOP: Boolean = false,
+                          /* Meta data values */
+                          maxChannels: Int = -1,
+                          beatsPerCycle: Int = -1,
+                          dataBitsPerSymbol: Int = -1,
+                          emptyWithinPacket: Boolean = false,
+                          errorDescriptor: Array[String] = Array(),
+                          symbolEndianness: Endianness = LITTLE,
+                          readyLatency: Int = 0,
+                          readyAllowance: Int = 0) {
+  assert(!(useReady || useValid), "AvalonST must have at least ready OR valid enabled!")
+}
+
+case class AvalonSTPayload(config: AvalonSTConfig) extends Bundle {
+  val data: Bits    = if (config.useData) Bits(config.dataWidth bit) else null
+  val channel: UInt = if (config.useChannels) UInt(config.channelWidth bit) else null
+  val error: Bits   = if (config.useError) Bits(config.errorWidth bit) else null
+  val empty: UInt   = if (config.useEmpty) UInt(config.emptyWidth bit) else null
+  val eop: Bool     = if (config.useEOP) Bool() else null
+  val sop: Bool     = if (config.useSOP) Bool() else null
+}
+
+case class AvalonST(config: AvalonSTConfig) extends Bundle with IMasterSlave {
+
+  val ready: Bool = if (config.useReady) Bool() else null
+  val valid: Bool = if (config.useValid) Bool() else null
+  val payload: AvalonSTPayload = AvalonSTPayload(config)
+
+  val latencyDelay: Bool = Delay(this.ready, config.readyLatency)
+  val latencyReady: Bool = ready && latencyDelay
+  val allowanceDelay: Bool = Delay(this.ready, config.readyAllowance)
+  val allowanceReady: Bool = !ready && allowanceDelay
+
+  // Logical ready accounting for ready latency and allowance
+  val logicalReady: Bool = latencyReady || allowanceReady
+
+  val fire: Bool = valid && logicalReady
+
+  override def clone: AvalonST = AvalonST(config)
+
+  override def asMaster(): Unit = {
+    if (config.useReady) { in(this.ready) }
+    if (config.useValid) { out(this.valid) }
+    out(this.payload)
+  }
+
+  private def driveWeak[T <: Data](sink: T, src: T) = {
+    if (sink != null && src != null) {
+      sink := src
+    } else if (sink != null || src != null) {
+      LocatedPendingError(s"Can't drive ${sink} with ${src} because sink or source is null!")
+    }
+  }
+
+  private def arbitrateFrom(that: AvalonST) = {
+    driveWeak(this.ready, that.ready)
+    driveWeak(that.valid, this.valid)
+  }
+
+  def <<(that: AvalonST): AvalonST = {
+    arbitrateFrom(that)
+    this.payload := that.payload
+
+    this
+  }
+
+  def >>(that: AvalonST): AvalonST = {
+    that << this
+    that
+  }
+
+  def <-<(that: AvalonST): AvalonST = {
+    this << that.stage()
+    that
+  }
+
+  def >->(that: AvalonST): AvalonST = {
+    that <-< this
+    that
+  }
+
+  def </<(that: AvalonST): AvalonST = {
+    this << that.m2sPipe()
+    that
+  }
+
+  def >/>(that: AvalonST): AvalonST = {
+    that </< this
+    that
+  }
+
+  def </-<(that: AvalonST): AvalonST = {
+    this << that.s2mPipe().m2sPipe()
+    that
+  }
+
+  def >-/>(that: AvalonST): AvalonST = {
+    that </-< this
+    that
+  }
+
+  def stage(): AvalonST = this.m2sPipe()
+
+  /**
+   * Cuts the valid/payload data path with a register and increments required ready allowance
+   */
+  def m2sPipe(flush: Bool = null, holdPayload : Boolean = false): AvalonST = new Composite(this) {
+      val m2sPipe = AvalonST(config.copy(readyAllowance = config.readyAllowance+1))
+
+      val rPayload = RegNextWhen(self.payload, if (holdPayload && config.useValid) self.valid else True)
+
+      config.useValid generate {
+        val rValid = RegNext(self.valid) init(False)
+        if (flush != null) rValid clearWhen(flush)
+        m2sPipe.valid := rValid
+      }
+
+      m2sPipe.payload := rPayload
+
+      driveWeak(self.ready, m2sPipe.ready)
+    }.m2sPipe
+
+  /**
+   * Cuts the ready data path with a register and decrements the required ready latency
+   */
+  def s2mPipe(): AvalonST = {
+    if (!config.useReady) {
+      this
+    } else {
+      new Composite(this) {
+        val s2mPipe = AvalonST(config.copy(readyLatency = 0.max(config.readyLatency-1)))
+
+        val rReady = RegNext(s2mPipe.ready) init(False)
+
+        self.ready := rReady
+
+        driveWeak(self.valid, s2mPipe.valid)
+        s2mPipe.payload := self.payload
+      }.s2mPipe
+    }
+  }
+}

--- a/lib/src/main/scala/spinal/lib/bus/avalon/sim/AvalonSTAgent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/sim/AvalonSTAgent.scala
@@ -1,0 +1,112 @@
+package spinal.lib.bus.avalon.sim
+
+import spinal.core._
+import spinal.lib._
+import spinal.core.sim._
+import spinal.lib.bus.avalon._
+import spinal.lib.sim.SimData
+
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.util.Random
+
+class AvalonSTMonitor(stream: AvalonST, clockDomain: ClockDomain) {
+  val callbacks = ArrayBuffer[(AvalonSTPayload) => Unit]()
+
+  def addCallback(callback : (AvalonSTPayload) => Unit): this.type = {
+    callbacks += callback
+    this
+  }
+
+  var keepValue = false
+  var payload : SimData = null
+  var keepValueEnable = false
+
+  val readyLatency: ListBuffer[Boolean] = ListBuffer().padTo(stream.config.readyLatency, false)
+  var readyAllowance: Int = 0
+
+  clockDomain.onSamplings {
+    val valid = stream.valid.toBoolean
+    val streamReady = stream.ready.toBoolean
+
+    readyLatency.append(streamReady)
+    val delayedReady = readyLatency.remove(0)
+    if (delayedReady) {
+      readyAllowance = stream.config.readyAllowance
+    } else {
+      readyAllowance -= 0
+      if (readyAllowance == 0)
+        readyAllowance = 0
+    }
+
+    val logicalReady = (readyAllowance > 0)
+    val logicalValid = valid && logicalReady
+
+    if (logicalValid) {
+      callbacks.foreach(_ (stream.payload))
+    }
+    if(keepValueEnable) {
+      if (!keepValue) {
+        if (logicalValid) {
+          keepValue = true
+          payload = SimData.copy(stream.payload)
+        }
+      } else {
+        assert(payload.equals(SimData.copy(stream.payload)))
+      }
+      if (logicalReady) {
+        keepValue = false
+      }
+    }
+  }
+
+  def reset(): Unit = {
+    keepValueEnable = false
+    keepValue = false
+  }
+}
+
+class AvalonSTDriver(stream: AvalonST, clockDomain: ClockDomain, var driver: (AvalonSTPayload) => Boolean) {
+  var transactionDelay : () => Int = () => {
+    val x = Random.nextDouble()
+    (x*x*10).toInt
+  }
+
+  var state = 0
+  var delay = transactionDelay()
+  stream.valid #= false
+  stream.payload.randomize()
+
+  def fsm(): Unit = {
+    state match{
+      case 0 => {
+        if (delay == 0) {
+          state += 1
+          fsm()
+        } else {
+          delay -= 1
+        }
+      }
+      case 1 => {
+        if(driver(stream.payload)){
+          stream.valid #= true
+          state += 1
+        }
+      }
+      case 2 => {
+        if(stream.logicalReady.toBoolean){
+          stream.valid #= false
+          stream.payload.randomize()
+          delay = transactionDelay()
+          state = 0
+          fsm()
+        }
+      }
+    }
+  }
+  clockDomain.onSamplings(fsm)
+
+  def reset(): Unit = {
+    state = 0
+    stream.valid #= false
+  }
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAvalonSTTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAvalonSTTester.scala
@@ -1,0 +1,105 @@
+package spinal.tester.scalatest
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib.bus.avalon._
+import spinal.lib._
+import spinal.lib.bus.avalon.sim.{AvalonSTDriver, AvalonSTMonitor}
+import spinal.lib.sim.{ScoreboardInOrder, SimData}
+
+import scala.collection.mutable
+
+case class AvalonSTPipelineFixture(config: AvalonSTConfig, m2s: Boolean, s2m: Boolean) extends Component {
+
+  val inStream = AvalonST(config)
+  val outStream = inStream.pipelined(m2s, s2m)
+
+  val io = new Bundle {
+    val s = slave(inStream)
+    val m = master(outStream)
+  }
+}
+
+case class AvalonSTDelayAdapterFixture(config: AvalonSTConfig,
+                                       lat_m: Int, allow_m: Int,
+                                       lat_s: Int, allow_s: Int) extends Component {
+
+  val io = new Bundle {
+    val s = slave(AvalonST(config.copy(readyLatency = lat_s, readyAllowance = allow_s)))
+    val m = master(AvalonST(config.copy(readyLatency = lat_m, readyAllowance = allow_m)))
+  }
+
+  AvalonSTDelayAdapter(io.s, io.m)
+}
+
+class AvalonSTTester extends AnyFunSuite {
+
+  for(s2m <- List(false, true);
+      m2s <- List(false, true);
+      lat <- List(0, 2, 8);
+      allow <- List(0, 2, 8)) {
+    if (s2m || m2s) {
+      val text1 = if (s2m) "_s2m" else ""
+      val text2 = if (m2s) "_m2s" else ""
+      test(s"pipeline${text1}${text2}_lat${lat}_allow${allow}") {
+        val config = AvalonSTConfig(4, readyLatency = lat, readyAllowance = allow)
+        SimConfig.compile(AvalonSTPipelineFixture(config, m2s = m2s, s2m = s2m)).doSim((dut) => {
+          dut.clockDomain.forkStimulus(10)
+          SimTimeout(1000000L)
+
+          val queue = new mutable.Queue[SimData]()
+
+          val driver = new AvalonSTDriver(dut.io.s, dut.clockDomain, p => {
+            queue.enqueue(SimData.copy(p))
+            true
+          })
+
+          var beats = 10000
+
+          val monitor = new AvalonSTMonitor(dut.io.m, dut.clockDomain)
+          monitor.addCallback(p => {
+            assert(queue.dequeue().check(p))
+            if (beats == 0)
+              simSuccess()
+            else
+              beats -= 1
+          })
+        })
+      }
+    }
+  }
+
+  for(lat_m <- List(0, 2, 8);
+      allow_m <- List(0, 2, 8);
+      lat_s <- List(0, 2, 8);
+      allow_s <- List(0, 2, 8)) {
+    test(s"delay_adapt_lat${lat_s}_allow${allow_s}_to_lat${lat_m}_allow${allow_m}") {
+      val config = AvalonSTConfig(4)
+      SimConfig.compile(AvalonSTDelayAdapterFixture(config,
+        lat_s = lat_s, allow_s = allow_s,
+        lat_m = lat_m, allow_m = allow_m)).doSim((dut) => {
+        dut.clockDomain.forkStimulus(10)
+        SimTimeout(1000000L)
+
+        val queue = new mutable.Queue[SimData]()
+
+        val driver = new AvalonSTDriver(dut.io.s, dut.clockDomain, p => {
+          queue.enqueue(SimData.copy(p))
+          true
+        })
+
+        var beats = 10000
+
+        val monitor = new AvalonSTMonitor(dut.io.m, dut.clockDomain)
+        monitor.addCallback(p => {
+          assert(queue.dequeue().check(p))
+          if (beats == 0)
+            simSuccess()
+          else
+            beats -= 1
+        })
+      })
+    }
+  }
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAvalonSTTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAvalonSTTester.scala
@@ -19,6 +19,9 @@ case class AvalonSTPipelineFixture(config: AvalonSTConfig, m2s: Boolean, s2m: Bo
     val s = slave(inStream)
     val m = master(outStream)
   }
+
+  clockDomain.readClockWire.dontSimplifyIt()
+  clockDomain.readResetWire.dontSimplifyIt()
 }
 
 case class AvalonSTDelayAdapterFixture(config: AvalonSTConfig,
@@ -39,7 +42,7 @@ class AvalonSTTester extends AnyFunSuite {
       m2s <- List(false, true);
       lat <- List(0, 2, 8);
       allow <- List(0, 2, 8)) {
-    if (s2m || m2s) {
+//    if (s2m || m2s) {
       val text1 = if (s2m) "_s2m" else ""
       val text2 = if (m2s) "_m2s" else ""
       test(s"pipeline${text1}${text2}_lat${lat}_allow${allow}") {
@@ -67,7 +70,7 @@ class AvalonSTTester extends AnyFunSuite {
           })
         })
       }
-    }
+//    }
   }
 
   for(lat_m <- List(0, 2, 8);


### PR DESCRIPTION
Avalon Streaming has special timing requirements and allowances which make it incompatible with Spinal streams. This PR will provide a way to model and adapt Avalon-ST between IP and Spinal streams.