### PR TITLE
ci: update vendor actions

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -4,13 +4,13 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'adopt'
 
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-v2
@@ -18,7 +18,7 @@ runs:
           ${{ runner.os }}-pip-
 
     - name: Cache SBT
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.ivy2/cache
@@ -37,7 +37,7 @@ runs:
 
     - name: Cache tools
       id: tools
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/tools
@@ -52,7 +52,7 @@ runs:
 
     - name: Cache fpga_toolchain
       id: fpga_toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/fpga-toolchain

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 90
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - uses: ./.github/actions
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 90
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - uses: ./.github/actions


### PR DESCRIPTION
It removes warnings in GitHub actions: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/