### PR TITLE
fix cocotb problem while runing on system with different language.

### DIFF
--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
@@ -117,11 +117,11 @@ abstract class SpinalTesterCocotbBase extends AnyFunSuite /* with BeforeAndAfter
         stdin.close()
       },
       stdout => {
-        out = scala.io.Source.fromInputStream(stdout).getLines.foldLeft("")(_ + "\n" + _)
+        out = scala.io.Source.fromInputStream(stdout)(scala.io.Codec.UTF8).getLines.foldLeft("")(_ + "\n" + _)
         stdout.close()
       },
       stderr => {
-        err = scala.io.Source.fromInputStream(stderr).getLines.foldLeft("")(_ + "\n" + _)
+        err = scala.io.Source.fromInputStream(stderr)(scala.io.Codec.UTF8).getLines.foldLeft("")(_ + "\n" + _)
         stderr.close()
       })
     val proc = Process("sh").run(io)


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #973 

# Context, Motivation & Description

fix cocotb charset error on different language environment.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added // not available.
- [x] API changes are or will be documented:  // not needed.
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
