### PR TITLE
add no delay function to transaction extender

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1809,22 +1809,19 @@ class StreamTransactionCounter(
 }
 
 object StreamTransactionExtender {
-    def apply[T <: Data](input: Stream[T], count: UInt)(driver: (UInt, T, Bool) => T = (_: UInt, p: T, _: Bool) => p): Stream[T] = {
-      StreamTransactionExtender(input, count, false, driver)
-    }
-    def apply[T <: Data](input: Stream[T], count: UInt, noDelay: Boolean): Stream[T] = {
-      StreamTransactionExtender(input, count, noDelay, (_: UInt, p: T, _: Bool) => p)
-    }
-    def apply[T <: Data](input: Stream[T], count: UInt, noDelay: Boolean, driver: (UInt, T, Bool) => T): Stream[T] = {
+    def apply[T <: Data](input: Stream[T], count: UInt, noDelay: Boolean = false)(
+        implicit driver: (UInt, T, Bool) => T = (_: UInt, p: T, _: Bool) => p
+    ): Stream[T] = {
         val c = new StreamTransactionExtender(input.payloadType, input.payloadType, count.getBitsWidth, noDelay, driver)
         c.io.input << input
         c.io.count := count
         c.io.output
     }
 
-    def apply[T <: Data, T2 <: Data](input: Stream[T], output: Stream[T2], count: UInt)(driver: (UInt, T, Bool) => T2): StreamTransactionExtender[T, T2] = {
-      StreamTransactionExtender[T, T2](input, output, count, false)(driver)
-    }
+    def apply[T <: Data, T2 <: Data](input: Stream[T], output: Stream[T2], count: UInt)(
+        driver: (UInt, T, Bool) => T2
+    ): StreamTransactionExtender[T, T2] = StreamTransactionExtender(input, output, count, false)(driver)
+
     def apply[T <: Data, T2 <: Data](input: Stream[T], output: Stream[T2], count: UInt, noDelay: Boolean)(
         driver: (UInt, T, Bool) => T2
     ): StreamTransactionExtender[T, T2] = {

--- a/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/FormalStreamExtender.scala
@@ -142,6 +142,50 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
         }
       })
   }
+  
+
+  def extenderNoDelayTester() {
+    FormalConfig
+      // .withBMC(10)
+      .withProve(10)
+      .withCover(10)
+      .doVerify(new Component {
+        val inStream = slave Stream (UInt(2 bits))
+        val outStream = master Stream (UInt(2 bits))
+        val count = in UInt (3 bits)
+        val dut = FormalDut(StreamTransactionExtender(inStream, outStream, count, true) { (_, p, _) => p })
+
+        val reset = ClockDomain.current.isResetActive
+        assumeInitial(reset)
+
+        val countHist = History(count, 2, inStream.fire, init = count.getZero)
+        val expected = countHist(1).getAheadValue()
+
+        when(inStream.fire) { assert(dut.io.working) }
+        when(pastValid & past(dut.io.done) & !inStream.fire) { assert(!dut.io.working) }
+
+        when(dut.io.done) { assert(dut.counter.counter.value >= expected) }
+        when(dut.io.working) {
+          assert(expected === dut.counter.expected) // key to sync verification logic and internal logic.
+          when(dut.counter.counter.value === expected & outStream.fire) { assert(dut.io.done) }
+          when(!inStream.fire) { assert(!dut.counter.io.available) }
+          .otherwise { assert(dut.counter.io.available) }
+          when(!dut.io.input.fire) { assert(!inStream.ready) }
+          when(dut.io.input.fire) { assert(dut.io.input.payload === dut.io.output.payload) }
+          .otherwise { assert(dut.io.output.payload === dut.payloadReg) }
+        }
+        cover(pastValid & past(dut.io.done) & inStream.fire)
+        cover(pastValid & past(dut.io.working) & !dut.io.working)
+
+        inStream.withAssumes()
+        outStream.withAssumes()
+
+        for(i <- 1 until 2) {
+          inStream.withCovers(i)
+          outStream.withCovers(i)
+        }
+      })
+  }
 
   test("transaction counter") {
     counterTester()
@@ -153,5 +197,9 @@ class FormalStreamExtender extends SpinalFormalFunSuite {
 
   test("transaction extender") {
     extenderTester()
+  }
+
+  test("transaction extender without delay") {
+    extenderNoDelayTester()
   }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamExtenderTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamExtenderTester.scala
@@ -78,6 +78,7 @@ class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
                 UInt(32 bits),
                 UInt(33 bits),
                 12,
+                false,
                 (id, payload: UInt, last) => payload @@ last
             )
             dut
@@ -99,6 +100,7 @@ class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
                 UInt(32 bits),
                 UInt(33 bits),
                 12,
+                false,
                 (id, payload: UInt, last) => payload @@ last
             )
             dut
@@ -120,6 +122,7 @@ class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
                 UInt(32 bits),
                 UInt(33 bits),
                 12,
+                false,
                 (id, payload: UInt, last) => payload @@ last
             )
             dut
@@ -141,6 +144,7 @@ class SpinalSimStreamExtenderTester extends SpinalSimFunSuite {
                 UInt(32 bits),
                 UInt(33 bits),
                 12,
+                false,
                 (id, payload: UInt, last) => payload @@ last
             )
             dut


### PR DESCRIPTION
so the extender can output at the cycle that input stream fire.