### PR TITLE
Fix bug: only top rtl present in rtl source paths when oneFilePerComponent enable.

### DIFF
--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -36,9 +36,9 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
 
   override def impl(pc: PhaseContext): Unit = {
 
-    report.generatedSourcesPaths += targetPath
     report.toplevelName = pc.topLevel.definitionName
     if (!pc.config.oneFilePerComponent) {
+      report.generatedSourcesPaths += targetPath
       outFile = new java.io.FileWriter(targetPath)
       outFile.write(VhdlVerilogBase.getHeader("//", pc.config.rtlHeader, topLevel, config.headerWithDate, config.headerWithRepoHash))
 
@@ -77,7 +77,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
     else {
       val fileList: mutable.LinkedHashSet[String] = new mutable.LinkedHashSet()
       // dump Enum define to define.v instead attach that on every .v file
-      if(!enums.isEmpty){
+      if(enums.nonEmpty){
         val defineFileName = pc.config.targetDirectory + "/enumdefine" + (if(pc.config.isSystemVerilog) ".sv" else ".v")
         val defineFile = new java.io.FileWriter(defineFileName)
         emitEnumPackage(defineFile)
@@ -90,6 +90,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
       for (c <- sortedComponents) {
         val moduleContent = compile(c)()
         val targetFilePath = pc.config.targetDirectory + "/" +  (if(pc.config.netlistFileName == null)(c.definitionName + (if(pc.config.isSystemVerilog) ".sv" else ".v")) else pc.config.netlistFileName)
+        report.generatedSourcesPaths += targetFilePath
 
         if (!moduleContent.contains("replaced by")) {
           if (!c.isInBlackBoxTree) {

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -568,7 +568,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
 
   val vpiModuleName = "vpi_vcs.so"
   val vpiModulePath = pluginsPath + "/" + vpiModuleName
-  val vpiModuleAbsPath = new File(vpiModulePath).getAbsolutePath().mkString
+  val vpiModuleAbsPath = new File(vpiModulePath).getAbsolutePath.mkString
   val vpiInclude = sys.env.get("VCS_HOME") match {
     case Some(x) => x + "/include"
     case None => {
@@ -583,7 +583,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
     case None => {
       if(config.waveFormat == WaveFormat.FSDB){
         var info = "$VERDI_HOME not found"
-        if(sys.env.get("LD_LIBRARY_PATH") == None) {
+        if(!sys.env.contains("LD_LIBRARY_PATH")) {
           info += "\n $LD_LIBRARY_PATH not found"
         }
         println(s"[Error]: ${info}")
@@ -601,7 +601,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       val cppSourceFile = new PrintWriter(new File(pluginsPath + "/" + filename))
       val stream = getClass.getResourceAsStream(filename)
       cppSourceFile.write(scala.io.Source.fromInputStream(stream).mkString)
-      cppSourceFile.close
+      cppSourceFile.close()
     }
     val vpiCFlags = s"-DVCS_PLUGIN -I$vpiInclude -fPIC -shared"
     val vpiCommand = Seq(


### PR DESCRIPTION
Related to #829 