### PR TITLE
Lib: Add PackedBundle

### DIFF
--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -29,13 +29,13 @@ class PackedBundle extends Bundle {
     elements.map(_._2).map(d => {
       val r = d.getTag(classOf[TagBitPackExact]) match {
         case t: Some[TagBitPackExact] =>
-          t.x.range
+          t.get.range
         case None =>
           (lastPos+d.getBitsWidth) downto (lastPos+1)
       }
       lastPos = r.high
       (r, d)
-    })
+    }).toSeq
   }
 
   override def asBits: Bits = {
@@ -44,7 +44,7 @@ class PackedBundle extends Bundle {
     val packed = B(0, maxWidth bit)
     for ((range, data) <- mappings) {
       val endianness: Endianness = data.getTag(classOf[TagBitPackExact]) match {
-        case t: Some[TagBitPackExact] => t.x.endianness
+        case t: Some[TagBitPackExact] => t.get.endianness
         case _ => LITTLE
       }
       endianness match {
@@ -63,7 +63,7 @@ class PackedBundle extends Bundle {
     val mappings = computePackMapping()
     for((elRange, el) <- mappings) {
       val endianness: Endianness = el.getTag(classOf[TagBitPackExact]) match {
-        case t: Some[TagBitPackExact] => t.x.endianness
+        case t: Some[TagBitPackExact] => t.get.endianness
         case _ => LITTLE
       }
       if (!(lo >= elRange.high || hi < elRange.low)) {

--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -6,14 +6,14 @@ import spinal.core._
   * Similar to Bundle but with bit packing capabilities.
   * Use pack implicit functions to assign fields to bit locations
   * - pack(Range, [Endianness]) - Packs the data into Range aligning to bit Endianness if too wide
-  * - packAt(Position) - Packs the data starting at Position. Uses full data length
-  * - packTo(Position) - Packs the data ending at Position. Uses full data length
+  * - packFrom(Position) - Packs the data starting (LSB) at Position. Uses full data length
+  * - packTo(Position) - Packs the data ending (MSB) at Position. Uses full data length
   *
   * Providing no location tag will place the next data value immediately after the last.
   *
   * @example {{{
   *     val regWord = new PackedBundle {
-  *       val init = Bool().packAt(0) // Bit 0
+  *       val init = Bool().packFrom(0) // Bit 0
   *       val stop = Bool() // Bit 1
   *       val result = Bits(16 bit).packTo(31) // Bits 16 to 31
   *     }
@@ -99,16 +99,16 @@ class PackedBundle extends Bundle {
     }
 
     /**
-      * Packs data starting at the bit position
+      * Packs data starting (LSB) at the bit position
       * @param pos Starting bit position of the data
       * @return Self
       */
-    def packAt(pos: Int): T = {
+    def packFrom(pos: Int): T = {
       t.pack(pos + t.getBitsWidth - 1 downto pos)
     }
 
     /**
-      * Packs data ending at the bit position
+      * Packs data ending (MSB) at the bit position
       * @param pos Ending bit position of the data
       * @return Self
       */

--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -31,7 +31,7 @@ class PackedBundle extends Bundle {
         case t: Some[TagBitPackExact] =>
           t.get.range
         case None =>
-          (lastPos+d.getBitsWidth) downto (lastPos+1)
+          (lastPos+d.getBitsWidth-1) downto (lastPos)
       }
       lastPos = r.high
       (r, d)

--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -49,9 +49,9 @@ class PackedBundle extends Bundle {
       }
       endianness match {
         case LITTLE =>
-          packed(range) := data.asBits.takeLow(range.size.min(data.getBitsWidth)).resizeLeft(range.size)
+          packed(range) := data.asBits.takeLow(range.size.min(data.getBitsWidth)).resize(range.size)
         case BIG =>
-          packed(range) := data.asBits.takeHigh(range.size.min(data.getBitsWidth)).resize(range.size)
+          packed(range) := data.asBits.takeHigh(range.size.min(data.getBitsWidth)).resizeLeft(range.size)
       }
     }
     packed
@@ -71,14 +71,10 @@ class PackedBundle extends Bundle {
         endianness match {
           case LITTLE =>
             val boundedBitsRange = hi.min(elRange.high-diff) downto lo.max(elRange.low)
-            el.assignFromBits(bits(boundedBitsRange),
-              boundedBitsRange.high - elRange.low,
-              boundedBitsRange.low - elRange.low)
+            el.assignFromBits(bits(boundedBitsRange).resize(el.getBitsWidth))
           case BIG =>
             val boundedBitsRange = hi.min(elRange.high) downto lo.max(elRange.low+diff)
-            el.assignFromBits(bits(boundedBitsRange),
-              boundedBitsRange.high - elRange.low-diff,
-              boundedBitsRange.low - elRange.low-diff)
+            el.assignFromBits(bits(boundedBitsRange).resizeLeft(el.getBitsWidth))
         }
       }
     }

--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -1,0 +1,119 @@
+package spinal.lib
+
+import spinal.core._
+
+/**
+  * Similar to Bundle but with bit packing capabilities.
+  * Use pack implicit functions to assign fields to bit locations
+  * - pack(Range, [Endianness]) - Packs the data into Range aligning to bit Endianness if too wide
+  * - packAt(Position) - Packs the data starting at Position. Uses full data length
+  * - packTo(Position) - Packs the data ending at Position. Uses full data length
+  *
+  * Providing no location tag will place the next data value immediately after the last.
+  *
+  * @example {{{
+  *     val regWord = new PackedBundle {
+  *       val init = Bool().packAt(0) // Bit 0
+  *       val stop = Bool() // Bit 1
+  *       val result = Bits(16 bit).packTo(31) // Bits 16 to 31
+  *     }
+  * }}}
+  *
+  */
+class PackedBundle extends Bundle {
+
+  class TagBitPackExact(val range: Range, val endianness: Endianness) extends SpinalTag
+
+  private def computePackMapping(): Seq[(Range, Data)] = {
+    var lastPos = 0
+    elements.map(_._2).map(d => {
+      val r = d.getTag(classOf[TagBitPackExact]) match {
+        case t: Some[TagBitPackExact] =>
+          t.x.range
+        case None =>
+          (lastPos+d.getBitsWidth) downto (lastPos+1)
+      }
+      lastPos = r.high
+      (r, d)
+    })
+  }
+
+  override def asBits: Bits = {
+    val mappings = computePackMapping()
+    val maxWidth = mappings.map(_._1.high).max + 1
+    val packed = B(0, maxWidth bit)
+    for ((range, data) <- mappings) {
+      val endianness: Endianness = data.getTag(classOf[TagBitPackExact]) match {
+        case t: Some[TagBitPackExact] => t.x.endianness
+        case _ => LITTLE
+      }
+      endianness match {
+        case LITTLE =>
+          packed(range) := data.asBits.takeLow(range.size.min(data.getBitsWidth))
+        case BIG =>
+          packed(range) := data.asBits.takeHigh(range.size.min(data.getBitsWidth))
+      }
+    }
+    packed
+  }
+
+  override def assignFromBits(bits: Bits): Unit = assignFromBits(bits, bits.getBitsWidth, 0)
+
+  override def assignFromBits(bits: Bits, hi: Int, lo: Int): Unit = {
+    val mappings = computePackMapping()
+    for((elRange, el) <- mappings) {
+      val endianness: Endianness = el.getTag(classOf[TagBitPackExact]) match {
+        case t: Some[TagBitPackExact] => t.x.endianness
+        case _ => LITTLE
+      }
+      if (!(lo >= elRange.high || hi < elRange.low)) {
+        val diff = (elRange.size - el.getBitsWidth).max(0)
+        endianness match {
+          case LITTLE =>
+            val boundedBitsRange = hi.min(elRange.high-diff) downto lo.max(elRange.low)
+            el.assignFromBits(bits(boundedBitsRange),
+              boundedBitsRange.high - elRange.low,
+              boundedBitsRange.low - elRange.low)
+          case BIG =>
+            val boundedBitsRange = hi.min(elRange.high) downto lo.max(elRange.low+diff)
+            el.assignFromBits(bits(boundedBitsRange),
+              boundedBitsRange.high - elRange.low-diff,
+              boundedBitsRange.low - elRange.low-diff)
+        }
+      }
+    }
+  }
+
+  override def getBitsWidth: Int = computePackMapping().map(_._1.high).max+1
+
+  implicit class DataPositionEnrich[T <: Data](t: T) {
+    /**
+      * Place the data at the given range. Extra bits will be lost (unassigned or read) if the data does not fit with the range.
+      * @param range Range to place the data
+      * @param endianness Bit direction to align data within the range
+      * @return Self
+      */
+    def pack(range: Range, endianness: Endianness = LITTLE): T = {
+      t.addTag(new TagBitPackExact(range, endianness))
+      t
+    }
+
+    /**
+      * Packs data starting at the bit position
+      * @param pos Starting bit position of the data
+      * @return Self
+      */
+    def packAt(pos: Int): T = {
+      t.pack(pos + t.getBitsWidth - 1 downto pos)
+    }
+
+    /**
+      * Packs data ending at the bit position
+      * @param pos Ending bit position of the data
+      * @return Self
+      */
+    def packTo(pos: Int): T = {
+      t.pack(pos downto pos - t.getBitsWidth + 1)
+    }
+  }
+}

--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -49,9 +49,9 @@ class PackedBundle extends Bundle {
       }
       endianness match {
         case LITTLE =>
-          packed(range) := data.asBits.takeLow(range.size.min(data.getBitsWidth))
+          packed(range) := data.asBits.takeLow(range.size.min(data.getBitsWidth)).resizeLeft(range.size)
         case BIG =>
-          packed(range) := data.asBits.takeHigh(range.size.min(data.getBitsWidth))
+          packed(range) := data.asBits.takeHigh(range.size.min(data.getBitsWidth)).resize(range.size)
       }
     }
     packed

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
@@ -12,10 +12,10 @@ class SpinalSimPackedBundleTester extends AnyFunSuite {
         val a = Bits(3 bit) // 0 to 2
         val b = Bits(3 bit).packFrom(4) // 4 to 6
         val c = Bits(3 bit).packTo(9) // 7 to 9
-        val d = Bits(3 bit).pack(10 to 14, LITTLE) // 00 00 12 13 14
-        val e = Bits(3 bit).pack(15 to 19, BIG) // 15 16 17 00 00
-        val f = Bits(6 bit).pack(20 to 24, LITTLE) // (19 drop) 20 21 22 23 24
-        val g = Bits(6 bit).pack(25 to 29, BIG) // 25 26 27 28 29 (30 drop)
+        val d = Bits(3 bit).pack(10 to 14, LITTLE) // 10 11 12 00 00
+        val e = Bits(3 bit).pack(15 to 19, BIG) // 00 00 17 18 19
+        val f = Bits(6 bit).pack(20 to 24, LITTLE) // 19 20 21 22 23 (24 drop)
+        val g = Bits(6 bit).pack(25 to 29, BIG) // (25 drop) 26 27 28 29 30
       }
       val io = new Bundle {
         val a = in(Bits(3 bit))
@@ -44,8 +44,8 @@ class SpinalSimPackedBundleTester extends AnyFunSuite {
         res += a
         res += b << 4
         res += c << 7
-        res += d << 12
-        res += e << 15
+        res += d << 10
+        res += e << 17
         res += (f & 0x1f) << 20
         res += (g >> 1) << 25
         res
@@ -67,6 +67,72 @@ class SpinalSimPackedBundleTester extends AnyFunSuite {
           dut.io.e.toBigInt,
           dut.io.f.toBigInt,
           dut.io.g.toBigInt)
+        assert(dut.io.packed.toBigInt == packedCalc, s"0x${dut.io.packed.toBigInt.toString(16)} =!= 0x${packedCalc.toString(16)}\n")
+      }
+    })
+  }
+
+  test("unpack") {
+    SimConfig.withWave.compile(new Component {
+      val packedBundle = new PackedBundle {
+        val a = Bits(3 bit) // 0 to 2
+        val b = Bits(3 bit).packFrom(4) // 4 to 6
+        val c = Bits(3 bit).packTo(9) // 7 to 9
+        val d = Bits(3 bit).pack(10 to 14, LITTLE) // 10 11 12 00 00
+        val e = Bits(3 bit).pack(15 to 19, BIG) // 00 00 17 18 19
+        val f = Bits(6 bit).pack(20 to 24, LITTLE) // 19 20 21 22 23 (24 drop)
+        val g = Bits(6 bit).pack(25 to 29, BIG) // (25 drop) 26 27 28 29 30
+      }
+      val io = new Bundle {
+        val a = out(Bits(3 bit))
+        val b = out(Bits(3 bit))
+        val c = out(Bits(3 bit))
+        val d = out(Bits(3 bit))
+        val e = out(Bits(3 bit))
+        val f = out(Bits(6 bit))
+        val g = out(Bits(6 bit))
+        val packed = in(packedBundle.asBits.clone)
+      }
+
+      packedBundle.assignFromBits(RegNext(io.packed))
+      io.a := packedBundle.a
+      io.b := packedBundle.b
+      io.c := packedBundle.c
+      io.d := packedBundle.d
+      io.e := packedBundle.e
+      io.f := packedBundle.f
+      io.g := packedBundle.g
+    }).doSim(dut => {
+      dut.clockDomain.forkStimulus(10)
+
+      def pack(a: BigInt, b: BigInt, c: BigInt, d: BigInt, e: BigInt, f: BigInt, g: BigInt): BigInt = {
+        var res = BigInt(0)
+        res += a
+        res += b << 4
+        res += c << 7
+        res += d << 10
+        res += e << 17
+        res += (f & 0x1f) << 20
+        res += (g >> 1) << 25
+        res
+      }
+
+      for (_ <- 0 to 100) {
+        dut.io.packed.randomize()
+        dut.clockDomain.waitFallingEdge()
+        var packedCalc = pack(dut.io.a.toBigInt,
+          dut.io.b.toBigInt,
+          dut.io.c.toBigInt,
+          dut.io.d.toBigInt,
+          dut.io.e.toBigInt,
+          dut.io.f.toBigInt,
+          dut.io.g.toBigInt)
+        // Add the ignored bits back in
+        packedCalc |= (dut.io.packed.toBigInt & 1 << 3)
+        packedCalc |= (dut.io.packed.toBigInt & 1 << 13)
+        packedCalc |= (dut.io.packed.toBigInt & 1 << 14)
+        packedCalc |= (dut.io.packed.toBigInt & 1 << 15)
+        packedCalc |= (dut.io.packed.toBigInt & 1 << 16)
         assert(dut.io.packed.toBigInt == packedCalc, s"0x${dut.io.packed.toBigInt.toString(16)} =!= 0x${packedCalc.toString(16)}\n")
       }
     })

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
@@ -7,7 +7,7 @@ import spinal.core.sim._
 
 class SpinalSimPackedBundleTester extends AnyFunSuite {
   test("pack") {
-    SimConfig.compile(new Component {
+    SimConfig.withWave.compile(new Component {
       val packedBundle = new PackedBundle {
         val a = Bits(3 bit) // 0 to 2
         val b = Bits(3 bit).packFrom(4) // 4 to 6
@@ -47,7 +47,7 @@ class SpinalSimPackedBundleTester extends AnyFunSuite {
         res += d << 12
         res += e << 15
         res += (f & 0x1f) << 20
-        res += (g & 0x2e) << 25
+        res += (g >> 1) << 25
         res
       }
 
@@ -59,7 +59,7 @@ class SpinalSimPackedBundleTester extends AnyFunSuite {
         dut.io.e.randomize()
         dut.io.f.randomize()
         dut.io.g.randomize()
-        dut.clockDomain.waitSampling()
+        dut.clockDomain.waitFallingEdge()
         val packedCalc = pack(dut.io.a.toBigInt,
           dut.io.b.toBigInt,
           dut.io.c.toBigInt,
@@ -67,7 +67,7 @@ class SpinalSimPackedBundleTester extends AnyFunSuite {
           dut.io.e.toBigInt,
           dut.io.f.toBigInt,
           dut.io.g.toBigInt)
-        assert(dut.io.packed.toBigInt == packedCalc)
+        assert(dut.io.packed.toBigInt == packedCalc, s"0x${dut.io.packed.toBigInt.toString(16)} =!= 0x${packedCalc.toString(16)}\n")
       }
     })
   }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
@@ -1,0 +1,74 @@
+package spinal.tester.scalatest
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import spinal.lib._
+import spinal.core.sim._
+
+class SpinalSimPackedBundleTester extends AnyFunSuite {
+  test("pack") {
+    SimConfig.compile(new Component {
+      val packedBundle = new PackedBundle {
+        val a = Bits(3 bit) // 0 to 2
+        val b = Bits(3 bit).packFrom(4) // 4 to 6
+        val c = Bits(3 bit).packTo(9) // 7 to 9
+        val d = Bits(3 bit).pack(10 to 14, LITTLE) // 00 00 12 13 14
+        val e = Bits(3 bit).pack(15 to 19, BIG) // 15 16 17 00 00
+        val f = Bits(6 bit).pack(20 to 24, LITTLE) // (19 drop) 20 21 22 23 24
+        val g = Bits(6 bit).pack(25 to 29, BIG) // 25 26 27 28 29 (30 drop)
+      }
+      val io = new Bundle {
+        val a = in(Bits(3 bit))
+        val b = in(Bits(3 bit))
+        val c = in(Bits(3 bit))
+        val d = in(Bits(3 bit))
+        val e = in(Bits(3 bit))
+        val f = in(Bits(6 bit))
+        val g = in(Bits(6 bit))
+        val packed = out(packedBundle.asBits.clone)
+      }
+
+      io.packed := RegNext(packedBundle.asBits)
+      packedBundle.a := io.a
+      packedBundle.b := io.b
+      packedBundle.c := io.c
+      packedBundle.d := io.d
+      packedBundle.e := io.e
+      packedBundle.f := io.f
+      packedBundle.g := io.g
+    }).doSim(dut => {
+      dut.clockDomain.forkStimulus(10)
+
+      def pack(a: BigInt, b: BigInt, c: BigInt, d: BigInt, e: BigInt, f: BigInt, g: BigInt): BigInt = {
+        var res = BigInt(0)
+        res += a
+        res += b << 4
+        res += c << 7
+        res += d << 12
+        res += e << 15
+        res += (f & 0x1f) << 20
+        res += (g & 0x2e) << 25
+        res
+      }
+
+      for(_ <- 0 to 100) {
+        dut.io.a.randomize()
+        dut.io.b.randomize()
+        dut.io.c.randomize()
+        dut.io.d.randomize()
+        dut.io.e.randomize()
+        dut.io.f.randomize()
+        dut.io.g.randomize()
+        dut.clockDomain.waitSampling()
+        val packedCalc = pack(dut.io.a.toBigInt,
+          dut.io.b.toBigInt,
+          dut.io.c.toBigInt,
+          dut.io.d.toBigInt,
+          dut.io.e.toBigInt,
+          dut.io.f.toBigInt,
+          dut.io.g.toBigInt)
+        assert(dut.io.packed.toBigInt == packedCalc)
+      }
+    })
+  }
+}


### PR DESCRIPTION
Simple standard bundle but with support for placing values at specified bit positions. Supports spare packing and endian alignment when data fields need to be truncated.

Long example:
```scala
object PackedExample {
  def main(args: Array[String]): Unit = {
    SpinalVhdl(new Component {
      val packedBundle = new PackedBundle {
        val f1 = UInt(4 bit).pack(15 downto 0, LITTLE)
        val f2 = UInt(8 bit)
        val f3 = UInt(1 bit).packTo(31)
        val f4 = UInt(8 bit).pack(34 downto 32, LITTLE)
        val f5 = UInt(8 bit).pack(38 downto 34, BIG)
        val f6 = UInt(4 bit).pack(48 downto 40, BIG)
      }

      packedBundle.f1.setAll()
      packedBundle.f1.allowOverride
      packedBundle.f4.setAll()
      packedBundle.f4.allowOverride
      packedBundle.f5.setAll()
      packedBundle.f5.allowOverride

      val unpackedBundle = new Bundle {
        val f1 = UInt(4 bit)
        val f2 = UInt(8 bit)
        val f3 = UInt(1 bit)
        val f4 = UInt(8 bit)
        val f5 = UInt(8 bit)
        val f6 = UInt(4 bit)
      }
      unpackedBundle.assignAllByName(packedBundle)

      val io = new Bundle {
        val i = in(packedBundle.asBits.clone())
        val o = out(unpackedBundle.asBits.clone())
      }

      packedBundle.assignFromBits(io.i)
      io.o := unpackedBundle.asBits
    })
  }
}
```