### PR TITLE
Temperal fix the aggressive prune signal feature of yosys.

### DIFF
--- a/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
+++ b/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
@@ -83,6 +83,7 @@ case class SpinalFormalConfig(
     var _modesWithDepths: LinkedHashMap[String, Int] = LinkedHashMap[String, Int](),
     var _backend: SpinalFormalBackendSel = SpinalFormalBackendSel.SYMBIYOSYS,
     var _keepDebugInfo: Boolean = false,
+    var _skipWireReduce: Boolean = false,
     var _hasAsync: Boolean = false
 ) {
   var _multiClock = false
@@ -147,6 +148,11 @@ case class SpinalFormalConfig(
 
   def withDebug: this.type = {
     _keepDebugInfo = true
+    this
+  }
+
+  def withOutWireReduce: this.type = {
+    _skipWireReduce = true
     this
   }
 
@@ -256,6 +262,7 @@ case class SpinalFormalConfig(
           modesWithDepths = _modesWithDepths,
           timeout = _timeout,
           keepDebugInfo = _keepDebugInfo,
+          skipWireReduce = _skipWireReduce,
           multiClock = _hasAsync
         )
         vConfig.rtlSourcesPaths ++= rtlFiles

--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -137,7 +137,7 @@ class SymbiYosysBackend(val config: SymbiYosysBackendConfig) extends FormalBacke
       "\n\n" +
       "[script]\n" +
       s"read -formal $read\n" +
-      s"prep -top ${config.toplevelName}\n" +
+      s"prep -ifx -top ${config.toplevelName}\n" +
       "\n" +
       "[files]\n" +
       localSources

--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -91,7 +91,8 @@ class SymbiYosysBackendConfig(
     var toplevelName: String = null,
     var workspacePath: String = null,
     var workspaceName: String = null,
-    var keepDebugInfo: Boolean = false
+    var keepDebugInfo: Boolean = false,
+    var skipWireReduce: Boolean = false
 )
 
 class SymbiYosysBackend(val config: SymbiYosysBackendConfig) extends FormalBackend {
@@ -119,6 +120,7 @@ class SymbiYosysBackend(val config: SymbiYosysBackendConfig) extends FormalBacke
     val taskCmd = modes.mkString("\n")
     val modeCmd = modes.map(x => s"$x: mode $x").mkString("\n")
     val depthCmd = modes.map(x => s"$x: depth ${config.modesWithDepths(x)}").mkString("\n")
+    val skipWireReduce: String = if (config.skipWireReduce) "-ifx" else ""
 
     val script = "[tasks]\n" +
       taskCmd +
@@ -137,7 +139,7 @@ class SymbiYosysBackend(val config: SymbiYosysBackendConfig) extends FormalBacke
       "\n\n" +
       "[script]\n" +
       s"read -formal $read\n" +
-      s"prep -ifx -top ${config.toplevelName}\n" +
+      s"prep ${skipWireReduce} -top ${config.toplevelName}\n" +
       "\n" +
       "[files]\n" +
       localSources

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalAxi4DownsizerTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalAxi4DownsizerTester.scala
@@ -13,7 +13,7 @@ class FormalAxi4DownsizerTester extends SpinalFormalFunSuite {
       .withBMC(10)
       // .withProve(10)
       .withCover(10)
-      .withDebug
+      .withOutWireReduce
       .doVerify(new Component {
         val dut = FormalDut(new Axi4WriteOnlyDownsizer(inConfig, outConfig))
         val reset = ClockDomain.current.isResetActive
@@ -89,7 +89,7 @@ class FormalAxi4DownsizerTester extends SpinalFormalFunSuite {
       .withBMC(10)
       // .withProve(10)
       .withCover(10)
-      .withDebug
+      .withOutWireReduce
       .doVerify(new Component {
         val dut = FormalDut(new Axi4ReadOnlyDownsizer(inConfig, outConfig))
         val reset = ClockDomain.current.isResetActive


### PR DESCRIPTION
Yosys would aggressively remove signals while it's wreduce procedure, which lead some non-trivial signals missing.
Add a switch can help to skip the wreduce command while sby command executing.

the withOutWireReduce function can be called from FormalConfig when the wreduce cause verification failed.