### PR TITLE
ci: add scalafmtCheck step

### DIFF
--- a/.github/checkfmt.bash
+++ b/.github/checkfmt.bash
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+print() {
+  local line=$1
+  local text=$2
+
+  echo "$file:$line: `basename $file` $message"
+  echo "$text"
+}
+
+blank='^[[:space:]]*$'
+
+sbt -no-colors clean scalafmtCheck | while IFS= read ll
+do
+
+  # Keep all lines in logs
+  echo "$ll"
+
+  # Skip lines which are not [warn]
+  if ! [[ "$ll" =~ ^\[warn\] ]]; then
+    continue
+  fi
+  # Remove this warn to ease process
+  l=$(sed 's/^\[warn\] //' <<< "$ll")
+
+  # Match start of mis-formatted file
+  if [[ "$l" =~ ^scalafmt:\ $PWD/([^[:space:]]+)\ (isn\'t\ formatted\ properly\!)$ ]]
+  then
+    file="${BASH_REMATCH[1]}"
+    message="${BASH_REMATCH[2]}"
+  fi
+
+  # Debug
+  #echo "debug $linea:$lineb:$l"
+  #echo "blank $blanklines"
+  #echo "removed $removedlines"
+
+  # Match start of code chunk
+  if [[ "$l" =~ ^@@\ -([[:digit:]]+),[[:digit:]]+\ \+[[:digit:]]+,[[:digit:]]+\ @@$ ]]
+  then
+    # current line in actual file
+    linea="${BASH_REMATCH[1]}"
+    # line of actual file matching line of virtual formatted file
+    lineb="$linea"
+    # count of empty lines for resync between paragraphs
+    blanklines=0
+    # count of removed lines to add more removed lines after block
+    removedlines=0
+  fi
+
+  # Match diff line which is addition, kept or deleted ('+', ' ' or '-')
+  if [[ "$l" =~ ^([[:space:]+-])(.*)$ ]]; then
+    linetype="${BASH_REMATCH[1]}"
+    linecode="${BASH_REMATCH[2]}"
+
+    # Skip if diff introducing filename
+    if [[ "$l" =~ ^\+\+\+\ b/ ]] || [[ "$l" =~ ^---\ a/ ]]; then
+      continue
+    fi
+
+    # Manage blank lines
+    if [[ "$linetype" == - ]]; then
+      [[ "$linecode" =~ $blank ]] && blanklines=$((blanklines + 1))
+    else # End of removed line, flush
+      # The current line will be printed in print phase
+      if [[ "$linetype" == + ]] && [[ "$linecode" =~ $blank ]]; then
+        blanklines=$((blanklines - 1))
+      fi
+      # Resync lines
+      while (($blanklines > 0)); do
+        print "$lineb" "-"
+        blanklines=$((blanklines - 1))
+        lineb=$((lineb + 1))
+      done
+    fi
+
+    # Count removed lines (blank lines are managed by blanklines)
+    if ! [[ "$linecode" =~ $blank ]]; then
+      if [[ "$linetype" == - ]]; then
+        removedlines=$((removedlines + 1))
+      elif [[ "$linetype" == + ]]; then
+        removedlines=$((removedlines - 1))
+      fi
+    fi
+
+    # If it is a new line from new version, print it
+    [[ "$linetype" == + ]] && print "$lineb" "$l"
+
+    # If it is an kept line, check if there was no remaining deletions
+    if [[ "$linetype" == " " ]]; then
+      if (($removedlines > 0)); then
+        print "$lineb" "-"
+        removedlines=$((removedlines - 1))
+      fi
+    fi
+
+    # Update line numbers
+    if [[ "$linetype" == + ]]; then
+      # Lines are appended in + to line above OR in modified block
+      # so lineb cannot join linea this way
+      if (( $lineb + 1 < $linea )); then
+        lineb=$((lineb + 1))
+      fi
+    elif [[ "$linetype" == - ]]; then
+      # Increment end of modified block
+      linea=$((linea + 1))
+    else # linetype is ' '
+      # resync
+      linea=$((linea + 1))
+      lineb=$linea
+    fi
+  fi
+done

--- a/.github/matcher.json
+++ b/.github/matcher.json
@@ -1,0 +1,19 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "sbt-scalacheck-with-diff",
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^([^:]+):(\\d+):\\s+(.*([+ ].*)*)$",
+          "file": 1,
+          "line": 2
+        },
+        {
+          "regexp": "^(.*)$",
+          "message": 1
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,6 +1,12 @@
 name: Scala CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
 
 jobs:
   test:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -47,3 +47,21 @@ jobs:
 
     - name: Build scaladoc
       run: sbt unidoc
+
+  fmt-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - uses: ./.github/actions
+    - name: Fetch dev to be able to check only modified files
+      run: |
+        git fetch --depth=1 origin dev
+        git branch dev origin/dev
+    - name: Setup annotations
+      run: echo "::add-matcher::.github/matcher.json"
+    - name: Check formatting and pass
+      run: bash .github/checkfmt.bash

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.2.1
+version = 3.6.0
 runner.dialect = scala212
 align.preset = some
 maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,9 @@ val defaultSettings = Defaults.coreDefaultSettings ++ xerial.sbt.Sonatype.sonaty
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   fork := true,
 
+  scalafmtFilter.withRank(KeyRanks.Invisible) := "diff-ref=dev",
+  scalafmtPrintDiff := true,
+
   //Enable parallel tests
   Test / testForkedParallel := true,
   Test / testGrouping := (Test / testGrouping).value.flatMap { group =>

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")


### PR DESCRIPTION
Fixes #535 

### This PR avoids double workflow

Double workflow makes annotations appear twice if PR and source branch are on the same repository, and consume twice more energy.

### This PR updates `sbt-scalafmt` plugin and configures it

Only modified files (compared to `dev` branch) are checked

### This PR adds a bash script to run scalafmt and interpret the diff to create parsable "problems"

### This PR adds a "problem" regular expression so that GitHub can parse the problems to turn them into PR annotations

### This PR adds a step to Scala CI workflow to check formatting against `dev` and put annotations on files

Example of annotated PR: https://github.com/numero-744/SpinalHDL/pull/6/files#diff-9c3e1dfcdddbdc33403d5e3c6ac4b6728f8f86ba6f7448c81d47906c8f7895f6

Notice [at the end of the diff](https://github.com/numero-744/SpinalHDL/pull/6/files#diff-9c3e1dfcdddbdc33403d5e3c6ac4b6728f8f86ba6f7448c81d47906c8f7895f6R62-R66), there are 3 blank lines, which GitHub detects correctly as a problem with severity "warning" (see the Checks log), but decides to not put the annotation on the file, I don't know why.

About authorship: I could not make work the stuff I found on other projects so I decided to do my own things, so I'm responsible for any bug which can occur XD