### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: spinalhdl


### PR DESCRIPTION
# Context, Motivation & Description

Github has this feature, so why not using it?

For reference:

* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
* An example (see right column, "Sponsor this project"): https://github.com/freeCodeCamp/freeCodeCamp