### PR TITLE
Deprecate Bool without braces

### DIFF
--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -24,14 +24,17 @@ import spinal.core.internals.Operator.Formal
 import spinal.core.internals._
 import spinal.idslplugin.Location
 
-/**
-  * Bool factory used for instance by the IODirection to create a in/out Bool()
-  */
+/** Bool factory used for instance by the IODirection to create a in/out Bool() */
 trait BoolFactory {
-  /** Create a new Bool */
-//  def Bool(): Bool = new Bool
-}
+  @deprecated("Use `Bool()` (with braces) instead")
+  def Bool: Bool = Bool()
 
+  /** Create a new Bool */
+  def Bool(u: Unit = ()): Bool = new Bool
+
+  /** Create a new Bool with a value */
+  def Bool(value: Boolean): Bool = BoolLiteral(value, Bool().setAsTypeNode())
+}
 
 /**
   * The Bool type corresponds to a boolean value (True or False)

--- a/core/src/main/scala/spinal/core/IODirection.scala
+++ b/core/src/main/scala/spinal/core/IODirection.scala
@@ -90,7 +90,7 @@ sealed trait IODirection extends BaseTypeFactory {
     *
     * See [[IODirection]] for other syntaxes.
     */
-  def Bool(u: Unit = ()): Bool = port(spinal.core.Bool())
+  override def Bool(u: Unit = ()): Bool = port(super.Bool())
 
   override def Bits(u: Unit = ()): Bits = port(super.Bits())
 

--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -39,8 +39,9 @@ package object core extends BaseTypeFactory with BaseTypeCast {
   type Module = spinal.core.Component
   type dontName = spinal.core.DontName @field
 
-  def Bool : Bool = new Bool
-  def Bool(u: DummyTrait = DummyObject) : Bool = new Bool
+  @deprecated("Use `Bool()` (with braces) instead")
+  def Bool: Bool = new Bool
+  def Bool(u: DummyTrait = DummyObject): Bool = new Bool
   def Bool(value: Boolean): Bool = BoolLiteral(value, this.Bool().setAsTypeNode())
 
   /**

--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -39,11 +39,6 @@ package object core extends BaseTypeFactory with BaseTypeCast {
   type Module = spinal.core.Component
   type dontName = spinal.core.DontName @field
 
-  @deprecated("Use `Bool()` (with braces) instead")
-  def Bool: Bool = new Bool
-  def Bool(u: DummyTrait = DummyObject): Bool = new Bool
-  def Bool(value: Boolean): Bool = BoolLiteral(value, this.Bool().setAsTypeNode())
-
   /**
     * Scala implicit
     */
@@ -235,7 +230,7 @@ package object core extends BaseTypeFactory with BaseTypeCast {
   /**
     * True / False definition
     */
-  def True  = Bool(true) //Should be def, not val, else it will create cross hierarchy usage of the same instance
+  def True  = Bool(true)
   def False = Bool(false)
 
 

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamSimpleWidthAdapter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamSimpleWidthAdapter.scala
@@ -62,7 +62,7 @@ class Axi4StreamSimpleWidthAdapter(inConfig: Axi4StreamConfig, outWidth: Int) ex
       inConfig.useId generate { buffer.id init(0) }
       inConfig.useLast generate { buffer.last init(False) }
 
-      val start = Reg(Bool) init(True)
+      val start = Reg(Bool()) init(True)
       start clearWhen start && io.axis_s.fire && counter === 0
       if (inConfig.useLast) {
         start setWhen io.axis_m.lastFire

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamWidthAdapter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamWidthAdapter.scala
@@ -45,7 +45,7 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
   val bufferLast = RegInit(False)
   val bufferId   = inConfig.useId   generate Reg(io.axis_s.id)
   val bufferDest = inConfig.useDest generate Reg(io.axis_s.dest)
-  val start = Reg(Bool) init(True)
+  val start = Reg(Bool()) init(True)
 
   // Maps inputs into buffer slices given the current fill level
   def doWriteStage(inBundle: Axi4StreamBundle, bufBundle: Axi4StreamBundle, bufValid: Bits, doWrite: Bool, fillLevel: UInt): (Axi4StreamBundle, Bits) = {

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/AxiLite4BusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/AxiLite4BusInterface.scala
@@ -16,12 +16,12 @@ case class AxiLite4BusInterface(bus: AxiLite4, sizeMap: SizeMapping, regPre: Str
 
   val axiAr = bus.readCmd.stage()
   val axiR  = Stream(AxiLite4R(bus.config))
-  val axiRValid = Reg(Bool) init(False)
+  val axiRValid = Reg(Bool()) init(False)
 
   val axiAw = bus.writeCmd.stage()
   val axiW  = bus.writeData.stage()
   val axiB  = Stream(AxiLite4B(bus.config))
-  val axiBValid = Reg(Bool) init(False)
+  val axiBValid = Reg(Bool()) init(False)
   
   axiAr.ready := !axiRValid || axiR.ready
   when(readError) {

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -338,13 +338,13 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf) {
   }
 
   def eventR() : Bool = {
-    val event = Reg(Bool) init(False)
+    val event = Reg(Bool()) init(False)
     event := hitDoRead
     event
   }
 
   def eventW() : Bool = {
-    val event = Reg(Bool) init(False)
+    val event = Reg(Bool()) init(False)
     event := hitDoWrite
     event
   }

--- a/lib/src/main/scala/spinal/lib/com/eth/Phy.scala
+++ b/lib/src/main/scala/spinal/lib/com/eth/Phy.scala
@@ -80,7 +80,7 @@ case class MiiRx(p : MiiRxParameter) extends Bundle with IMasterSlave {
 }
 
 case class Mdio() extends Bundle with IMasterSlave{
-  val IO = TriState(Bool)
+  val IO = TriState(Bool())
   val C = Bool()
 
   override def asMaster(): Unit = {

--- a/lib/src/main/scala/spinal/lib/com/i2c/I2cCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/i2c/I2cCtrl.scala
@@ -326,7 +326,7 @@ object I2cCtrl {
       }
 
 
-      val txReady = Bool //Say if the tx buffer is ready to continue
+      val txReady = Bool() //Say if the tx buffer is ready to continue
 
       val fsm = new StateMachine {
         always {

--- a/lib/src/main/scala/spinal/lib/com/spi/Misc.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/Misc.scala
@@ -27,7 +27,7 @@ case class SpiMaster(ssWidth : Int = 1,
 case class SpiSlave(useSclk : Boolean = true) extends Bundle with IMasterSlave{
   val sclk = if(useSclk)Bool() else null
   val mosi = Bool()
-  val miso = TriStateOutput(Bool)
+  val miso = TriStateOutput(Bool())
   val ss   = Bool()
 
   override def asMaster(): Unit = {

--- a/lib/src/main/scala/spinal/lib/com/spi/SpiSlaveCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/SpiSlaveCtrl.scala
@@ -77,7 +77,7 @@ case class SpiSlaveCtrlIo(generics : SpiSlaveCtrlGenerics) extends Bundle{
 
     //RX
     val rxLogic = new Area {
-      val listen = busWithOffset.createReadAndWrite(Bool, address = 4, bitOffset = 15) init(False)
+      val listen = busWithOffset.createReadAndWrite(Bool(), address = 4, bitOffset = 15) init(False)
       val (stream, fifoOccupancy) = rx.takeWhen(listen).queueWithOccupancy(txFifoDepth)
       busWithOffset.readStreamNonBlocking(stream, address = 0, validBitOffset = 31, payloadBitOffset = 0)
       busWithOffset.read(fifoOccupancy, address = 0, 16)
@@ -85,10 +85,10 @@ case class SpiSlaveCtrlIo(generics : SpiSlaveCtrlGenerics) extends Bundle{
 
     //Status
     val interruptCtrl = new Area {
-      val txIntEnable = busWithOffset.createReadAndWrite(Bool, address = 4, 0) init(False)
-      val rxIntEnable = busWithOffset.createReadAndWrite(Bool, address = 4, 1) init(False)
-      val ssEnabledIntEnable = busWithOffset.createReadAndWrite(Bool, address = 4, 2) init(False)
-      val ssDisabledIntEnable = busWithOffset.createReadAndWrite(Bool, address = 4, 3) init(False)
+      val txIntEnable = busWithOffset.createReadAndWrite(Bool(), address = 4, 0) init(False)
+      val rxIntEnable = busWithOffset.createReadAndWrite(Bool(), address = 4, 1) init(False)
+      val ssEnabledIntEnable = busWithOffset.createReadAndWrite(Bool(), address = 4, 2) init(False)
+      val ssDisabledIntEnable = busWithOffset.createReadAndWrite(Bool(), address = 4, 3) init(False)
 
 
       val ssFiltedEdges = ssFilted.edges(True)

--- a/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
@@ -25,7 +25,7 @@ case class XdrOutput(rate : Int) extends Bundle with IMasterSlave{
 
   def toTriState(): TriState[Bool] ={
     assert(rate == 2)
-    val io = TriState(Bool)
+    val io = TriState(Bool())
     val clk = ClockDomain.readClockWire
     val writeBuffer = RegNext(write)
     io.write := (clk ? writeBuffer(0))| writeBuffer(1)
@@ -44,7 +44,7 @@ case class XdrPin(rate : Int) extends Bundle with IMasterSlave{
 
   def toTriState(): TriState[Bool] ={
     assert(rate == 2)
-    val io = TriState(Bool)
+    val io = TriState(Bool())
     val clk = ClockDomain.readClockWire
     io.writeEnable := writeEnable
     val writeBuffer = RegNext(write)
@@ -224,9 +224,9 @@ case class SpiXdrMaster(val p : SpiXdrParameter) extends Bundle with IMasterSlav
   }
 
   case class SpiIce40(p : SpiXdrParameter) extends Bundle {
-    val sclk = Analog(Bool)
-    val ss = Vec.fill(p.ssWidth)(Analog(Bool))
-    val data = Vec.fill(p.dataWidth)(Analog(Bool))
+    val sclk = Analog(Bool())
+    val ss = Vec.fill(p.ssWidth)(Analog(Bool()))
+    val data = Vec.fill(p.dataWidth)(Analog(Bool()))
   }
 
   def toSpiIce40() = {
@@ -482,8 +482,8 @@ object SpiXdrMasterCtrl {
 
     //Interrupts
     val interruptCtrl = new Area {
-      val cmdIntEnable = bus.createReadAndWrite(Bool, address = baseAddress + 12, 0) init(False)
-      val rspIntEnable  = bus.createReadAndWrite(Bool, address = baseAddress + 12, 1) init(False)
+      val cmdIntEnable = bus.createReadAndWrite(Bool(), address = baseAddress + 12, 0) init(False)
+      val rspIntEnable  = bus.createReadAndWrite(Bool(), address = baseAddress + 12, 1) init(False)
       val cmdInt = bus.read(cmdIntEnable & !cmdLogic.stream.valid, address = baseAddress + 12, 8)
       val rspInt = bus.read(rspIntEnable &  rspLogic.stream.valid, address = baseAddress + 12, 9)
       val interrupt = rspInt || cmdInt

--- a/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
@@ -139,8 +139,8 @@ class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
 
     //manage interrupts
     val interruptCtrl = new Area {
-      val writeIntEnable = busCtrlWrapped.createReadAndWrite(Bool, address = 4, 0) init(False)
-      val readIntEnable  = busCtrlWrapped.createReadAndWrite(Bool, address = 4, 1) init(False)
+      val writeIntEnable = busCtrlWrapped.createReadAndWrite(Bool(), address = 4, 0) init(False)
+      val readIntEnable  = busCtrlWrapped.createReadAndWrite(Bool(), address = 4, 1) init(False)
       val readInt   = readIntEnable  &  read.streamBreaked.valid
       val writeInt  = writeIntEnable & !write.stream.valid
       val interrupt = readInt || writeInt
@@ -149,8 +149,8 @@ class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
     }
 
     val misc = new Area{
-      val readError = busCtrlWrapped.createReadAndClearOnSet(Bool, 0x10, 0) init(False) setWhen(io.readError)
-      val readOverflowError = busCtrlWrapped.createReadAndClearOnSet(Bool, 0x10, 1) init(False) setWhen(io.read.isStall)
+      val readError = busCtrlWrapped.createReadAndClearOnSet(Bool(), 0x10, 0) init(False) setWhen(io.readError)
+      val readOverflowError = busCtrlWrapped.createReadAndClearOnSet(Bool(), 0x10, 1) init(False) setWhen(io.read.isStall)
       busCtrlWrapped.read(io.readBreak, 0x10, 8)
       val breakDetected = RegInit(False) setWhen(io.readBreak.rise())
       busCtrlWrapped.read(breakDetected, 0x10, 9)

--- a/lib/src/main/scala/spinal/lib/com/usb/ohci/UsbOhci.scala
+++ b/lib/src/main/scala/spinal/lib/com/usb/ohci/UsbOhci.scala
@@ -405,8 +405,8 @@ case class UsbOhci(p : UsbOhciParameter, ctrlParameter : BmbParameter) extends C
 
     val hcRhStatus = new Area { //TODO events to RHSC
       val OCI = ctrl.read(io.phy.overcurrent, 0x50, 1)
-      val DRWE = ctrl.createReadOnly(Bool, 0x50, 15) softInit (False)
-      val CCIC = ctrl.createReadAndClearOnSet(Bool, 0x50, 17) softInit (False) setWhen (OCI.edge(False))
+      val DRWE = ctrl.createReadOnly(Bool(), 0x50, 15) softInit (False)
+      val CCIC = ctrl.createReadAndClearOnSet(Bool(), 0x50, 17) softInit (False) setWhen (OCI.edge(False))
 
       val clearGlobalPower = ctrl.setOnSet(False, 0x50, 0)
       val setRemoteWakeupEnable = ctrl.setOnSet(False, 0x50, 15)

--- a/lib/src/main/scala/spinal/lib/com/usb/phy/UsbDevicePhyNative.scala
+++ b/lib/src/main/scala/spinal/lib/com/usb/phy/UsbDevicePhyNative.scala
@@ -201,7 +201,7 @@ case class UsbDevicePhyNative(sim : Boolean = false) extends Component{
     val decoder = new Area{
       val state = Reg(Bool())
 
-      val output = Flow(Bool)
+      val output = Flow(Bool())
       output.valid := False
       output.payload.assignDontCare()
 

--- a/lib/src/main/scala/spinal/lib/com/usb/phy/UsbHubPhy.scala
+++ b/lib/src/main/scala/spinal/lib/com/usb/phy/UsbHubPhy.scala
@@ -9,7 +9,7 @@ import spinal.lib.io.TriState
 
 
 case class UsbPhyFsNativeIo() extends Bundle with IMasterSlave {
-  val dp,dm = TriState(Bool)
+  val dp,dm = TriState(Bool())
 
   override def asMaster(): Unit = {
     master(dp,dm)
@@ -436,7 +436,7 @@ case class UsbLsFsPhy(portCount : Int, sim : Boolean = false) extends Component 
       val decoder = new Area{
         val state = Reg(Bool())
 
-        val output = Flow(Bool)
+        val output = Flow(Bool())
         output.valid := False
         output.payload.assignDontCare()
 

--- a/lib/src/main/scala/spinal/lib/com/usb/udc/UsbDeviceCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/usb/udc/UsbDeviceCtrl.scala
@@ -165,7 +165,7 @@ case class UsbDeviceCtrl(p: UsbDeviceCtrlParameter, bmbParameter : BmbParameter)
       val effective = RegInit(False)
       val hit = Bool()
     }
-    val pullup = Reg(Bool) init(False)
+    val pullup = Reg(Bool()) init(False)
     io.phy.pullup := pullup
   }
 

--- a/lib/src/main/scala/spinal/lib/cpu/riscv/impl/RiscvCore.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/impl/RiscvCore.scala
@@ -576,7 +576,7 @@ class RiscvCore(implicit val c : RiscvCoreConfig) extends Component{
   val decode = new Area{
     val inInst = fetch.outInst.m2sPipe()
     val ctrl = getInstructionCtrl(inInst.instruction)
-    val hazard = Bool //Used to stall decode phase because of register file hazard
+    val hazard = Bool() //Used to stall decode phase because of register file hazard
     val throwIt = False
     val halt = False
     when(hazard){

--- a/lib/src/main/scala/spinal/lib/graphic/vga/VgaCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/graphic/vga/VgaCtrl.scala
@@ -215,7 +215,7 @@ case class VgaCtrl(rgbConfig: RgbConfig, timingsWidth: Int = 12) extends Compone
   def feedWith(that : Stream[Fragment[Rgb]], resync : Bool = False): Unit ={
     val error = RegInit(False)
     val waitStartOfFrame = RegInit(False)
-    val firstPixel = Reg(Bool) setWhen(io.frameStart) clearWhen(that.firstFire)
+    val firstPixel = Reg(Bool()) setWhen(io.frameStart) clearWhen(that.firstFire)
 
     io.pixels << that.toStreamOfFragment.throwWhen(error).haltWhen(waitStartOfFrame)
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #972 

# Checklist

- [x] Deprecate `Bool`, should use `Bool()` instead
- [x] Check no deprecated syntax is in this repository
- [x] Check no deprecated syntax in RTD: https://github.com/SpinalHDL/SpinalDoc-RTD/pull/156