### PR TITLE
Axi4: Add Axi4IdRemover and tests

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4IdRemover.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4IdRemover.scala
@@ -70,13 +70,13 @@ class Axi4SharedIdRemover(config: Axi4Config) extends Component {
 
     txnActive clearWhen(readDone || writeDone)
 
-    io.input.r.arbitrationFrom(io.output.r.continueWhen(txnActive && !txnWrite))
+    io.input.r.arbitrationFrom(io.output.r)
     io.input.r.payload.assignSomeByName(io.output.r.payload)
     io.input.r.id := txnId
 
-    io.output.w << io.input.w.continueWhen(txnActive && txnWrite)
+    io.output.w << io.input.w
 
-    io.input.b.arbitrationFrom(io.output.b.continueWhen(txnActive && txnWrite))
+    io.input.b.arbitrationFrom(io.output.b)
     io.input.b.payload.assignSomeByName(io.output.b.payload)
     io.input.b.id := txnId
   }
@@ -101,7 +101,7 @@ class Axi4ReadOnlyIdRemover(config: Axi4Config) extends Component {
 
     txnActive clearWhen(io.output.r.last && io.output.r.fire)
 
-    io.input.r.arbitrationFrom(io.output.r.continueWhen(txnActive))
+    io.input.r.arbitrationFrom(io.output.r)
     io.input.r.payload.assignSomeByName(io.output.r.payload)
     io.input.r.id := txnId
   }
@@ -127,9 +127,9 @@ class Axi4WriteOnlyIdRemover(config: Axi4Config) extends Component {
 
     txnActive clearWhen(io.output.b.fire)
 
-    io.output.w << io.input.w.continueWhen(txnActive)
+    io.output.w << io.input.w
 
-    io.input.b.arbitrationFrom(io.output.b.continueWhen(txnActive))
+    io.input.b.arbitrationFrom(io.output.b)
     io.input.b.payload.assignSomeByName(io.output.b.payload)
     io.input.b.id := txnId
   }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4IdRemover.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4IdRemover.scala
@@ -1,0 +1,136 @@
+package spinal.lib.bus.amba4.axi
+
+import spinal.core._
+import spinal.lib._
+
+object Axi4IdRemover {
+  def apply(axi: Axi4): Axi4 = {
+    val idRemover = new Axi4IdRemover(axi.config)
+    idRemover.io.input << axi
+    idRemover.io.output
+  }
+
+  def apply(axi: Axi4Shared): Axi4Shared = {
+    val idRemover = new Axi4SharedIdRemover(axi.config)
+    idRemover.io.input << axi
+    idRemover.io.output
+  }
+
+  def apply(axi: Axi4ReadOnly): Axi4ReadOnly = {
+    val idRemover = new Axi4ReadOnlyIdRemover(axi.config)
+    idRemover.io.input << axi
+    idRemover.io.output
+  }
+
+  def apply(axi: Axi4WriteOnly): Axi4WriteOnly = {
+    val idRemover = new Axi4WriteOnlyIdRemover(axi.config)
+    idRemover.io.input << axi
+    idRemover.io.output
+  }
+}
+
+class Axi4IdRemover(config: Axi4Config) extends Component {
+  val io = new Bundle {
+    val input = slave(new Axi4(config))
+    val output = master(new Axi4(config.copy(useId = false, idWidth = -1)))
+  }
+
+  val readOnlyRemover = new Axi4ReadOnlyIdRemover(config)
+  val writeOnlyRemover = new Axi4WriteOnlyIdRemover(config)
+
+  readOnlyRemover.io.input << io.input
+  writeOnlyRemover.io.input << io.input
+
+  io.output << readOnlyRemover.io.output
+  io.output << writeOnlyRemover.io.output
+}
+
+class Axi4SharedIdRemover(config: Axi4Config) extends Component {
+  val io = new Bundle {
+    val input = slave(new Axi4Shared(config))
+    val output = master(new Axi4Shared(config.copy(useId = false, idWidth = -1)))
+  }
+
+  if (!config.useId) {
+    // Combo stage for naming
+    io.output << io.input.pipelined(arw = StreamPipe.NONE,
+      w = StreamPipe.NONE,
+      b = StreamPipe.NONE,
+      r = StreamPipe.NONE)
+  } else {
+    val txnActive = RegInit(False)
+    txnActive setWhen(io.input.arw.fire)
+    val txnId = RegNextWhen(io.input.arw.id, io.input.arw.fire)
+    val txnWrite = RegNextWhen(io.input.arw.write, io.input.arw.fire)
+
+    io.output.arw << io.input.arw.continueWhen(!txnActive)
+
+    val readDone = (io.output.r.last && io.output.r.fire && !txnWrite)
+    val writeDone = (io.output.b.fire && txnWrite)
+
+    txnActive clearWhen(readDone || writeDone)
+
+    io.input.r.arbitrationFrom(io.output.r.continueWhen(txnActive && !txnWrite))
+    io.input.r.payload.assignSomeByName(io.output.r.payload)
+    io.input.r.id := txnId
+
+    io.output.w << io.input.w.continueWhen(txnActive && txnWrite)
+
+    io.input.b.arbitrationFrom(io.output.b.continueWhen(txnActive && txnWrite))
+    io.input.b.payload.assignSomeByName(io.output.b.payload)
+    io.input.b.id := txnId
+  }
+}
+
+class Axi4ReadOnlyIdRemover(config: Axi4Config) extends Component {
+  val io = new Bundle {
+    val input = slave(new Axi4ReadOnly(config))
+    val output = master(new Axi4ReadOnly(config.copy(useId = false, idWidth = -1)))
+  }
+
+  if (!config.useId) {
+    // Combo stage for naming
+    io.output << io.input.pipelined(ar = StreamPipe.NONE,
+                                    r = StreamPipe.NONE)
+  } else {
+    val txnActive = RegInit(False)
+    txnActive setWhen(io.input.ar.fire)
+    val txnId = RegNextWhen(io.input.ar.id, io.input.ar.fire)
+
+    io.output.ar << io.input.ar.continueWhen(!txnActive)
+
+    txnActive clearWhen(io.output.r.last && io.output.r.fire)
+
+    io.input.r.arbitrationFrom(io.output.r.continueWhen(txnActive))
+    io.input.r.payload.assignSomeByName(io.output.r.payload)
+    io.input.r.id := txnId
+  }
+}
+
+class Axi4WriteOnlyIdRemover(config: Axi4Config) extends Component {
+  val io = new Bundle {
+    val input = slave(new Axi4WriteOnly(config))
+    val output = master(new Axi4WriteOnly(config.copy(useId = false, idWidth = -1)))
+  }
+
+  if (!config.useId) {
+    // Combo stage for naming
+    io.output << io.input.pipelined(aw = StreamPipe.NONE,
+      w = StreamPipe.NONE,
+      b = StreamPipe.NONE)
+  } else {
+    val txnActive = RegInit(False)
+    txnActive setWhen(io.input.aw.fire)
+    val txnId = RegNextWhen(io.input.aw.id, io.input.aw.fire)
+
+    io.output.aw << io.input.aw.continueWhen(!txnActive)
+
+    txnActive clearWhen(io.output.b.fire)
+
+    io.output.w << io.input.w.continueWhen(txnActive)
+
+    io.input.b.arbitrationFrom(io.output.b.continueWhen(txnActive))
+    io.input.b.payload.assignSomeByName(io.output.b.payload)
+    io.input.b.id := txnId
+  }
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
@@ -5,7 +5,7 @@ import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.core.sim.SimCompiled
 import spinal.lib.bus.amba4.axi.sim.{Axi4ReadOnlyMasterAgent, Axi4ReadOnlyMonitor, Axi4ReadOnlySlaveAgent, Axi4WriteOnlyMasterAgent, Axi4WriteOnlyMonitor, Axi4WriteOnlySlaveAgent}
-import spinal.lib.bus.amba4.axi.{Axi4Config, Axi4ReadOnlyUpsizer, Axi4WriteOnlyUpsizer, Axi4ReadOnlyDownsizer, Axi4WriteOnlyDownsizer}
+import spinal.lib.bus.amba4.axi.{Axi4, Axi4Config, Axi4ReadOnly, Axi4ReadOnlyDownsizer, Axi4ReadOnlyIdRemover, Axi4ReadOnlyUpsizer, Axi4SharedIdRemover, Axi4WriteOnly, Axi4WriteOnlyDownsizer, Axi4WriteOnlyIdRemover, Axi4WriteOnlyUpsizer}
 import spinal.lib.bus.misc.SizeMapping
 import spinal.lib.{master, slave}
 
@@ -325,4 +325,234 @@ class Axi4DownsizerTester extends AnyFunSuite {
             .compile(Axi4ReadOnlyDownsizer(Axi4Config(20, 128, 4), Axi4Config(20, 32, 4)))
             .doSim("test", 42)((dut: Axi4ReadOnlyDownsizer) => readTester(dut, true))
     }
+}
+
+class Axi4IdRemoverTester extends AnyFunSuite {
+
+  def writeTester(dut : Axi4WriteOnlyIdRemover): Unit ={
+    dut.clockDomain.forkStimulus(10)
+
+
+    val regions = mutable.Set[SizeMapping]()
+    val inputAgent = new Axi4WriteOnlyMasterAgent(dut.io.input, dut.clockDomain) {
+      override def genAddress(): BigInt = ((Random.nextInt(1 << 19)))// & 0xFFF00) | 6
+
+      override def bursts: List[Int] = List(1)
+
+      override def mappingAllocate(mapping: SizeMapping): Boolean = {
+        if(regions.exists(_.overlap(mapping))) return false
+        regions += mapping
+        true
+      }
+
+      override def mappingFree(mapping: SizeMapping): Unit = regions.remove(mapping)
+    }
+    val outputAgent = new Axi4WriteOnlySlaveAgent(dut.io.output, dut.clockDomain)
+
+    val writes = mutable.HashMap[BigInt, Byte]()
+    val inputMonitor = new Axi4WriteOnlyMonitor(dut.io.input, dut.clockDomain) {
+      override def onWriteByte(address: BigInt, data: Byte): Unit = {
+        //          println(s"I $address -> $data")
+        writes(address) = data
+      }
+    }
+
+    val outputMonitor = new Axi4WriteOnlyMonitor(dut.io.output, dut.clockDomain) {
+      override def onWriteByte(address: BigInt, data: Byte): Unit = {
+        //          println(s"O $address -> $data")
+        assert(writes(address) == data)
+        writes.remove(address)
+      }
+    }
+
+
+    dut.clockDomain.waitSamplingWhere(inputAgent.rspCounter > 10000)
+    inputAgent.allowGen = false
+    dut.clockDomain.waitSamplingWhere(!inputAgent.pending)
+    dut.clockDomain.waitSampling(100)
+    assert(writes.isEmpty)
+    println("done")
+  }
+
+  test("writeOnly") {
+    SimConfig.withWave.compile(new Axi4WriteOnlyIdRemover(Axi4Config(20, 32, 4))).doSim("test", 42)(writeTester)
+  }
+
+  def readTester(dut : Axi4ReadOnlyIdRemover): Unit ={
+    dut.clockDomain.forkStimulus(10)
+
+    val regions = mutable.Set[SizeMapping]()
+    val inputAgent = new Axi4ReadOnlyMasterAgent(dut.io.input, dut.clockDomain) {
+      override def genAddress(): BigInt = Random.nextInt(1 << 19)
+      override def bursts: List[Int] = List(1)
+      override def mappingAllocate(mapping: SizeMapping): Boolean = {
+        if(regions.exists(_.overlap(mapping))) return false
+        regions += mapping
+        true
+      }
+
+      override def mappingFree(mapping: SizeMapping): Unit = regions.remove(mapping)
+    }
+
+    val outputAgent = new Axi4ReadOnlySlaveAgent(dut.io.output, dut.clockDomain)
+
+
+
+    val reads = mutable.HashMap[BigInt, Byte]()
+    val inputMonitor = new Axi4ReadOnlyMonitor(dut.io.input, dut.clockDomain) {
+      override def onReadByte(address: BigInt, data: Byte, id : Int): Unit = {
+        reads(address) = data
+      }
+      override def onLast(id: Int): Unit = {}
+    }
+
+    val outputMonitor = new Axi4ReadOnlyMonitor(dut.io.output, dut.clockDomain) {
+      override def onReadByte(address: BigInt, data: Byte, id : Int): Unit = {
+        if(reads.contains(address)) {
+          assert(reads(address) == data)
+          reads.remove(address)
+        }
+      }
+
+      override def onLast(id: Int): Unit = assert(reads.isEmpty)
+    }
+
+
+
+    dut.clockDomain.waitSamplingWhere(inputAgent.rspCounter > 10000)
+    inputAgent.allowGen = false
+    dut.clockDomain.waitSamplingWhere(!inputAgent.pending)
+    dut.clockDomain.waitSampling(100)
+    assert(reads.isEmpty)
+    println("done")
+  }
+
+  test("readOnly") {
+    SimConfig.withWave.compile(new Axi4ReadOnlyIdRemover(Axi4Config(20, 32, 4))).doSim("test", 42)(readTester)
+  }
+
+  def sharedTester(dut: Axi4SharedIdRemoverDut): Unit = {
+    dut.clockDomain.forkStimulus(10)
+
+    val readFork = fork {
+      val regions = mutable.Set[SizeMapping]()
+      val inputAgent = new Axi4ReadOnlyMasterAgent(dut.io.inputs.read, dut.clockDomain) {
+        override def genAddress(): BigInt = Random.nextInt(1 << 19)
+
+        override def bursts: List[Int] = List(1)
+
+        override def mappingAllocate(mapping: SizeMapping): Boolean = {
+          if (regions.exists(_.overlap(mapping))) return false
+          regions += mapping
+          true
+        }
+
+        override def mappingFree(mapping: SizeMapping): Unit = regions.remove(mapping)
+      }
+      val outputAgent = new Axi4ReadOnlySlaveAgent(dut.io.outputs.read, dut.clockDomain)
+
+
+      val reads = mutable.HashMap[BigInt, Byte]()
+      val inputMonitor = new Axi4ReadOnlyMonitor(dut.io.inputs.read, dut.clockDomain) {
+        override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
+          reads(address) = data
+        }
+
+        override def onLast(id: Int): Unit = {}
+      }
+
+      val outputMonitor = new Axi4ReadOnlyMonitor(dut.io.outputs.read, dut.clockDomain) {
+        override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
+          if (reads.contains(address)) {
+            assert(reads(address) == data)
+            reads.remove(address)
+          }
+        }
+
+        override def onLast(id: Int): Unit = assert(reads.isEmpty)
+      }
+
+      dut.clockDomain.waitSamplingWhere(inputAgent.rspCounter > 10000)
+      inputAgent.allowGen = false
+      dut.clockDomain.waitSamplingWhere(!inputAgent.pending)
+      dut.clockDomain.waitSampling(100)
+      assert(reads.isEmpty)
+    }
+
+    val writeFork = fork {
+      val regions = mutable.Set[SizeMapping]()
+      val inputAgent = new Axi4WriteOnlyMasterAgent(dut.io.inputs.write, dut.clockDomain) {
+        override def genAddress(): BigInt = ((Random.nextInt(1 << 19))) // & 0xFFF00) | 6
+
+        override def bursts: List[Int] = List(1)
+
+        override def mappingAllocate(mapping: SizeMapping): Boolean = {
+          if (regions.exists(_.overlap(mapping))) return false
+          regions += mapping
+          true
+        }
+
+        override def mappingFree(mapping: SizeMapping): Unit = regions.remove(mapping)
+      }
+      val outputAgent = new Axi4WriteOnlySlaveAgent(dut.io.outputs.write, dut.clockDomain)
+
+      val writes = mutable.HashMap[BigInt, Byte]()
+      val inputMonitor = new Axi4WriteOnlyMonitor(dut.io.inputs.write, dut.clockDomain) {
+        override def onWriteByte(address: BigInt, data: Byte): Unit = {
+          //          println(s"I $address -> $data")
+          writes(address) = data
+        }
+      }
+
+      val outputMonitor = new Axi4WriteOnlyMonitor(dut.io.outputs.write, dut.clockDomain) {
+        override def onWriteByte(address: BigInt, data: Byte): Unit = {
+          //          println(s"O $address -> $data")
+          assert(writes(address) == data)
+          writes.remove(address)
+        }
+      }
+
+      dut.clockDomain.waitSamplingWhere(inputAgent.rspCounter > 10000)
+      inputAgent.allowGen = false
+      dut.clockDomain.waitSamplingWhere(!inputAgent.pending)
+      dut.clockDomain.waitSampling(100)
+      assert(writes.isEmpty)
+    }
+
+    readFork.join()
+    writeFork.join()
+
+    println("done")
+  }
+
+  class Axi4SharedIdRemoverDut(config: Axi4Config) extends Component {
+
+    val idRemover = new Axi4SharedIdRemover(config)
+
+    val io = new Bundle {
+      val inputs = new Bundle {
+        val read = slave(Axi4ReadOnly(config))
+        val write = slave(Axi4WriteOnly(config))
+      }
+      val outputs = new Bundle {
+        val read = master(Axi4ReadOnly(idRemover.io.output.config))
+        val write = master(Axi4WriteOnly(idRemover.io.output.config))
+      }
+    }
+
+    val input = Axi4(config)
+    input << io.inputs.read
+    input << io.inputs.write
+
+    idRemover.io.input << input.toShared()
+
+    val output = idRemover.io.output.toAxi4()
+
+    io.outputs.read << output
+    io.outputs.write << output
+  }
+
+  test("shared") {
+    SimConfig.withWave.compile(new Axi4SharedIdRemoverDut(Axi4Config(20, 32, 4))).doSim("test", 42)(sharedTester)
+  }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
@@ -375,7 +375,7 @@ class Axi4IdRemoverTester extends AnyFunSuite {
   }
 
   test("writeOnly") {
-    SimConfig.withWave.compile(new Axi4WriteOnlyIdRemover(Axi4Config(20, 32, 4))).doSim("test", 42)(writeTester)
+    SimConfig.compile(new Axi4WriteOnlyIdRemover(Axi4Config(20, 32, 4))).doSim("test", 42)(writeTester)
   }
 
   def readTester(dut : Axi4ReadOnlyIdRemover): Unit ={
@@ -428,7 +428,7 @@ class Axi4IdRemoverTester extends AnyFunSuite {
   }
 
   test("readOnly") {
-    SimConfig.withWave.compile(new Axi4ReadOnlyIdRemover(Axi4Config(20, 32, 4))).doSim("test", 42)(readTester)
+    SimConfig.compile(new Axi4ReadOnlyIdRemover(Axi4Config(20, 32, 4))).doSim("test", 42)(readTester)
   }
 
   def sharedTester(dut: Axi4SharedIdRemoverDut): Unit = {
@@ -553,6 +553,6 @@ class Axi4IdRemoverTester extends AnyFunSuite {
   }
 
   test("shared") {
-    SimConfig.withWave.compile(new Axi4SharedIdRemoverDut(Axi4Config(20, 32, 4))).doSim("test", 42)(sharedTester)
+    SimConfig.compile(new Axi4SharedIdRemoverDut(Axi4Config(20, 32, 4))).doSim("test", 42)(sharedTester)
   }
 }


### PR DESCRIPTION
Adds a component to perform ID reflection to Axi buses without ID support. Integral part of the translation to Axi4Lite.