### PR TITLE
skip formal verification while CI.

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -19,7 +19,7 @@ jobs:
       run: sbt "+test:compile"
 
     - name: Run tests
-      run: sbt "++2.11.12; test"
+      run: sbt "++2.11.12; testWithoutFormal"
   
   formal:
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -206,6 +206,7 @@ test in assembly := {}
 
 Test / testOptions += Tests.Argument("-l", "spinal.tester.formal")
 addCommandAlias("testFormal", "testOnly * -- -n spinal.tester.formal")
+addCommandAlias("testWithoutFormal", "testOnly * -- -l spinal.tester.formal")
 
 assemblyOutputPath in assembly := file("./release/spinalhdl.jar")
 


### PR DESCRIPTION
exclude arguments for test are not working now, add testWithoutFormal to reduce the test time while CI.
fix #825 