### PR TITLE
feat(lib): add Axi4Unburster

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburster.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburster.scala
@@ -3,10 +3,10 @@ package spinal.lib.bus.amba4.axi
 import spinal.core._
 import spinal.lib._
 
-object Axi4Unburstifier {
+object Axi4Unburster {
   def apply(axi: Axi4): Axi4 = {
-    val roUnburstifier = new Axi4ReadOnlyUnburstifier(axi.config)
-    val woUnburstifier = new Axi4WriteOnlyUnbustifier(axi.config)
+    val roUnburstifier = new Axi4ReadOnlyUnburster(axi.config)
+    val woUnburstifier = new Axi4WriteOnlyUnburster(axi.config)
 
     roUnburstifier.io.input << axi.toReadOnly()
     woUnburstifier.io.input << axi.toWriteOnly()
@@ -18,19 +18,19 @@ object Axi4Unburstifier {
   }
 
   def apply(axi: Axi4ReadOnly): Axi4ReadOnly = {
-    val unburstifier = new Axi4ReadOnlyUnburstifier(axi.config)
+    val unburstifier = new Axi4ReadOnlyUnburster(axi.config)
     unburstifier.io.input << axi
     unburstifier.io.output
   }
 
   def apply(axi: Axi4WriteOnly): Axi4WriteOnly = {
-    val unburstifier = new Axi4WriteOnlyUnbustifier(axi.config)
+    val unburstifier = new Axi4WriteOnlyUnburster(axi.config)
     unburstifier.io.input << axi
     unburstifier.io.output
   }
 }
 
-class Axi4ReadOnlyUnburstifier(config: Axi4Config) extends Component {
+class Axi4ReadOnlyUnburster(config: Axi4Config) extends Component {
   val io = new Bundle {
     val input = slave(Axi4ReadOnly(config))
     val output = master(Axi4ReadOnly(config.copy(useLen = false, useBurst = false, useSize = false, useLast = false)))
@@ -60,7 +60,7 @@ class Axi4ReadOnlyUnburstifier(config: Axi4Config) extends Component {
   }
 }
 
-class Axi4WriteOnlyUnbustifier(config: Axi4Config) extends Component {
+class Axi4WriteOnlyUnburster(config: Axi4Config) extends Component {
   val io = new Bundle {
     val input = slave(Axi4WriteOnly(config))
     val output = master(Axi4WriteOnly(config.copy(useLen = false, useBurst = false, useSize = false)))

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburster.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburster.scala
@@ -234,7 +234,7 @@ class Axi4ReadOnlyUnburster(config: Axi4Config, pendingDepth: Int = 3, pendingWi
     io.output.ar.arbitrationFrom(unburstified)
     io.output.ar.payload.assignSomeByName(unburstified.fragment)
 
-    val rFifo = io.output.r.queueLowLatency(8).continueWhen(manager.io.retIdResp.ready)
+    val rFifo = io.output.r.continueWhen(manager.io.retIdResp.ready)
     (config.useId) generate { manager.io.retIdResp.id := rFifo.id }
     manager.io.retIdResp.valid := rFifo.fire
     manager.io.retIdResp.resp.clearAll()
@@ -279,7 +279,7 @@ class Axi4WriteOnlyUnburster(config: Axi4Config, pendingDepth: Int = 3, pendingW
     io.output.w.last := True
   }
 
-  val bFifo = io.output.b.queueLowLatency(8).continueWhen(manager.io.retIdResp.ready)
+  val bFifo = io.output.b.continueWhen(manager.io.retIdResp.ready)
   (config.useId) generate { manager.io.retIdResp.id := bFifo.id }
   manager.io.retIdResp.valid := bFifo.fire
   if(config.useResp) {

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburster.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburster.scala
@@ -30,6 +30,13 @@ object Axi4Unburster {
   }
 }
 
+/**
+  * Converts a burst transaction into single beat transactions.
+  *
+  * Notice: This component only supports a single transaction at a time.
+  *
+  * TODO: Support concurrent transactions
+  */
 class Axi4ReadOnlyUnburster(config: Axi4Config) extends Component {
   val io = new Bundle {
     val input = slave(Axi4ReadOnly(config))
@@ -62,6 +69,13 @@ class Axi4ReadOnlyUnburster(config: Axi4Config) extends Component {
   }
 }
 
+/**
+  * Converts a single burst transaction into single beat transactions and merges write responses.
+  *
+  * Notice: This component only supports a single transaction at a time.
+  *
+  * TODO: Support concurrent transactions
+  */
 class Axi4WriteOnlyUnburster(config: Axi4Config) extends Component {
   val io = new Bundle {
     val input = slave(Axi4WriteOnly(config))

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburstifier.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburstifier.scala
@@ -50,7 +50,7 @@ class Axi4ReadOnlyUnburstifier(config: Axi4Config) extends Component {
 
     when(io.input.ar.fire) {
       addrBeats := io.input.ar.len
-      active set()
+      active.set()
     }
 
     when(io.input.r.fire) {
@@ -79,7 +79,7 @@ class Axi4WriteOnlyUnbustifier(config: Axi4Config) extends Component {
   when(io.input.aw.fire) {
     addrBeats := io.input.aw.len
     active := True
-    done clear()
+    done.clear()
     config.useResp generate resp.clearAll()
   }
 
@@ -89,7 +89,7 @@ class Axi4WriteOnlyUnbustifier(config: Axi4Config) extends Component {
 
   when(io.output.b.fire) {
     addrBeats := addrBeats - 1
-    done setWhen(addrBeats === 0)
+    done.setWhen(addrBeats === 0)
     config.useResp generate {
       when(!resp.orR) {
         resp := io.output.b.resp
@@ -100,6 +100,6 @@ class Axi4WriteOnlyUnbustifier(config: Axi4Config) extends Component {
   io.input.b.valid := done
   config.useResp generate { io.input.b.resp := resp }
 
-  active clearWhen (io.input.b.fire)
-  done clearWhen (io.input.b.fire)
+  active.clearWhen(io.input.b.fire)
+  done.clearWhen(io.input.b.fire)
 }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburstifier.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburstifier.scala
@@ -91,7 +91,7 @@ class Axi4WriteOnlyUnbustifier(config: Axi4Config) extends Component {
     addrBeats := addrBeats - 1
     done setWhen(addrBeats === 0)
     config.useResp generate {
-      when(resp.orR) {
+      when(!resp.orR) {
         resp := io.output.b.resp
       }
     }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburstifier.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Unburstifier.scala
@@ -1,0 +1,85 @@
+package spinal.lib.bus.amba4.axi
+
+import spinal.core._
+import spinal.lib._
+
+object Axi4Unburstifier {
+  def apply(axi: Axi4): Axi4 = {
+    val roUnburstifier = new Axi4ReadOnlyUnburstifier(axi.config)
+    val woUnburstifier = new Axi4WriteOnlyUnbustifier(axi.config)
+
+    roUnburstifier.io.input << axi.toReadOnly()
+    woUnburstifier.io.input << axi.toWriteOnly()
+
+    val axiUnburst = new Axi4(axi.config.copy(useLen = false))
+    axiUnburst << roUnburstifier.io.output
+    axiUnburst << woUnburstifier.io.output
+    axiUnburst
+  }
+
+  def apply(axi: Axi4ReadOnly): Axi4ReadOnly = {
+    val unburstifier = new Axi4ReadOnlyUnburstifier(axi.config)
+    unburstifier.io.input << axi
+    unburstifier.io.output
+  }
+
+  def apply(axi: Axi4WriteOnly): Axi4WriteOnly = {
+    val unburstifier = new Axi4WriteOnlyUnbustifier(axi.config)
+    unburstifier.io.input << axi
+    unburstifier.io.output
+  }
+}
+
+class Axi4ReadOnlyUnburstifier(config: Axi4Config) extends Component {
+  val io = new Bundle {
+    val input = slave(Axi4ReadOnly(config))
+    val output = master(Axi4ReadOnly(config.copy(useLen = false)))
+  }
+
+  val unburstified = io.input.ar.unburstify
+
+  io.output.ar.arbitrationFrom(unburstified)
+  io.output.ar.payload.assignAllByName(unburstified.payload)
+
+  io.output.r << io.input.r
+}
+
+class Axi4WriteOnlyUnbustifier(config: Axi4Config) extends Component {
+  val io = new Bundle {
+    val input = slave(Axi4WriteOnly(config))
+    val output = master(Axi4WriteOnly(config.copy(useLen = false)))
+  }
+
+  val unburstified = io.input.aw.unburstify
+
+  val addrBeats = Reg(UInt(9 bit))
+  val active = RegInit(False)
+  val resp = if (config.useResp) Reg(Bits(2 bit)) else null
+
+  io.output.aw.arbitrationFrom(unburstified)
+  io.output.aw.payload.assignAllByName(unburstified.payload)
+
+  when(io.input.aw.fire) {
+    addrBeats := io.input.aw.len+1
+    active := True
+    config.useResp generate resp.clearAll()
+  }
+
+  io.output.w << io.input.w
+
+  io.output.b.ready := active
+
+  when(io.output.b.fire) {
+    addrBeats := addrBeats - 1
+    config.useResp generate {
+      when(resp.orR) {
+        resp := io.output.b.resp
+      }
+    }
+  }
+
+  io.input.b.valid := (addrBeats === 0 && active)
+  config.useResp generate { io.input.b.resp := resp }
+
+  active clearWhen (io.input.b.fire)
+}

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/Agent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/Agent.scala
@@ -34,6 +34,7 @@ abstract class Axi4WriteOnlyMasterAgent(aw : Stream[Axi4Aw], w : Stream[Axi4W], 
   val bQueue = Array.fill(idCount)(mutable.Queue[() => Unit]())
   var allowGen = true
   var rspCounter = 0
+  val assertOkResp = true
   def pending = bQueue.exists(_.nonEmpty)
   val bDriver = StreamReadyRandomizer(b, clockDomain)
 
@@ -122,7 +123,7 @@ abstract class Axi4WriteOnlyMasterAgent(aw : Stream[Axi4Aw], w : Stream[Axi4W], 
 
     //WRITE RSP
     bQueue(id).enqueue { () =>
-      if(busConfig.useResp) assert(b.resp.toInt == 0)
+      if(busConfig.useResp && assertOkResp) assert(b.resp.toInt == 0)
       mappingFree(mapping)
     }
   }
@@ -173,6 +174,7 @@ abstract class Axi4ReadOnlyMasterAgent(ar : Stream[Axi4Ar], r : Stream[Axi4R], c
   val rQueue = Array.fill(idCount)(mutable.Queue[() => Unit]())
   var allowGen = true
   var rspCounter = 0
+  val assertOkResp = true
 
   def genAddress() : BigInt
   def mappingAllocate(mapping : SizeMapping) : Boolean
@@ -245,7 +247,7 @@ abstract class Axi4ReadOnlyMasterAgent(ar : Stream[Axi4Ar], r : Stream[Axi4R], c
 
     //READ RSP
     for(beat <- 0 to len) rQueue(id).enqueue { () =>
-      if(busConfig.useResp) assert(r.resp.toInt == 0)
+      if(busConfig.useResp && assertOkResp) assert(r.resp.toInt == 0)
       if(busConfig.useLast) assert(r.last.toBoolean == (beat == len))
       if((busConfig.useLast && r.last.toBoolean) || (beat == len)) {
         mappingFree(mapping)

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
@@ -106,7 +106,7 @@ class Axi4UpsizerTester extends AnyFunSuite {
         }
       }
 
-      override def onResponse(address: BigInt, id: Int, last: Boolean, resp: Byte): Unit = assert(last && reads.isEmpty)
+      override def onResponse(address: BigInt, id: Int, last: Boolean, resp: Byte): Unit = if (last) assert(reads.isEmpty)
     }
 
 

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
@@ -7,6 +7,7 @@ import spinal.core.sim.SimCompiled
 import spinal.lib.bus.amba4.axi.sim.{Axi4ReadOnlyMasterAgent, Axi4ReadOnlyMonitor, Axi4ReadOnlySlaveAgent, Axi4WriteOnlyMasterAgent, Axi4WriteOnlyMonitor, Axi4WriteOnlySlaveAgent}
 import spinal.lib.bus.amba4.axi.{Axi4Config, Axi4ReadOnlyUpsizer, Axi4WriteOnlyUpsizer, Axi4ReadOnlyDownsizer, Axi4WriteOnlyDownsizer}
 import spinal.lib.bus.misc.SizeMapping
+import spinal.lib.{master, slave}
 
 import scala.collection.mutable
 import scala.util.Random
@@ -35,14 +36,14 @@ class Axi4UpsizerTester extends AnyFunSuite {
 
     val writes = mutable.HashMap[BigInt, Byte]()
     val inputMonitor = new Axi4WriteOnlyMonitor(dut.io.input, dut.clockDomain) {
-      override def onWriteByte(address: BigInt, data: Byte): Unit = {
+      override def onWriteByte(address: BigInt, data: Byte, id: Int): Unit = {
         //          println(s"I $address -> $data")
         writes(address) = data
       }
     }
 
     val outputMonitor = new Axi4WriteOnlyMonitor(dut.io.output, dut.clockDomain) {
-      override def onWriteByte(address: BigInt, data: Byte): Unit = {
+      override def onWriteByte(address: BigInt, data: Byte, id: Int): Unit = {
         //          println(s"O $address -> $data")
         assert(writes(address) == data)
         writes.remove(address)
@@ -95,7 +96,6 @@ class Axi4UpsizerTester extends AnyFunSuite {
       override def onReadByte(address: BigInt, data: Byte, id : Int): Unit = {
         reads(address) = data
       }
-      override def onLast(id: Int): Unit = {}
     }
 
     val outputMonitor = new Axi4ReadOnlyMonitor(dut.io.output, dut.clockDomain) {
@@ -106,7 +106,7 @@ class Axi4UpsizerTester extends AnyFunSuite {
         }
       }
 
-      override def onLast(id: Int): Unit = assert(reads.isEmpty)
+      override def onResponse(address: BigInt, id: Int, last: Boolean, resp: Byte): Unit = assert(last && reads.isEmpty)
     }
 
 
@@ -167,7 +167,7 @@ class Axi4DownsizerTester extends AnyFunSuite {
         val writes = mutable.HashMap[BigInt, Byte]()
         val datas  = mutable.Queue[Byte]()
         val inputMonitor = new Axi4WriteOnlyMonitor(dut.io.input, dut.clockDomain) {
-            override def onWriteByte(address: BigInt, data: Byte): Unit = {
+            override def onWriteByte(address: BigInt, data: Byte, id: Int): Unit = {
                 //          println(s"I $address -> $data")
                 writes(address) = data
                 datas.enqueue(data)
@@ -175,7 +175,7 @@ class Axi4DownsizerTester extends AnyFunSuite {
         }
 
         val outputMonitor = new Axi4WriteOnlyMonitor(dut.io.output, dut.clockDomain) {
-            override def onWriteByte(address: BigInt, data: Byte): Unit = {
+            override def onWriteByte(address: BigInt, data: Byte, id: Int): Unit = {
                 //          println(s"O $address -> $data")
                 assert(writes(address) == data)
                 writes.remove(address)
@@ -289,15 +289,12 @@ class Axi4DownsizerTester extends AnyFunSuite {
             override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
                 checkReads(address, data)
             }
-            override def onLast(id: Int): Unit = {}
         }
 
         val outputMonitor = new Axi4ReadOnlyMonitor(dut.io.output, dut.clockDomain) {
             override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
                 checkReads(address, data)
             }
-
-            override def onLast(id: Int): Unit = {}
         }
 
         dut.clockDomain.waitSamplingWhere(inputAgent.rspCounter > 10000)

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4SharedOnChipRamTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4SharedOnChipRamTester.scala
@@ -76,10 +76,13 @@ class Axi4SharedOnChipRamMultiPortTester extends AnyFunSuite {
         }
 
         val readMonitor = new Axi4ReadOnlyMonitor(port, clockDomain) {
+            override def onReadStart(address: BigInt, id: Int, size: Int, len: Int, burst: Int): Unit = {}
+
             override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
                 if (memory.contains(address)) assert(memory(address) == data, id.toString + ":" + address.toString(16))
             }
-            override def onLast(id: Int): Unit = {}
+
+            override def onResponse(address: BigInt, id: Int, last: Boolean, resp: Byte): Unit = {}
         }
 
         val write = new Axi4WriteOnlyMasterAgent(port, clockDomain) {
@@ -94,9 +97,13 @@ class Axi4SharedOnChipRamMultiPortTester extends AnyFunSuite {
             override def mappingFree(mapping: SizeMapping): Unit = regions.remove(mapping)
         }
         val writeMonitor = new Axi4WriteOnlyMonitor(port, clockDomain) {
-            override def onWriteByte(address: BigInt, data: Byte): Unit = {
+            override def onWriteStart(address: BigInt, id: Int, size: Int, len: Int, burst: Int): Unit = {}
+
+            override def onWriteByte(address: BigInt, data: Byte, id: Int): Unit = {
                 memory(address) = data
             }
+
+            override def onResponse(id: Int, resp: Byte): Unit = {}
         }
         (read, write, readMonitor, writeMonitor)
     }

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4SimAgentTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4SimAgentTester.scala
@@ -54,14 +54,14 @@ class Axi4SimAgentTester extends AnyFunSuite {
 
         val writes = mutable.HashMap[BigInt, Byte]()
         val inputMonitor = new Axi4WriteOnlyMonitor(dut.io.input, dut.clockDomain) {
-            override def onWriteByte(address: BigInt, data: Byte): Unit = {
+            override def onWriteByte(address: BigInt, data: Byte, id: Int): Unit = {
                 // println(s"I $address -> $data")
                 writes(address) = data
             }
         }
 
         val outputMonitor = new Axi4WriteOnlyMonitor(dut.io.output, dut.clockDomain) {
-            override def onWriteByte(address: BigInt, data: Byte): Unit = {
+            override def onWriteByte(address: BigInt, data: Byte, id: Int): Unit = {
                 // println(s"O $address -> $data")
                 assert(writes(address) == data)
                 writes.remove(address)
@@ -145,7 +145,6 @@ class Axi4SimAgentTester extends AnyFunSuite {
             override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
                 reads(address) = data
             }
-            override def onLast(id: Int): Unit = {}
         }
 
         val outputMonitor = new Axi4ReadOnlyMonitor(dut.io.output, dut.clockDomain) {
@@ -156,7 +155,7 @@ class Axi4SimAgentTester extends AnyFunSuite {
                 }
             }
 
-            override def onLast(id: Int): Unit = assert(reads.isEmpty)
+            override def onResponse(address: BigInt, id: Int, last: Boolean, resp: Byte): Unit = if (last) assert(reads.isEmpty)
         }
 
         dut.clockDomain.waitSamplingWhere(inputAgent.rspCounter > 10000)

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4UnburstTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4UnburstTester.scala
@@ -1,0 +1,130 @@
+package spinal.tester.scalatest
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core.sim._
+import spinal.lib.bus.amba4.axi._
+import spinal.lib.bus.amba4.axi.sim.{Axi4ReadOnlyMasterAgent, Axi4ReadOnlyMonitor, Axi4ReadOnlySlaveAgent, Axi4WriteOnlyMasterAgent, Axi4WriteOnlyMonitor, Axi4WriteOnlySlaveAgent}
+import spinal.lib.bus.misc.SizeMapping
+import spinal.lib.sim.ScoreboardInOrder
+
+import scala.util.Random
+
+class Axi4UnburstTester extends AnyFunSuite {
+
+  def tester_readonly(dut: Axi4ReadOnlyUnburster): Unit = {
+    dut.clockDomain.forkStimulus(10)
+
+    val readScoreboard = ScoreboardInOrder[(BigInt, Byte, Int)]()
+    val readRespScoreboard = ScoreboardInOrder[Byte]()
+
+    new Axi4ReadOnlyMasterAgent(dut.io.input.ar, dut.io.input.r, dut.clockDomain) {
+      override def genAddress(): BigInt = ((Random.nextInt(1 << 19)))// & 0xFFF00) | 6
+
+      override def mappingAllocate(mapping: SizeMapping): Boolean = true
+
+      override def mappingFree(mapping: SizeMapping): Unit = {}
+
+      override val assertOkResp: Boolean = false
+    }
+
+    new Axi4ReadOnlyMonitor(dut.io.output.ar, dut.io.output.r, dut.clockDomain) {
+      override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
+        readScoreboard.pushDut(address, data, id)
+      }
+
+      override def onResponse(address: BigInt, id: Int, last: Boolean, resp: Byte): Unit = {
+        readRespScoreboard.pushRef(resp)
+      }
+    }
+
+    new Axi4ReadOnlyMonitor(dut.io.input.ar, dut.io.input.r, dut.clockDomain) {
+      override def onReadByte(address: BigInt, data: Byte, id: Int): Unit = {
+        readScoreboard.pushRef(address, data, id)
+      }
+
+      override def onResponse(address: BigInt, id: Int, last: Boolean, resp: Byte): Unit = {
+        readRespScoreboard.pushDut(resp)
+      }
+    }
+
+    new Axi4ReadOnlySlaveAgent(dut.io.output.ar, dut.io.output.r, dut.clockDomain)
+
+    SimTimeout(100000000L)
+
+    while(true) {
+      dut.clockDomain.waitSampling()
+      readRespScoreboard.check()
+      readScoreboard.check()
+
+      if (readRespScoreboard.matches >= 256 && readScoreboard.matches >= 1024) {
+        simSuccess()
+      }
+    }
+  }
+
+  test("unburst_readonly") {
+    SimConfig.compile(new Axi4ReadOnlyUnburster(Axi4Config(dataWidth = 32, addressWidth = 32, idWidth = 4)))
+      .doSim {dut => tester_readonly(dut) }
+  }
+
+  def tester_writeonly(dut: Axi4WriteOnlyUnburster): Unit = {
+    dut.clockDomain.forkStimulus(10)
+
+    val writeScoreboard = ScoreboardInOrder[(BigInt, Byte)]()
+    var writeRespRolling: Byte = 0
+    val writeRespScoreboard = ScoreboardInOrder[Byte]()
+
+    new Axi4WriteOnlyMasterAgent(dut.io.input.aw, dut.io.input.w, dut.io.input.b, dut.clockDomain) {
+      override def genAddress(): BigInt = ((Random.nextInt(1 << 19))) // & 0xFFF00) | 6
+
+      override def mappingAllocate(mapping: SizeMapping): Boolean = true
+
+      override def mappingFree(mapping: SizeMapping): Unit = {}
+
+      override val assertOkResp: Boolean = false
+    }
+
+    new Axi4WriteOnlyMonitor(dut.io.output.aw, dut.io.output.w, dut.io.output.b, dut.clockDomain) {
+      override def onWriteByte(address: BigInt, data: Byte, id: Int): Unit = {
+        writeScoreboard.pushDut(address, data)
+      }
+
+      override def onResponse(id: Int, resp: Byte): Unit = {
+        if (writeRespRolling == 0 && resp != 0) {
+          writeRespRolling = resp
+        }
+      }
+    }
+
+    new Axi4WriteOnlyMonitor(dut.io.input.aw, dut.io.input.w, dut.io.input.b, dut.clockDomain) {
+      override def onWriteByte(address: BigInt, data: Byte, id: Int): Unit = {
+        writeScoreboard.pushRef(address, data)
+      }
+
+      override def onResponse(id: Int, resp: Byte): Unit = {
+        writeRespScoreboard.pushDut(resp)
+        writeRespScoreboard.pushRef(writeRespRolling)
+        writeRespRolling = 0
+      }
+    }
+
+    new Axi4WriteOnlySlaveAgent(dut.io.output.aw, dut.io.output.w, dut.io.output.b, dut.clockDomain)
+
+    SimTimeout(100000000L)
+
+    while (true) {
+      dut.clockDomain.waitSampling()
+      writeScoreboard.check()
+      writeRespScoreboard.check()
+
+      if (writeRespScoreboard.matches >= 256 && writeScoreboard.matches >= 1024) {
+        simSuccess()
+      }
+    }
+  }
+
+  test("unburst_writeonly") {
+    SimConfig.compile(new Axi4WriteOnlyUnburster(Axi4Config(dataWidth = 32, addressWidth = 32, idWidth = 4)))
+      .doSim { dut => tester_writeonly(dut) }
+  }
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4UnburstTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4UnburstTester.scala
@@ -62,6 +62,21 @@ class Axi4UnburstTester extends AnyFunSuite {
     }
   }
 
+  test("unburst_readonly_no_last_no_id") {
+    SimConfig.compile(new Axi4ReadOnlyUnburster(Axi4Config(dataWidth = 32, addressWidth = 32, useId = false, useLast = false)))
+      .doSim { dut => tester_readonly(dut) }
+  }
+
+  test("unburst_readonly_no_id") {
+    SimConfig.compile(new Axi4ReadOnlyUnburster(Axi4Config(dataWidth = 32, addressWidth = 32, useId = false)))
+      .doSim { dut => tester_readonly(dut) }
+  }
+
+  test("unburst_readonly_no_last") {
+    SimConfig.compile(new Axi4ReadOnlyUnburster(Axi4Config(dataWidth = 32, addressWidth = 32, idWidth = 4, useLast = false)))
+      .doSim { dut => tester_readonly(dut) }
+  }
+
   test("unburst_readonly") {
     SimConfig.compile(new Axi4ReadOnlyUnburster(Axi4Config(dataWidth = 32, addressWidth = 32, idWidth = 4)))
       .doSim {dut => tester_readonly(dut) }
@@ -121,6 +136,21 @@ class Axi4UnburstTester extends AnyFunSuite {
         simSuccess()
       }
     }
+  }
+
+  test("unburst_writeonly_no_last_no_id") {
+    SimConfig.compile(new Axi4WriteOnlyUnburster(Axi4Config(dataWidth = 32, addressWidth = 32, useId = false, useLast = false)))
+      .doSim { dut => tester_writeonly(dut) }
+  }
+
+  test("unburst_writeonly_no_id") {
+    SimConfig.compile(new Axi4WriteOnlyUnburster(Axi4Config(dataWidth = 32, addressWidth = 32, useId = false)))
+      .doSim { dut => tester_writeonly(dut) }
+  }
+
+  test("unburst_writeonly_no_last") {
+    SimConfig.compile(new Axi4WriteOnlyUnburster(Axi4Config(dataWidth = 32, addressWidth = 32, idWidth = 4, useLast = false)))
+      .doSim { dut => tester_writeonly(dut) }
   }
 
   test("unburst_writeonly") {


### PR DESCRIPTION
Create an Axi4Unburster which unburstifies the entire Axi4 bus.  There's a little more overhead in generating new last signals and accumulating write response errors.

I also added more event functions to the Axi4 monitors and enriched the existing ones. While I don't strictly need some of these now I will need them in the future for in-progress Axi4 to Lite converter tests.