### PR TITLE
gitignore: ignore project/{project,metals.sbt}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+project/project
+project/metals.sbt
 
 # Scala-IDE specific
 .scala_dependencies


### PR DESCRIPTION
I don't know for you, but in my installation it creates these files. (Sometimes it creates `project/project/project` :thinking: :upside_down_face: )

I think they can be ignored.