### PR TITLE
Add formal verification cases on StreamTransactionCounter and StreamTransactionExtender

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1781,7 +1781,7 @@ class StreamTransactionCounter(
         running := False
     }
 
-    when(done | io.ctrlFire) {
+    when(done) {
         counter.clear()
     } elsewhen (io.targetFire & running) {
         counter.increment()
@@ -1797,6 +1797,11 @@ class StreamTransactionCounter(
     io.last := lastOne
     io.done := done & running
     io.value := counter
+
+    def withAsserts() = new Area {
+      when(!io.working) { assert(counter.value === 0) }
+      assert(counter.value <= expected)
+    }
 }
 
 object StreamTransactionExtender {

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1774,13 +1774,9 @@ class StreamTransactionCounter(
 
     val done         = lastOne && io.targetFire
     if(noDelay){
-      val oneCycleCount = done & io.ctrlFire & !running
-      when (oneCycleCount) { working := True }
-      .elsewhen(done & running) { running := False } 
-      .elsewhen(io.ctrlFire) { 
-        working := True 
-        running := True
-      }
+      when(io.ctrlFire) { working := True }
+      when(done) { running := False }
+      .otherwise { running := working }
     } else {
       when (io.ctrlFire) { running := True } 
       .elsewhen(done) { running := False }

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1805,6 +1805,7 @@ class StreamTransactionCounter(
       when(done) { startedReg := False }
 
       when(startedReg) { assert(io.working && counter.value > 0 && counter.value <= expected) }
+      when(counter.value > 0) { assert(started) }
 //      when(!io.working) { assert(counter.value === 0) }
 //      assert(counter.value <= expected)
     }

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1781,9 +1781,9 @@ class StreamTransactionCounter(
         running := False
     }
 
-    when(done) {
+    when(done | io.ctrlFire) {
         counter.clear()
-    } elsewhen (io.targetFire) {
+    } elsewhen (io.targetFire & running) {
         counter.increment()
     }
 
@@ -1795,7 +1795,7 @@ class StreamTransactionCounter(
 
     io.working := running
     io.last := lastOne
-    io.done := lastOne && io.targetFire
+    io.done := done & running
     io.value := counter
 }
 

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Downsizer.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Downsizer.scala
@@ -110,7 +110,7 @@ case class Axi4WriteOnlyDownsizer(inputConfig: Axi4Config, outputConfig: Axi4Con
     val staleInputData   = Bool()
     val writeData        = io.input.writeData.haltWhen(staleInputData)
     val inputDataCounter = StreamTransactionCounter(writeCmd, writeData, writeCmd.len, true)
-    staleInputData := inputDataCounter.io.available && !writeCmd.fire
+    staleInputData := !inputDataCounter.io.working
 
     val (rspCountStream, countCmdStream, outCmdStream) = StreamFork3(cmdStream)
     writeStream.writeCmd << outCmdStream
@@ -137,7 +137,7 @@ case class Axi4WriteOnlyDownsizer(inputConfig: Axi4Config, outputConfig: Axi4Con
     }
     dataWorking := !inputDataCounter.io.available || !writeData.ready
 
-    val staleData = streamCounter.io.available && !countCmdStream.fire
+    val staleData = !streamCounter.io.working
     writeStream.writeData.translateFrom(dataStream.haltWhen(staleData)) { (to, from) =>
         to.data := from.data(offset << 3, outputConfig.dataWidth bits)
         if (outputConfig.useLast) to.last := streamCounter.io.last

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Downsizer.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Downsizer.scala
@@ -110,14 +110,14 @@ case class Axi4WriteOnlyDownsizer(inputConfig: Axi4Config, outputConfig: Axi4Con
     val staleInputData   = Bool()
     val writeData        = io.input.writeData.haltWhen(staleInputData)
     val inputDataCounter = StreamTransactionCounter(writeCmd, writeData, writeCmd.len, true)
-    staleInputData := !inputDataCounter.io.working && !writeCmd.fire
+    staleInputData := inputDataCounter.io.available && !writeCmd.fire
 
     val (rspCountStream, countCmdStream, outCmdStream) = StreamFork3(cmdStream)
     writeStream.writeCmd << outCmdStream
 
     val dataStream    = cloneOf(writeData)
     val streamCounter = StreamTransactionCounter(countCmdStream, dataStream, countCmdStream.len, true)
-    countCmdStream.ready := !streamCounter.io.working
+    countCmdStream.ready := streamCounter.io.available
 
     val beatOffsetReg = RegNextWhen(countCmdStream.addr(inputConfig.symbolRange), countCmdStream.fire)
     val beatOffset    = CombInit(beatOffsetReg)
@@ -135,9 +135,9 @@ case class Axi4WriteOnlyDownsizer(inputConfig: Axi4Config, outputConfig: Axi4Con
         out.assignUnassignedByName(p)
         out
     }
-    dataWorking := inputDataCounter.io.working || (dataExtender.io.working && !dataExtender.io.done)
+    dataWorking := !inputDataCounter.io.available || !writeData.ready
 
-    val staleData = !streamCounter.io.working && !countCmdStream.fire
+    val staleData = streamCounter.io.available && !countCmdStream.fire
     writeStream.writeData.translateFrom(dataStream.haltWhen(staleData)) { (to, from) =>
         to.data := from.data(offset << 3, outputConfig.dataWidth bits)
         if (outputConfig.useLast) to.last := streamCounter.io.last

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -41,6 +41,8 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
           .otherwise { assert(dut.io.available) }
         }
         .otherwise { assert(dut.io.available) }
+        val counterHelper = dut.withAsserts()
+
         cover(inStream.fire & outStream.fire & dut.io.done)
         cover(pastValid & past(dut.io.working) & !dut.io.working)
 

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -1,0 +1,81 @@
+package spinal.tester.scalatest
+
+import spinal.core.formal._
+import spinal.core._
+import spinal.lib._
+
+class FormalStreamExtender extends SpinalFormalFunSuite {
+  def counterTester(noDelay: Boolean = false) {
+    FormalConfig
+      .withBMC(10)
+      .withProve(10)
+      .withCover(10)
+      .withDebug
+      .doVerify(new Component {
+        val inStream = slave Stream(UInt(2 bits))
+        val outStream = master Stream(UInt(2 bits))
+        val count = in UInt(3 bits)
+        val dut = FormalDut(StreamTransactionCounter(inStream, outStream, count, noDelay))
+        
+        val inReady = in Bool()
+        inStream.ready := inReady
+        val outValid = in Bool()
+        outStream.valid := outValid
+        val outPayload = in UInt(2 bits)
+        outStream.payload := outPayload
+
+        val reset = ClockDomain.current.isResetActive
+        assumeInitial(reset)
+
+        val countHist = History(count, 2, inStream.fire, init = count.getZero)
+        when(dut.io.working) {
+            assume(inReady === False)
+        }
+
+        val verifyCounter = Counter(4 bits, inc = outStream.fire & dut.io.working)
+        when(dut.io.done) {
+            assert(verifyCounter.value === countHist(1))
+            verifyCounter.clear()
+        }
+        when(dut.io.working) {
+            assert(countHist(1) === dut.expected)
+            assert(verifyCounter.value === dut.counter.value)
+        }
+        when(!dut.io.working) { assume(verifyCounter.value === 0) }
+        assert(dut.counter.value <= dut.expected)
+
+        cover(past(dut.io.working) & !dut.io.working)
+
+        inStream.withAssumes()
+        outStream.withAssumes()
+
+        inStream.withCovers()
+        outStream.withCovers()
+      })
+  }
+
+  def extenderTester() {
+    FormalConfig
+      .withBMC(10)
+      .withProve(10)
+      .withCover(10)
+      .withDebug
+      .doVerify(new Component {
+        val inStream = slave Stream(UInt(2 bits))
+        val outStream = master Stream(UInt(2 bits))
+        val count = in UInt(4 bits)
+        val dut = FormalDut(StreamTransactionExtender(inStream, outStream, count){(_, p, _) => p})
+
+        val reset = ClockDomain.current.isResetActive
+        assumeInitial(reset)
+      })
+  }
+  
+  test("transaction counter") {
+    counterTester()
+  }
+  
+//   test("transaction extender") {
+//     extenderTester()
+//   }
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -37,7 +37,10 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         when(dut.io.working) {
           assert(countHist(1) === dut.expected) // key to sync verification logic and internal logic.
           when(dut.counter.value === countHist(1) & outStream.fire) { assert(dut.io.done) }
+          when(!dut.io.done) { assert(!dut.io.available) }
+          .otherwise { assert(dut.io.available) }
         }
+        .otherwise { assert(dut.io.available) }
         cover(inStream.fire & outStream.fire & dut.io.done)
         cover(pastValid & past(dut.io.working) & !dut.io.working)
 
@@ -83,7 +86,10 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         when(dut.io.working) {
           assert(expected === dut.expected) // key to sync verification logic and internal logic.
           when(dut.counter.value === expected & outStream.fire) { assert(dut.io.done) }
+          when(!inStream.fire) { assert(!dut.io.available) }
+          .otherwise { assert(dut.io.available) }
         }
+        .otherwise { assert(dut.io.available) }
         cover(pastValid & past(dut.io.done) & inStream.fire)
         cover(pastValid & past(dut.io.working) & !dut.io.working)
 

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -29,7 +29,7 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         assumeInitial(reset)
 
         val countHist = History(count, 2, inStream.fire, init = count.getZero)
-        when(dut.io.working && !dut.io.done) { assume(inReady === False) }
+        when(!dut.io.available) { assume(inReady === False) }
 
         when(pastValid & past(inStream.fire)) { assert(dut.io.working) }
         when(pastValid & past(dut.io.done & !inStream.fire)) { assert(!dut.io.working) }
@@ -74,7 +74,7 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
 
         val countHist = History(count, 2, inStream.fire, init = count.getZero)
         val expected = countHist(1).getAheadValue()
-        // when(dut.running) { assume(inReady === False) }
+        when(!dut.io.available) { assume(inReady === False) }
 
         when(inStream.fire) { assert(dut.io.working) }
         when(pastValid & past(dut.io.done) & !inStream.fire) { assert(!dut.io.working) }
@@ -104,11 +104,33 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
       .doVerify(new Component {
         val inStream = slave Stream (UInt(2 bits))
         val outStream = master Stream (UInt(2 bits))
-        val count = in UInt (4 bits)
+        val count = in UInt (3 bits)
         val dut = FormalDut(StreamTransactionExtender(inStream, outStream, count) { (_, p, _) => p })
 
         val reset = ClockDomain.current.isResetActive
         assumeInitial(reset)
+
+        val countHist = History(count, 2, inStream.fire, init = count.getZero)
+
+        when(pastValid & past(inStream.fire)) { assert(dut.io.working) }
+        when(pastValid & past(dut.io.done & !inStream.fire)) { assert(!dut.io.working) }
+
+        when(dut.io.done) { assert(dut.counter.counter.value >= countHist(1)) }
+        when(dut.io.working) {
+          assert(countHist(1) === dut.counter.expected) // key to sync verification logic and internal logic.
+          when(dut.counter.counter.value === countHist(1) & outStream.fire) { assert(dut.io.done) }
+          when(!dut.io.done) { assert(!inStream.ready) }
+        }
+        cover(inStream.fire & outStream.fire & dut.io.done)
+        cover(pastValid & past(dut.io.working) & !dut.io.working)
+
+        inStream.withAssumes()
+        outStream.withAssumes()
+
+        for(i <- 1 until 2) {
+          inStream.withCovers(i)
+          outStream.withCovers(i)
+        }
       })
   }
 
@@ -120,7 +142,7 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
     counterNoDelayTester()
   }
 
-//   test("transaction extender") {
-//     extenderTester()
-//   }
+  test("transaction extender") {
+    extenderTester()
+  }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -29,22 +29,18 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         assumeInitial(reset)
 
         val countHist = History(count, 2, inStream.fire, init = count.getZero)
-        when(dut.io.working) {
-            assume(inReady === False)
-        }
+        // when(dut.io.working) {
+        //     assume(inReady === False)
+        // }
 
-        val verifyCounter = Counter(4 bits, inc = outStream.fire & dut.io.working)
         when(dut.io.done) {
-            assert(verifyCounter.value === countHist(1))
-            verifyCounter.clear()
+            assert(dut.counter.value === countHist(1))
         }
         when(dut.io.working) {
             assert(countHist(1) === dut.expected)
-            assert(verifyCounter.value === dut.counter.value)
         }
-        when(!dut.io.working) { assume(verifyCounter.value === 0) }
-        assert(dut.counter.value <= dut.expected)
 
+        cover(inStream.fire & outStream.fire & dut.io.done)
         cover(past(dut.io.working) & !dut.io.working)
 
         inStream.withAssumes()

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -1,8 +1,9 @@
 package spinal.tester.scalatest
 
-import spinal.core.formal._
 import spinal.core._
+import spinal.core.formal._
 import spinal.lib._
+import spinal.lib.formal._
 
 class FormalStreamExtender extends SpinalFormalFunSuite {
   def counterTester(noDelay: Boolean = false) {

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -8,10 +8,9 @@ import spinal.lib.formal._
 class FormalStreamExtender extends SpinalFormalFunSuite {
   def counterTester() {
     FormalConfig
-      .withBMC(10)
+      // .withBMC(10)
       .withProve(10)
       .withCover(10)
-      .withDebug
       .doVerify(new Component {
         val inStream = slave Stream (UInt(2 bits))
         val outStream = master Stream (UInt(2 bits))
@@ -45,17 +44,18 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         inStream.withAssumes()
         outStream.withAssumes()
 
-        inStream.withCovers()
-        outStream.withCovers()
+        for(i <- 1 until 2) {
+          inStream.withCovers(i)
+          outStream.withCovers(i)
+        }
       })
   }
 
   def counterNoDelayTester() {
     FormalConfig
-      .withBMC(10)
+      // .withBMC(10)
       .withProve(10)
       .withCover(10)
-      .withDebug
       .doVerify(new Component {
         val inStream = slave Stream (UInt(2 bits))
         val outStream = master Stream (UInt(2 bits))
@@ -90,17 +90,18 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         inStream.withAssumes()
         outStream.withAssumes()
 
-        inStream.withCovers()
-        outStream.withCovers()
+        for(i <- 1 until 2) {
+          inStream.withCovers(i)
+          outStream.withCovers(i)
+        }
       })
   }
 
   def extenderTester() {
     FormalConfig
-      .withBMC(10)
+      // .withBMC(10)
       .withProve(10)
       .withCover(10)
-      .withDebug
       .doVerify(new Component {
         val inStream = slave Stream (UInt(2 bits))
         val outStream = master Stream (UInt(2 bits))

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -34,14 +34,10 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         when(pastValid & past(inStream.fire)) { assert(dut.io.working) }
         when(pastValid & past(dut.io.done & !inStream.fire)) { assert(!dut.io.working) }
 
-        val d1 = anyconst(cloneOf(count))
         when(dut.io.done) { assert(dut.counter.value >= countHist(1)) }
         when(dut.io.working) {
           assert(countHist(1) === dut.expected) // key to sync verification logic and internal logic.
           when(dut.counter.value === countHist(1) & outStream.fire) { assert(dut.io.done) }
-          // val updateCond = inStream.fire && (dut.io.count === d1) && (d1 < dut.counter.value)
-          // when(updateCond) { assert(dut.io.done) }
-          // if(!noDelay) { cover(updateCond) }
         }
         cover(inStream.fire & outStream.fire & dut.io.done)
         cover(pastValid & past(dut.io.working) & !dut.io.working)
@@ -78,19 +74,15 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
 
         val countHist = History(count, 2, inStream.fire, init = count.getZero)
         val expected = countHist(1).getAheadValue()
-        when(dut.running) { assume(inReady === False) }
+        // when(dut.running) { assume(inReady === False) }
 
         when(inStream.fire) { assert(dut.io.working) }
         when(pastValid & past(dut.io.done) & !inStream.fire) { assert(!dut.io.working) }
 
-        val d1 = anyconst(cloneOf(count))
         when(dut.io.done) { assert(dut.counter.value >= expected) }
         when(dut.io.working) {
           assert(expected === dut.expected) // key to sync verification logic and internal logic.
           when(dut.counter.value === expected & outStream.fire) { assert(dut.io.done) }
-          // val updateCond = inStream.fire && (dut.io.count === d1) && (d1 < dut.counter.value)
-          // when(updateCond) { assert(dut.io.done) }
-          // if(!noDelay) { cover(updateCond) }
         }
         cover(pastValid & past(dut.io.done) & inStream.fire)
         cover(pastValid & past(dut.io.working) & !dut.io.working)

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -29,7 +29,7 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         assumeInitial(reset)
 
         val countHist = History(count, 2, inStream.fire, init = count.getZero)
-        // when(dut.io.working) {
+        // when(dut.io.working && !dut.io.done) {
         //     assume(inReady === False)
         // }
 


### PR DESCRIPTION
1. simplify the logic and fix the working signal
2. fix the bug that working signal did not cover the first cycle while noDelay is true.
3. introduce available signal to Counter to indicate if it's ready for new control fire trigger.