### PR TITLE
feat: add port keyword

### DIFF
--- a/core/src/main/scala/spinal/core/IODirection.scala
+++ b/core/src/main/scala/spinal/core/IODirection.scala
@@ -1,0 +1,47 @@
+package spinal.core
+
+/**
+  * Trait used to set the direction of a data
+  */
+trait IODirection extends BaseTypeFactory {
+
+  def applyIt[T <: Data](data: T): T
+  def apply[T <: Data](data: T): T = applyIt(data)
+  def apply[T <: Data](data: HardType[T]): T = applyIt(data())
+  def apply[T <: Data](datas: T*): Unit = datas.foreach(applyIt(_))
+  def apply(senum: SpinalEnum) = applyIt(senum.craft())
+  def cloneOf[T <: Data](that: T): T = applyIt(spinal.core.cloneOf(that))
+
+  def Bool(u: Unit = ()): Bool = applyIt(spinal.core.Bool())
+  override def Bits(u: Unit = ()) = applyIt(super.Bits())
+  override def UInt(u: Unit = ()) = applyIt(super.UInt())
+  override def SInt(u: Unit = ()) = applyIt(super.SInt())
+  override def Vec[T <: Data](elements: TraversableOnce[T], dataType : HardType[T] = null): Vec[T] = applyIt(super.Vec(elements, dataType))
+
+  override def postTypeFactory[T <: Data](that: T): T = applyIt(that)
+}
+
+/** Set a data to input */
+object in extends IODirection {
+  override def applyIt[T <: Data](data: T): T = data.asInput()
+}
+
+/** Set a data to output */
+object out extends IODirection {
+  override def applyIt[T <: Data](data: T): T = data.asOutput()
+}
+
+/** Set a data to inout */
+object inout extends IODirection {
+  override def applyIt[T <: Data](data: T): T = data.asInOut()
+}
+
+/** Set a data to in if the data is not null */
+object inWithNull extends IODirection {
+  override def applyIt[T <: Data](data: T): T = if(data != null) data.asInput() else data
+}
+
+/** Set a data to out if the data is not null */
+object outWithNull extends IODirection {
+  override def applyIt[T <: Data](data: T): T = if(data != null) data.asOutput() else data
+}

--- a/core/src/main/scala/spinal/core/IODirection.scala
+++ b/core/src/main/scala/spinal/core/IODirection.scala
@@ -1,47 +1,139 @@
 package spinal.core
 
-/**
-  * Trait used to set the direction of a data
+/** Declare ports
+  *
+  * A port is some Data with a direction, which can be `in`, `out` or `inout`.
+  *
+  * There are 4 available syntaxes, which are all equivalent:
+  *
+  * {{{
+  * val braces = in(Vec(Bool, 5))
+  *
+  * val short = in Vec (Bool, 5)
+  *
+  * val spaceful = in port Vec(Bool, 5)
+  *
+  * val variadic = Vec(Bool, 5)
+  * in(variadic)
+  * }}}
+  *
+  * The "braces" syntax is short and generic, but it uses braces.
+  *
+  * The "short" syntax is short, but it is formatted with a space between the
+  * type and its parameters, and it can be used only with:
+  *
+  *   - `Bool`
+  *   - `Bits`
+  *   - `UInt`
+  *   - `SInt`
+  *   - `Vec`
+  *
+  * The "spaceful" syntax is generic and beatiful, but more verbose.
+  *
+  * The "variadic" syntax can be used with any number of ports, but can be used
+  * only if the ports types are already declared.
+  *
+  * @see [[in]] [[out]] [[inout]]
   */
-trait IODirection extends BaseTypeFactory {
+sealed trait IODirection extends BaseTypeFactory {
 
+  // This function should be protected, not public
+  // Override it to define how to apply port specification on a non-null Data
+  @deprecated("Use apply or port instead: `val b = in Bool ()` or `val rgb = out port Rgb`")
   def applyIt[T <: Data](data: T): T
-  def apply[T <: Data](data: T): T = applyIt(data)
-  def apply[T <: Data](data: HardType[T]): T = applyIt(data())
-  def apply[T <: Data](datas: T*): Unit = datas.foreach(applyIt(_))
-  def apply(senum: SpinalEnum) = applyIt(senum.craft())
-  def cloneOf[T <: Data](that: T): T = applyIt(spinal.core.cloneOf(that))
 
-  def Bool(u: Unit = ()): Bool = applyIt(spinal.core.Bool())
-  override def Bits(u: Unit = ()) = applyIt(super.Bits())
-  override def UInt(u: Unit = ()) = applyIt(super.UInt())
-  override def SInt(u: Unit = ()) = applyIt(super.SInt())
-  override def Vec[T <: Data](elements: TraversableOnce[T], dataType : HardType[T] = null): Vec[T] = applyIt(super.Vec(elements, dataType))
+  /** Declare a port without braces, spaceful syntax
+    *
+    * See [[IODirection]] for other syntax.
+    */
+  def port[T <: Data](data: T): T =
+    if (data != null) applyIt(data)
+    else data
 
-  override def postTypeFactory[T <: Data](that: T): T = applyIt(that)
+  /** Declare a port without braces, spaceful syntax
+    *
+    * See [[IODirection]] for other syntax.
+    */
+  def port[T <: Data](data: HardType[T]): T = port(data())
+
+  /** Declare a [[SpinalEnum]] port without braces, spaceful syntax
+    *
+    * See [[IODirection]] for other syntax.
+    */
+  def port(senum: SpinalEnum): SpinalEnumCraft[senum.type] = port(senum.craft())
+
+  /** Declare a port with braces
+    *
+    * See [[IODirection]] for other syntaxes.
+    */
+  def apply[T <: Data](data: T): T = port(data)
+
+  /** Declare a port with braces
+    *
+    * See [[IODirection]] for other syntaxes.
+    */
+  def apply[T <: Data](data: HardType[T]): T = port(data())
+
+  /** Declare a [[SpinalEnum]] port with braces
+    *
+    * See [[IODirection]] for other syntaxes.
+    */
+  def apply(senum: SpinalEnum): SpinalEnumCraft[senum.type] = port(senum.craft())
+
+  /** Declare existing Data as ports, "variadic" syntax */
+  def apply[T <: Data](datas: T*): Unit = datas.foreach(port(_))
+
+  /** Declare port with same type as that */
+  def cloneOf[T <: Data](that: T): T = port(spinal.core.cloneOf(that))
+
+  /** Declare a port without braces, short syntax
+    *
+    * See [[IODirection]] for other syntaxes.
+    */
+  def Bool(u: Unit = ()): Bool = port(spinal.core.Bool())
+
+  override def Bits(u: Unit = ()): Bits = port(super.Bits())
+
+  override def UInt(u: Unit = ()): UInt = port(super.UInt())
+
+  override def SInt(u: Unit = ()): SInt = port(super.SInt())
+
+  override def Vec[T <: Data](elements: TraversableOnce[T], dataType: HardType[T] = null): Vec[T] =
+    port(super.Vec(elements, dataType))
+
+  override def postTypeFactory[T <: Data](that: T): T = port(that)
 }
 
-/** Set a data to input */
+/** Declare an input port
+  *
+  * See [[IODirection]] for syntax help.
+  */
 object in extends IODirection {
   override def applyIt[T <: Data](data: T): T = data.asInput()
 }
 
-/** Set a data to output */
+/** Declare an output port
+  *
+  * See [[IODirection]] for syntax help.
+  */
 object out extends IODirection {
   override def applyIt[T <: Data](data: T): T = data.asOutput()
 }
 
-/** Set a data to inout */
+/** Declare an inout port
+  *
+  * See [[IODirection]] for syntax help.
+  */
 object inout extends IODirection {
   override def applyIt[T <: Data](data: T): T = data.asInOut()
 }
 
-/** Set a data to in if the data is not null */
+@deprecated("Use apply or port instead: 'val b = in(maybeNull)' or 'val rgb = in port maybeNull'")
 object inWithNull extends IODirection {
-  override def applyIt[T <: Data](data: T): T = if(data != null) data.asInput() else data
+  override def applyIt[T <: Data](data: T): T = if (data != null) data.asInput() else data
 }
 
-/** Set a data to out if the data is not null */
+@deprecated("Use apply or port instead: 'val b = out(maybeNull)' or 'val rgb = out port maybeNull'")
 object outWithNull extends IODirection {
-  override def applyIt[T <: Data](data: T): T = if(data != null) data.asOutput() else data
+  override def applyIt[T <: Data](data: T): T = if (data != null) data.asOutput() else data
 }

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -30,51 +30,6 @@ import spinal.core.internals._
 
 trait DummyTrait
 object DummyObject extends DummyTrait
-/**
-  * Trait used to set the direction of a data
-  */
-trait IODirection extends BaseTypeFactory {
-
-  def applyIt[T <: Data](data: T): T
-  def apply[T <: Data](data: T): T = applyIt(data)
-  def apply[T <: Data](data: HardType[T]): T = applyIt(data())
-  def apply[T <: Data](datas: T*): Unit = datas.foreach(applyIt(_))
-  def apply(senum: SpinalEnum) = applyIt(senum.craft())
-  def cloneOf[T <: Data](that: T): T = applyIt(spinal.core.cloneOf(that))
-
-  def Bool(u: Unit = ()): Bool = applyIt(spinal.core.Bool())
-  override def Bits(u: Unit = ()) = applyIt(super.Bits())
-  override def UInt(u: Unit = ()) = applyIt(super.UInt())
-  override def SInt(u: Unit = ()) = applyIt(super.SInt())
-  override def Vec[T <: Data](elements: TraversableOnce[T], dataType : HardType[T] = null): Vec[T] = applyIt(super.Vec(elements, dataType))
-
-  override def postTypeFactory[T <: Data](that: T): T = applyIt(that)
-}
-
-/** Set a data to input */
-object in extends IODirection {
-  override def applyIt[T <: Data](data: T): T = data.asInput()
-}
-
-/** Set a data to output */
-object out extends IODirection {
-  override def applyIt[T <: Data](data: T): T = data.asOutput()
-}
-
-/** Set a data to inout */
-object inout extends IODirection {
-  override def applyIt[T <: Data](data: T): T = data.asInOut()
-}
-
-/** Set a data to in if the data is not null */
-object inWithNull extends IODirection {
-  override def applyIt[T <: Data](data: T): T = if(data != null) data.asInput() else data
-}
-
-/** Set a data to out if the data is not null */
-object outWithNull extends IODirection {
-  override def applyIt[T <: Data](data: T): T = if(data != null) data.asOutput() else data
-}
 
 
 trait AssertNodeSeverity

--- a/lib/src/main/scala/spinal/lib/MasterSlave.scala
+++ b/lib/src/main/scala/spinal/lib/MasterSlave.scala
@@ -91,7 +91,6 @@ trait MSFactory {
   *
   *   - `Flow`
   *   - `Stream`
-  *   - `Event`
   *
   * The "spaceful" syntax is generic and beatiful, but more verbose.
   *
@@ -143,16 +142,6 @@ sealed trait MS {
       port(interface)
     }
   }
-
-  object event extends EventFactory {
-    override def postApply(interface: IMasterSlave): Unit = {
-      super.postApply(interface)
-      port(interface)
-    }
-  }
-
-  // TODO: why not just renaming event above as Event?
-  def Event: Event = port(spinal.lib.Event)
 }
 
 /** Declare a master port

--- a/lib/src/main/scala/spinal/lib/MasterSlave.scala
+++ b/lib/src/main/scala/spinal/lib/MasterSlave.scala
@@ -27,14 +27,14 @@ trait IMasterSlave extends Data {
 
   /** Set as master interface */
   final def setAsMaster(): Unit = {
-    _isMasterInterface = Some(true)
     asMaster()
+    _isMasterInterface = Some(true)
   }
 
   /** Set a slave interface */
   final def setAsSlave(): Unit = {
-    _isMasterInterface = Some(false)
     asSlave()
+    _isMasterInterface = Some(false)
   }
 
   /** Override it to define port directions for a master interface.

--- a/lib/src/main/scala/spinal/lib/MasterSlave.scala
+++ b/lib/src/main/scala/spinal/lib/MasterSlave.scala
@@ -3,7 +3,7 @@ package spinal.lib
 import spinal.core.{Data, HardType}
 
 /** Master/slave interface */
-trait IMasterSlave extends Data {
+trait IMasterSlave {
 
   /** Are port directions set for a Master interface? */
   final def isMasterInterface: Boolean = _isMasterInterface == Some(true)
@@ -116,7 +116,7 @@ sealed trait MS {
     *
     * See [[MS]] for other syntax.
     */
-  def port[T <: IMasterSlave](i: HardType[T]): T = port(i())
+  def port[T <: Data with IMasterSlave](i: HardType[T]): T = port(i())
 
   /** Declare a port with braces
     *
@@ -124,7 +124,7 @@ sealed trait MS {
     */
   def apply[T <: IMasterSlave](i: T): T = port(i)
 
-  def apply[T <: IMasterSlave](data: HardType[T]): T = apply(data())
+  def apply[T <: Data with IMasterSlave](data: HardType[T]): T = apply(data())
 
   /** Declare existing interfaces as ports, variadic syntax */
   def apply(is: IMasterSlave*): Unit = is.foreach(port(_))

--- a/tester/src/main/scala/spinal/tester/code/Presentation.scala
+++ b/tester/src/main/scala/spinal/tester/code/Presentation.scala
@@ -336,45 +336,6 @@ object C10_2 {
     val userTrigger = io.cfgPort pulseOn (0x02)
     val configs = io.cfgPort filterHeader (0x0F) toRegOf (LogicAnalyserConfig())
   }
-
-
-  case class Color(channelWidth: Int) extends Bundle {
-    val r = UInt(channelWidth bit)
-    val g = UInt(channelWidth bit)
-    val b = UInt(channelWidth bit)
-  }
-
-  class ColorDMA extends Component {
-    val io = new Bundle {
-      val run = slave Event
-
-      val memoryReadAddress = master Stream (Bits(32 bit))
-      val memoryReadData = slave Stream (Bits(32 bit))
-
-      val colorStream = master Stream (Color(8))
-    }
-
-    io.run.ready := False
-    val addressCounter = RegInit(U"x0000")
-    when(io.memoryReadAddress.fire) {
-      addressCounter := addressCounter + 1
-      when(addressCounter === U"xFFFF") {
-        addressCounter := 0
-        io.run.ready := True
-      }
-    }
-
-    io.memoryReadAddress.valid := io.run.valid
-    io.memoryReadAddress.payload := B(addressCounter)
-
-    io.colorStream.translateFrom(io.memoryReadData)(_.assignFromBits(_))
-  }
-
-  def main(args: Array[String]) {
-    println("START")
-    SpinalVhdl(new ColorDMA)
-    println("DONE")
-  }
 }
 
 object C10_removed {


### PR DESCRIPTION
Status: I think code is good, please approve it so that I rework git history and merge.

### Context

I have identified 3 syntaxes to define ports. A port can be `in`, `out`, `inout`, `master` or `slave`. Let `$dir` be one of these 5 keywords.

The 3 syntaxes are:

* `$dir($ports)` for already-defined wires (useful for `IMasterSlave`)
* `val $a = $dir $Type ($type_params)` for `Type` in a restricted set of types. It uses the Scala infix operator notation so it is formatted with a space between `Type` and `(`.
* `val $a = $dir($Type($type_params))` (useful for other types but braces are annoying for a DSL)

### This PR adds the following syntax, using Scala infix operator (no braces) and compatible with all possible types

`val $a = $dir port $Type($type_params)`

For instance:

```scala
val a = in port Rgb
val b = out port Rgb(8 bits)
val c = master port AhbLite3(cfg)
```

It is still possible to use the previous syntaxes:

```scala
val d = in Bits (8 bits)
val e = out(Bits(8 bits))
```

It is syntaxically of the equivalent of `ClockDomain.on` for ports:

`val a = cd(comp)` => `val a = cd on comp`
`val a = in(type)` => `val a = in port type`

### This PR brings documentation for `IODirection` & `IMasterSlave` + seals these two traits

I guess these two traits were not meant to be overloaded so it it almost non-breaking? @Readon :grin:

### This PR brings native management of `null`

Do not use `inWithNull`, just use `in` :smiley: