### PR TITLE
ci: use scala 2.12 with unidoc

### DIFF
--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -20,11 +20,11 @@ jobs:
     - uses: ./.github/actions
 
     - name: Build scaladoc
-      run: sbt clean compile unidoc
+      run: sbt clean '++ 2.12.13' unidoc
 
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@v4
       with:
-        folder: target/scala-2.11/unidoc
+        folder: target/scala-2.12/unidoc
         target-folder: ${{ github.ref_name }}
         single-commit: true


### PR DESCRIPTION
# Context, Motivation & Description

We are pushing generated code documentation to [spinalhdl.github.io/SpinalHDL/dev](https://spinalhdl.github.io/SpinalHDL/dev/index.html#spinal.core.package) but it is not pretty so we do not want to use it as it is not user-friendly.

It is because Scala 2.11 (which we want to keep in use for now) has a poor template. Scala 2.12 has a better one.

This PR uses Scala 2.12 only to build documentation and push it. You can also do it by-hand:

```sh
sbt '++ 2.12.13' unidoc
```

# Checklist

- [x] Unit tests were added: it pushes correctly on [numero-744.github.io/SpinalHDL/dev](https://numero-744.github.io/SpinalHDL/dev/spinal/core/index.html)
