### PR TITLE
fix: StreamFragmentWidthAdapter(x, y, true) widthOf(y) = 2 * widthOf(x)

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1598,11 +1598,11 @@ object StreamFragmentWidthAdapter {
           for((bit, id) <- dataMask.asBools.zipWithIndex) bit := counter >= id
 
           when(input.fire) {
-            whenIndexed(buffer.subdivideIn(inputWidth bits), counter) {
+            whenIndexed(buffer.subdivideIn(inputWidth bits), counter, relaxedWidth = (factor <= 2)) {
               _ := input.fragment.asBits
             }
           }
-          whenIndexed(data.subdivideIn(inputWidth bits).dropRight(1), counter) {
+          whenIndexed(data.subdivideIn(inputWidth bits).dropRight(1), counter, relaxedWidth = (factor <= 2)) {
             _ := input.fragment.asBits
           }
         }

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1598,11 +1598,11 @@ object StreamFragmentWidthAdapter {
           for((bit, id) <- dataMask.asBools.zipWithIndex) bit := counter >= id
 
           when(input.fire) {
-            whenIndexed(buffer.subdivideIn(inputWidth bits), counter, relaxedWidth = (factor <= 2)) {
+            whenIndexed(buffer.subdivideIn(inputWidth bits), counter, relaxedWidth = true) {
               _ := input.fragment.asBits
             }
           }
-          whenIndexed(data.subdivideIn(inputWidth bits).dropRight(1), counter, relaxedWidth = (factor <= 2)) {
+          whenIndexed(data.subdivideIn(inputWidth bits).dropRight(1), counter, relaxedWidth = true) {
             _ := input.fragment.asBits
           }
         }

--- a/tester/src/test/scala/spinal/tester/scalatest/Issue963Tester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Issue963Tester.scala
@@ -31,8 +31,8 @@ class Issue963Tester extends AnyFunSuite {
   test("Minimal example for Issue963 which fails Spinal elaboration") {
     class Dut extends Component {
       val io = new Bundle {
-          val sink = slave Stream(Fragment(Bits(8 bits)))
-          val source = master Stream(Fragment(Bits(16 bits)))
+        val sink = slave Stream (Fragment(Bits(8 bits)))
+        val source = master Stream (Fragment(Bits(16 bits)))
       }
       val x = Stream(Fragment(Bits(16 bits)))
 
@@ -40,12 +40,14 @@ class Issue963Tester extends AnyFunSuite {
       io.source <-< x
     }
 
-    SimConfig.withConfig(SpinalConfig(defaultClockDomainFrequency = FixedFrequency(4000 Hz))).compile(new Component{
-      val issue = new Dut()
-    })
-   .doSim{dut =>
-      dut.clockDomain.forkStimulus(10)
-      dut.clockDomain.waitSampling()
-    }
+    SimConfig
+      .withConfig(SpinalConfig(defaultClockDomainFrequency = FixedFrequency(4000 Hz)))
+      .compile(new Component {
+        val issue = new Dut()
+      })
+      .doSim { dut =>
+        dut.clockDomain.forkStimulus(10)
+        dut.clockDomain.waitSampling()
+      }
   }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/Issue963Tester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Issue963Tester.scala
@@ -1,0 +1,51 @@
+package spinal.tester.scalatest
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.core._
+import spinal.lib._
+import spinal.core.sim._
+
+// unit test for issue #963
+
+// [info] - Minimal example for Issue963 which fails Spinal elaboration *** FAILED ***
+// [info]   java.lang.AssertionError: assertion failed
+// [info]   at scala.Predef$.assert(Predef.scala:156)
+// [info]   at spinal.core.package$.assert(core.scala:463)
+// [info]   at spinal.lib.whenIndexed$.apply(Utils.scala:1320)
+// [info]   at spinal.lib.StreamFragmentWidthAdapter$$anon$56$$anon$41$$anonfun$41.apply$mcV$sp(Stream.scala:1601)
+// [info]   at spinal.core.when$.apply(when.scala:90)
+// [info]   at spinal.lib.StreamFragmentWidthAdapter$$anon$56$$anon$41.<init>(Stream.scala:1600)
+// [info]   at spinal.lib.StreamFragmentWidthAdapter$$anon$56.<init>(Stream.scala:1562)
+// [info]   at spinal.lib.StreamFragmentWidthAdapter$.apply(Stream.scala:1541)
+// [info]   at spinal.tester.scalatest.Issue963$$anonfun$1$Dut$1.<init>(Issue963.scala:40)
+// [info]   at spinal.tester.scalatest.Issue963$$anonfun$1$$anonfun$apply$mcV$sp$1$$anon$2.<init>(Issue963.scala:45)
+// [info]   ...
+// [info] Run completed in 532 milliseconds.
+// [info] Total number of tests run: 1
+// [info] Suites: completed 1, aborted 0
+// [info] Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
+// [info] *** 1 TEST FAILED ***
+
+class Issue963Tester extends AnyFunSuite {
+  test("Minimal example for Issue963 which fails Spinal elaboration") {
+    class Dut extends Component {
+      val io = new Bundle {
+          val sink = slave Stream(Fragment(Bits(8 bits)))
+          val source = master Stream(Fragment(Bits(16 bits)))
+      }
+      val x = Stream(Fragment(Bits(16 bits)))
+
+      StreamFragmentWidthAdapter(io.sink, x, earlyLast = true)
+      io.source <-< x
+    }
+
+    SimConfig.withConfig(SpinalConfig(defaultClockDomainFrequency = FixedFrequency(4000 Hz))).compile(new Component{
+      val issue = new Dut()
+    })
+   .doSim{dut =>
+      dut.clockDomain.forkStimulus(10)
+      dut.clockDomain.waitSampling()
+    }
+  }
+}


### PR DESCRIPTION
Root cause is that counter is in range [0,1], number of elements in buffer Vector is 1, thus the number of bits differs in whenIndexed(), only for the case of widthOf(y) = 2 * widthOf(x). Triggering assert in whenIndexed().

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #963

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
