### PR TITLE
fix past valid definition.

### DIFF
--- a/core/src/main/scala/spinal/core/formal/package.scala
+++ b/core/src/main/scala/spinal/core/formal/package.scala
@@ -16,7 +16,7 @@ package object formal {
     ptr
   }
   def past[T <: Data](that : T) : T = past(that, 1)
-  def pastValid() : Bool = signalCache("formal.pastValid")(past(!ClockDomain.current.isResetActive) init(False) setWeakName("formal_with_past"))
+  def pastValid() : Bool = signalCache("formal.pastValid")(RegNext(True) initial(False)  setWeakName("f_past_valid"))
 
   def rose(that : Bool) : Bool = that.rise(True)
   def fell(that : Bool) : Bool = that.fall(False)

--- a/core/src/main/scala/spinal/core/formal/package.scala
+++ b/core/src/main/scala/spinal/core/formal/package.scala
@@ -16,7 +16,7 @@ package object formal {
     ptr
   }
   def past[T <: Data](that : T) : T = past(that, 1)
-  def pastValid() : Bool = signalCache("formal.pastValid")(RegNext(True) initial(False)  setWeakName("f_past_valid"))
+  def pastValid() : Bool = signalCache("formal.pastValid")(RegNext(True) initial(False)  setWeakName("formal_with_past"))
   def pastValidAfterReset() : Bool = signalCache("formal.pastValidAfterReset")(past(!ClockDomain.current.isResetActive) init(False) setWeakName("formal_with_past_after_reset"))
 
   def rose(that : Bool) : Bool = that.rise(True)

--- a/core/src/main/scala/spinal/core/formal/package.scala
+++ b/core/src/main/scala/spinal/core/formal/package.scala
@@ -17,6 +17,7 @@ package object formal {
   }
   def past[T <: Data](that : T) : T = past(that, 1)
   def pastValid() : Bool = signalCache("formal.pastValid")(RegNext(True) initial(False)  setWeakName("f_past_valid"))
+  def pastValidAfterReset() : Bool = signalCache("formal.pastValidAfterReset")(past(!ClockDomain.current.isResetActive) init(False) setWeakName("formal_with_past_after_reset"))
 
   def rose(that : Bool) : Bool = that.rise(True)
   def fell(that : Bool) : Bool = that.fall(False)

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalHistoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalHistoryTester.scala
@@ -31,7 +31,7 @@ class FormalHistoryModifyableTester extends SpinalFormalFunSuite {
         when(input.valid) {
           assume(!outExists(input.payload))
         }
-        when(past(input.valid) && pastValid()) { assert(results(0).valid && results(0).payload === past(input.payload)) }
+        when(pastValid & past(!reset & input.valid)) { assert(results(0).valid && results(0).payload === past(input.payload)) }
 
         val dataOverflow = anyconst(cloneOf(input.payload))
         assert(
@@ -82,7 +82,7 @@ class FormalHistoryModifyableTester extends SpinalFormalFunSuite {
         val outOverflowCount = U(overflowCondition)
         val fireCount = results.sCount(x => x.fire && x.payload === dataOut)
 
-        when(pastValid()) {
+        when(pastValid & !past(reset)) {
           assert(past(validCount - fireCount + inputCount - outOverflowCount - modifyCount) === validCount)
         }
         results.map(x => cover(x.fire))

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -30,7 +30,7 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         val countHist = History(count, 2, inStream.fire, init = count.getZero)
         when(!dut.io.available) { assume(inReady === False) }
 
-        when(pastValid & past(inStream.fire)) { assert(dut.io.working) }
+        when(pastValid & past(!reset & inStream.fire)) { assert(dut.io.working) }
         when(pastValid & past(dut.io.done & !inStream.fire)) { assert(!dut.io.working) }
 
         when(dut.io.done) { assert(dut.counter.value >= countHist(1)) }
@@ -121,7 +121,7 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
 
         val countHist = History(count, 2, inStream.fire, init = count.getZero)
 
-        when(pastValid & past(inStream.fire)) { assert(dut.io.working) }
+        when(pastValid & past(!reset & inStream.fire)) { assert(dut.io.working) }
         when(pastValid & past(dut.io.done & !inStream.fire)) { assert(!dut.io.working) }
 
         when(dut.io.done) { assert(dut.counter.counter.value >= countHist(1)) }


### PR DESCRIPTION
So the pastValid is only to indicate there are past values exist.
pastValidAfterReset is defined for synchronous logic with reset logic.
Answer the issue #813 , but not directly fix it.