### PR TITLE
fix the error generated by xsim emulation of xilinx ip for different devices

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -155,7 +155,7 @@ object SpinalVerilatorSim {
 }
 
 class SpinalVpiBackendConfig[T <: Component](val rtl               : SpinalReport[T],
-                                             val waveFormat       : WaveFormat, 
+                                             val waveFormat       : WaveFormat,
                                              val workspacePath    : String,
                                              val workspaceName    : String,
                                              val wavePath         : String,
@@ -180,16 +180,16 @@ case class SpinalIVerilogBackendConfig[T <: Component](override val rtl : Spinal
                                                    override val usePluginsCache   : Boolean = true,
                                                    override val pluginsCachePath  : String = "./simWorkspace/.pluginsCachePath",
                                                    override val enableLogging     : Boolean = false) extends
-                                              SpinalVpiBackendConfig[T](rtl, 
-                                                                        waveFormat, 
+                                              SpinalVpiBackendConfig[T](rtl,
+                                                                        waveFormat,
                                                                         workspacePath,
                                                                         workspaceName,
                                                                         wavePath,
-                                                                        wavePrefix, 
-                                                                        waveDepth, 
-                                                                        optimisationLevel, 
+                                                                        wavePrefix,
+                                                                        waveDepth,
+                                                                        optimisationLevel,
                                                                         simulatorFlags,
-                                                                        usePluginsCache, 
+                                                                        usePluginsCache,
                                                                         pluginsCachePath,
                                                                         enableLogging)
 
@@ -406,7 +406,8 @@ case class SpinalXSimBackendConfig[T <: Component](val rtl               : Spina
                                                val waveFormat       : WaveFormat,
                                                val workspacePath    : String,
                                                val workspaceName    : String,
-                                               val wavePath         : String)
+                                               val wavePath         : String,
+                                               val xilinxDevice:String )
 
 object SpinalXSimBackend {
   class Backend(val signals : ArrayBuffer[Signal], vconfig : XSimBackendConfig) extends XSimBackend(vconfig)
@@ -426,6 +427,7 @@ object SpinalXSimBackend {
     }
     vconfig.workspaceName     = workspaceName
     vconfig.workspacePath     = workspacePath
+    vconfig.xilinxDevice      = xilinxDevice
 
     var signalId = 0
 
@@ -615,7 +617,8 @@ case class SpinalSimConfig(
                             var _vcsSimSetupFile   : String = null,
                             var _vcsEnvSetup       : () => Unit = null,
                             var _xciSourcesPaths   : ArrayBuffer[String] = ArrayBuffer[String](),
-                            var _bdSourcesPaths    : ArrayBuffer[String] = ArrayBuffer[String]()
+                            var _bdSourcesPaths    : ArrayBuffer[String] = ArrayBuffer[String](),
+                            var _xilinxDevice:String = "xc7vx485tffg1157-1"
   ){
 
 
@@ -722,6 +725,11 @@ case class SpinalSimConfig(
 
   def withLogging: this.type = {
     _withLogging = true
+    this
+  }
+
+  def withXilinxDevice(xilinxDevice:String):this.type ={
+    _xilinxDevice = xilinxDevice
     this
   }
 
@@ -997,7 +1005,9 @@ case class SpinalSimConfig(
           wavePath = s"${_workspacePath}/${_workspaceName}",
           workspaceName = "xsim",
           xciSourcesPaths = _xciSourcesPaths,
-          bdSourcesPaths = _bdSourcesPaths
+          bdSourcesPaths = _bdSourcesPaths,
+          xilinxDevice = _xilinxDevice
+
         )
         val backend = SpinalXSimBackend(vConfig)
         new SimCompiled(report) {
@@ -1013,7 +1023,7 @@ case class SpinalSimConfig(
 
 
 /**
-  * Legacy simulation configuration 
+  * Legacy simulation configuration
   */
 case class SimConfigLegacy[T <: Component](
   var _rtlGen       : Option[() => T] = None,

--- a/sim/src/main/scala/spinal/sim/XSimBackend.scala
+++ b/sim/src/main/scala/spinal/sim/XSimBackend.scala
@@ -17,6 +17,7 @@ case class XSimBackendConfig(
                              val rtlSourcesPaths: ArrayBuffer[String] = ArrayBuffer[String](),
                              var xciSourcesPaths: ArrayBuffer[String] = ArrayBuffer[String](),
                              var bdSourcesPaths: ArrayBuffer[String] = ArrayBuffer[String](),
+                             var xilinxDevice:String = "xc7vx485tffg1157-1",
                              var CC: String             = "g++",
                              var toplevelName: String   = null,
                              var workspacePath: String  = null,
@@ -38,6 +39,7 @@ class XSimBackend(config: XSimBackendConfig) extends Backend {
   val workspaceName = config.workspaceName
   val wavePath = config.wavePath
   val waveFormat = config.waveFormat
+  val xilinxDevice = config.xilinxDevice
 
   val format: WaveFormat = {
     val availableFormats = Array(WaveFormat.WDB, WaveFormat.DEFAULT, WaveFormat.NONE)
@@ -144,7 +146,7 @@ class XSimBackend(config: XSimBackendConfig) extends Backend {
          |
          |""".stripMargin
 
-    val createProject = s"create_project -force $projectName"
+    val createProject = s"create_project -force $projectName -part $xilinxDevice"
     val importRtl = rtlAbsoluteSourcesPaths map { p =>
       s"import_files -force $p"
     }


### PR DESCRIPTION
Because the original xsim backend did not specify information about the xilinx chip when generating the vivado project. Therefore, a default xc7vx485tffg1157 project will be generated, and an error will be reported when we use xci files for chips other than this series. As shown below.
I have two xilinx adder ip's for xc7vx485tffg1157-1 and xc7k325tffv900-2.

When I use the adder ip of 325t, the following error is reported.
![image](https://user-images.githubusercontent.com/56644752/180432772-d43c20f1-e980-41a1-92e7-875dbd5e1a1d.png)

![image](https://user-images.githubusercontent.com/56644752/180433108-f2c07cc9-5148-46bd-a8a0-78355abfcde4.png)
[VRFC 10-2063] Module <addAdd> not found while processing module instance <add>

When I use the adder ip of 485t, it is correct.

I have therefore added a method to specify the xilinx device to be used in the simulation.
It works now at both 325t and 485t.

Use the following directions to specify the xilinx device in the added withXilinxDevice method.
![image](https://user-images.githubusercontent.com/56644752/180433939-c25c74ef-5a78-4509-86fa-ba7636398405.png)

The simulation results are as follows.
![image](https://user-images.githubusercontent.com/56644752/180434237-b1f33150-975c-4518-874c-3e0902b59b79.png)

