### PR TITLE
Make SpinalSim seed default random again

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -571,7 +571,7 @@ abstract class SimCompiled[T <: Component](val report: SpinalReport[T]){
     }
   }
 
-  def doSimApi(name: String="test", seed: Int=newSeed(), joinAll: Boolean)(body: T => Unit): Unit = {
+  def doSimApi(name: String = "test", seed: Int = newSeed(), joinAll: Boolean)(body: T => Unit): Unit = {
     Random.setSeed(seed)
     GlobalData.set(report.globalData)
 

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -564,7 +564,14 @@ abstract class SimCompiled[T <: Component](val report: SpinalReport[T]){
 
   def newSimRaw(name: String, seed: Int) : SimRaw
 
-  def doSimApi(name: String = "test", seed: Int = sys.env.getOrElse("SPINAL_SIM_SEED_RANDOM", "0").toInt*Random.nextInt(2000000000), joinAll: Boolean)(body: T => Unit): Unit = {
+  def newSeed(): Int = {
+    sys.env.get("SPINAL_SIM_SEED") match {
+      case Some(v) => v.toInt
+      case None => Random.nextInt(2000000000)
+    }
+  }
+
+  def doSimApi(name: String="test", seed: Int=newSeed(), joinAll: Boolean)(body: T => Unit): Unit = {
     Random.setSeed(seed)
     GlobalData.set(report.globalData)
 


### PR DESCRIPTION
Closes https://github.com/SpinalHDL/SpinalHDL/issues/948

This changes the default behavior for simulation back to random.
As discussed in the Bug, it only uses a single environment variable (SPINAL_SIM_SEED) which can be set to any fixed value.

This will change the behavior for people that are currently using SPINAL_SIM_SEED_RANDOM, but prevent future confusion as agreed in https://github.com/SpinalHDL/SpinalHDL/issues/948#issuecomment-1309904827.

RTD note on this will be added, just not sure where to add it ATM - I think that needs a new page...