### PR TITLE
XSim: Overhaul XSI interface and make it signal width aware

### DIFF
--- a/sim/src/main/resources/XSIIface.hpp
+++ b/sim/src/main/resources/XSIIface.hpp
@@ -26,7 +26,7 @@ public:
     std::vector<int8_t> read(int32_t handle, int32_t width);
     int64_t read64(int32_t handle);
     int32_t read32(int32_t handle);
-    void write(int32_t handle, int32_t width, const std::vector<int8_t>& data);
+    void write(int32_t handle, int32_t width, std::vector<int8_t> data);
     void write64(int32_t handle, int64_t data);
     void write32(int32_t handle, int32_t data);
     
@@ -34,6 +34,9 @@ public:
     void check_status();
 private:
     Xsi::Loader loader;
+    int32_t get_port_width(int32_t handle);
+    std::vector<int8_t> read_vlog(int32_t handle);
+    void write_vlog(int32_t handle, std::vector<int8_t> data);
 
     int64_t sim_time_precision;
 };

--- a/sim/src/main/resources/xsi_loader.cpp
+++ b/sim/src/main/resources/xsi_loader.cpp
@@ -18,7 +18,9 @@ Loader::Loader(const std::string& design_libname, const std::string& simkernel_l
     _xsi_get_port_number(NULL),
     _xsi_get_port_name(NULL),
     _xsi_trace_all(NULL), 
-    _xsi_get_time(NULL)
+    _xsi_get_time(NULL),
+    _xsi_get_int(NULL),
+    _xsi_get_int_port(NULL)
 {
 
     if (!initialize()) {
@@ -118,6 +120,11 @@ XSI_INT32 Loader::get_sim_time_precision()
     return _xsi_get_int(_design_handle, xsiTimePrecisionKernel);
 }
 
+XSI_INT32 Loader::get_int_port(int port_number, int property)
+{
+    return _xsi_get_int_port(_design_handle, port_number, property);
+}
+
 bool
 Loader::initialize()
 {
@@ -208,6 +215,11 @@ Loader::initialize()
 
     _xsi_get_int = (t_fp_xsi_get_int) _simkernel_lib.getfunction("xsi_get_int");
     if (!_xsi_get_int) {
+        return false;
+    }
+
+    _xsi_get_int_port = (t_fp_xsi_get_int_port) _simkernel_lib.getfunction("xsi_get_int_port");
+    if (!_xsi_get_int_port) {
         return false;
     }
 

--- a/sim/src/main/resources/xsi_loader.h
+++ b/sim/src/main/resources/xsi_loader.h
@@ -44,6 +44,7 @@ public:
     void trace_all();
     XSI_INT32 get_sim_time_precision();
     XSI_INT64 get_time();
+    XSI_INT32 get_int_port(int port_number, int property);
 
 private:
     bool initialize();
@@ -68,6 +69,7 @@ private:
     t_fp_xsi_trace_all _xsi_trace_all;
     t_fp_xsi_get_time _xsi_get_time;
     t_fp_xsi_get_int _xsi_get_int;
+    t_fp_xsi_get_int_port _xsi_get_int_port;
 
 }; // class Loader
 

--- a/sim/src/main/scala/spinal/sim/XSimBackend.scala
+++ b/sim/src/main/scala/spinal/sim/XSimBackend.scala
@@ -1,6 +1,6 @@
 package spinal.sim
 
-import java.nio.file.{Paths, Files, Path}
+import java.nio.file.Paths
 import java.io.{File, PrintWriter}
 import java.lang.Thread
 import scala.io.Source
@@ -11,6 +11,8 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.sys.process._
 import spinal.sim.xsi._
+
+import scala.util.Properties
 
 case class XSimBackendConfig(
                              val rtlIncludeDirs : ArrayBuffer[String] = ArrayBuffer[String](),
@@ -108,8 +110,8 @@ class XSimBackend(config: XSimBackendConfig) extends Backend {
 
   class Logger extends ProcessLogger {
     val logs = new StringBuilder()
-    override def err(s: => String): Unit = { logs ++= (s) }
-    override def out(s: => String): Unit = { logs ++= (s) }
+    override def err(s: => String): Unit = { logs ++= (s + Properties.lineSeparator) }
+    override def out(s: => String): Unit = { logs ++= (s + Properties.lineSeparator) }
     override def buffer[T](f: => T) = f
   }
 


### PR DESCRIPTION
Fixes #828 

This is a rewrite of how the XSI interface accesses signal data. I believe the problems in #828 are caused by uninitialized memory or some other issue. On top of that, conversion with `.toInt` and `.toLong` could crash XSim if the underlying signal was not properly sized. Sure this could have been fixed in the JNI interface but I prefer a more robust C++ interface.