### PR TITLE
Add SystemRDL RegIf exporter

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/SystemRdlGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/SystemRdlGenerator.scala
@@ -128,7 +128,7 @@ final case class SystemRdlGenerator(
     val targetPath = s"${pc.config.targetDirectory}/${fileName}.rdl"
     val pw = new PrintWriter(targetPath)
 
-    sb ++= "};\n"
+    sb ++= "\n};\n"
     pw.write(sb.toString())
     pw.close()
   }

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/SystemRdlGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/SystemRdlGenerator.scala
@@ -1,0 +1,95 @@
+package spinal.lib.bus.regif
+
+import spinal.core.GlobalData
+import spinal.lib.bus.regif._
+import java.io.PrintWriter
+import java.util.Calendar
+
+final case class SystemRdlGenerator(
+    fileName: String,
+    addrmapName: String,
+    name: Option[String] = None,
+    desc: Option[String] = None
+) extends BusIfVisitor {
+  val sb: StringBuilder = new StringBuilder
+  var prefix = ""
+
+  def clean(str: String): String = {
+    str.replace("\n", "\\n").replace("\r", "\\r")
+  }
+
+  def begin(busDataWidth: Int): Unit = {
+    sb ++=
+      s"""|// SystemRDL 2.0 register description for ${addrmapName}
+          |// Generated from SpinalHDL RegIf definition. Don't edit.
+          |// Date: ${Calendar.getInstance().getTime()}
+          |
+          |addrmap ${addrmapName} {
+          |""".stripMargin
+    if (name.isDefined) {
+      sb ++= s"""    name = "${name}";\n"""
+    }
+    if (desc.isDefined) {
+      sb ++= s"""    desc = "${desc}";\n"""
+    }
+    if (name.isDefined || desc.isDefined) {
+      sb ++= "\n"
+    }
+    sb ++=
+      """|    default hw = rw;
+         |    default sw = rw;
+         |
+         |""".stripMargin
+  }
+
+  def visit(descr: BaseDescriptor): Unit = {
+    descr match {
+      case descr: RegDescr => regDescrVisit(descr)
+      case _               => ???
+    }
+  }
+
+  private def regDescrVisit(descr: RegDescr) = {
+    sb ++= prefix
+
+    sb ++=
+      s"""|    reg {
+          |        name = "${descr.getName()}";
+          |        desc = "${clean(descr.getDoc())}";
+          |
+          |""".stripMargin
+
+    var fieldPrefix = ""
+    descr
+      .getFieldDescrs()
+      .foreach(f => {
+        // Ignore reserved.
+        if (f.getName() != "--") {
+          sb ++= fieldPrefix
+          val section = s"${f.getSection().start}:${f.getSection().end}"
+          // TODO: Add AccessType mapping.
+          sb ++=
+            f"""|        field {
+                |            name = "${f.getName()}%s";
+                |            desc = "${clean(f.getDoc())}%s";
+                |            reset = 0x${f.getResetValue()}%X;
+                |        } ${f.getName()}%s[${section}%s];""".stripMargin
+          fieldPrefix = "\n\n"
+        }
+      })
+    sb ++= "\n"
+    sb ++= f"""    } ${descr.getName()} @ 0x${descr.getAddr()}%X;"""
+
+    prefix = "\n\n"
+  }
+
+  def end(): Unit = {
+    val pc = GlobalData.get.phaseContext
+    val targetPath = s"${pc.config.targetDirectory}/${fileName}.rdl"
+    val pw = new PrintWriter(targetPath)
+
+    sb ++= "};\n"
+    pw.write(sb.toString())
+    pw.close()
+  }
+}

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/SystemRdlGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/SystemRdlGenerator.scala
@@ -4,6 +4,7 @@ import spinal.core.GlobalData
 import spinal.lib.bus.regif._
 import java.io.PrintWriter
 import java.util.Calendar
+import spinal.lib.bus.regif.AccessType._
 
 final case class SystemRdlGenerator(
     fileName: String,
@@ -49,6 +50,45 @@ final case class SystemRdlGenerator(
     }
   }
 
+  private def mapAccessType(accessType: AccessType): String = {
+    val indent = "            "
+    val out = accessType match {
+      case RO    => "sw = r;"
+      case RW    => "sw = rw;"
+      case RC    => "sw = r;\nonread = rclr;"
+      case RS    => "sw = r;\nonread = rset;"
+      case WRC   => "sw = rw;\nonread = rclr;"
+      case WRS   => "sw = rw;\nonread = rset;"
+      case WC    => "sw = rw;\nonwrite = wclr;"
+      case WS    => "sw = rw;\nonwrite = wset;"
+      case WSRC  => "sw = rw;\nonwrite = wset;\nonread = rclr;"
+      case WCRS  => "sw = rw;\nonwrite = wclr;\nonread = rset;"
+      case W1C   => "sw = rw;\nonwrite = woclr;"
+      case W1S   => "sw = rw;\nonwrite = woset;"
+      case W1T   => "sw = rw;\nonwrite = wot;"
+      case W0C   => "sw = rw;\nonwrite = wzc;"
+      case W0S   => "sw = rw;\nonwrite = wzs;"
+      case W0T   => "sw = rw;\nonwrite = wzt;"
+      case W1SRC => "sw = rw;\nonwrite = woset;\nonread = rclr;"
+      case W1CRS => "sw = rw;\nonwrite = woclr;\nonread = rset;"
+      case W0SRC => "sw = rw;\nonwrite = wzs;\nonread = rclr;"
+      case W0CRS => "sw = rw;\nonwrite = wzc;\nonread = rset;"
+      case WO    => "sw = w;"
+      case WOC   => "sw = w;\nonwrite = wclr;"
+      case WOS   => "sw = w;\nonwrite = wset;"
+      case W1 =>
+        "sw = rw;\nonwrite = wuser;  // First one after HARD reset is as-is, other W have no effect."
+      case WO1 =>
+        "sw = w;\nonwrite = wuser;  // First one after HARD reset is as-is, other W have no effect."
+      case NA  => "sw = na;"
+      case W1P => "sw = rw;\nsinglepulse;  // On 1 pulse on matching bit."
+      case W0P =>
+        "sw = rw;\nonwrite = wuser;  // On 0 write pulse on matching bit."
+      case _ => "// Unknown access type. Report an issue on SpinalHDL's GitHub."
+    }
+    out.replaceAll("\n", "\n" + indent)
+  }
+
   private def regDescrVisit(descr: RegDescr) = {
     sb ++= prefix
 
@@ -67,12 +107,12 @@ final case class SystemRdlGenerator(
         if (f.getName() != "--") {
           sb ++= fieldPrefix
           val section = s"${f.getSection().start}:${f.getSection().end}"
-          // TODO: Add AccessType mapping.
           sb ++=
             f"""|        field {
                 |            name = "${f.getName()}%s";
                 |            desc = "${clean(f.getDoc())}%s";
                 |            reset = 0x${f.getResetValue()}%X;
+                |            ${mapAccessType(f.getAccessType())}
                 |        } ${f.getName()}%s[${section}%s];""".stripMargin
           fieldPrefix = "\n\n"
         }

--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/SystemRdlGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/SystemRdlGenerator.scala
@@ -28,10 +28,10 @@ final case class SystemRdlGenerator(
           |addrmap ${addrmapName} {
           |""".stripMargin
     if (name.isDefined) {
-      sb ++= s"""    name = "${name}";\n"""
+      sb ++= s"""    name = "${name.get}";\n"""
     }
     if (desc.isDefined) {
-      sb ++= s"""    desc = "${desc}";\n"""
+      sb ++= s"""    desc = "${desc.get}";\n"""
     }
     if (name.isDefined || desc.isDefined) {
       sb ++= "\n"

--- a/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
+++ b/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
@@ -85,7 +85,7 @@ class RegIfExample2 extends Component {
   val fd3 = M_REG0.fieldAt(pos=16, 4 bits, RW, doc= "fields 3")
 //  val fd3 = M_REG0.field(4 bits, RW, doc= "fields 3")
   //auto reserved 12 bits
-  busif.accept(HtmlGenerator("regif.html", "Example"))
+  busif.accept(HtmlGenerator("regif", "Example"))
 }
 
 class InterruptRegIf extends Component {
@@ -218,8 +218,8 @@ object getRegIfExample {
     targetDirectory="tmp/")
       .generate(new RegIfExample)
 
-    example.toplevel.busif.accept(CHeaderGenerator("header.h", "AP"))
-    example.toplevel.busif.accept(HtmlGenerator("regif.html", "AP"))
-    example.toplevel.busif.accept(JsonGenerator("regif.json"))
+    example.toplevel.busif.accept(CHeaderGenerator("header", "AP"))
+    example.toplevel.busif.accept(HtmlGenerator("regif", "AP"))
+    example.toplevel.busif.accept(JsonGenerator("regif"))
   }
 }

--- a/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
+++ b/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
@@ -221,6 +221,7 @@ object getRegIfExample {
     example.toplevel.busif.accept(CHeaderGenerator("header", "AP"))
     example.toplevel.busif.accept(HtmlGenerator("regif", "AP"))
     example.toplevel.busif.accept(JsonGenerator("regif"))
+    example.toplevel.busif.accept(RalfGenerator("regif"))
     example.toplevel.busif.accept(SystemRdlGenerator("regif", "AP", Some("addrmap name"), Some("addrmap desc")))
   }
 }

--- a/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
+++ b/tester/src/main/scala/spinal/tester/code/RegIfExample.scala
@@ -221,5 +221,6 @@ object getRegIfExample {
     example.toplevel.busif.accept(CHeaderGenerator("header", "AP"))
     example.toplevel.busif.accept(HtmlGenerator("regif", "AP"))
     example.toplevel.busif.accept(JsonGenerator("regif"))
+    example.toplevel.busif.accept(SystemRdlGenerator("regif", "AP", Some("addrmap name"), Some("addrmap desc")))
   }
 }


### PR DESCRIPTION
SystemRDL can be used for project documentation or code generation. Generating SystemRDL from RegIf is especially useful in projects incorporating SpinalHDL IP cores when other IPs have the register interface documentation available in SystemRDL.

Relates to SpinalHDL/SpinalDoc-RTD#125.

Example export snippet:

```scala
val regs = BusInterface(...)

val pwm_enable = regs
  .newRegAt(RegMap.PWM_ENABLE, "Enable PWM channels.")
  .field(Bool, RW, 0)

val pwm_a_duty = regs
  .newRegAt(RegMap.PWM_A_DUTY, "PWM channel A duty cycle.")
  .field(UInt(config.pwm.dutyCycleWidth), RW, 0x10)

val pwm_b_duty = regs
  .newRegAt(RegMap.PWM_B_DUTY, "PWM channel B duty cycle.")
  .field(UInt(config.pwm.dutyCycleWidth), RW, 0x20)

val sw_rst = regs
  .newRegAt(
    RegMap.SW_RST,
    "Software reset."
  )
  .field(Bool, W1P, 0)

regs.accept(SystemRdlGenerator("regs", "my_ip", Some("My IP"), Some("Example IP register map.")))
```

```systemrdl
// SystemRDL 2.0 register description for crosslink
// Generated from SpinalHDL RegIf definition. Don't edit.
// Date: Thu Oct 13 17:10:03 CEST 2022

addrmap my_ip {
    name = "My IP";
    desc = "Example IP register map.";

    default hw = rw;
    default sw = rw;

    reg {
        name = "pwm_enable";
        desc = "Enable PWM channels.";

        field {
            name = "pwm_enable";
            desc = "";
            reset = 0x0;
            sw = rw;
        } pwm_enable[0:0];
    } pwm_enable @ 0x54;

    reg {
        name = "pwm_a_duty";
        desc = "PWM channel A duty cycle.";

        field {
            name = "pwm_a_duty";
            desc = "";
            reset = 0x10;
            sw = rw;
        } pwm_a_duty[7:0];
    } pwm_a_duty @ 0x55;

    reg {
        name = "pwm_b_duty";
        desc = "PWM channel B duty cycle.";

        field {
            name = "pwm_b_duty";
            desc = "";
            reset = 0x20;
            sw = rw;
        } pwm_b_duty[7:0];
    } pwm_b_duty @ 0x57;

    reg {
        name = "sw_rst";
        desc = "Software reset.";

        field {
            name = "sw_rst";
            desc = "";
            reset = 0x0;
            sw = rw;
            singlepulse;  // On 1 pulse on matching bit.
        } sw_rst[0:0];
    } sw_rst @ 0xF9;
};
```