### PR TITLE
Enum merge

### DIFF
--- a/core/src/main/scala/spinal/core/Enum.scala
+++ b/core/src/main/scala/spinal/core/Enum.scala
@@ -32,6 +32,8 @@ import scala.collection.mutable.ArrayBuffer
   */
 class SpinalEnumElement[T <: SpinalEnum](val spinalEnum: T, val position: Int) extends Nameable {
 
+  def getSignature() : Any = List(position, getName(""))
+
   def ===(that: SpinalEnumCraft[T]): Bool = that === this
   def =/=(that: SpinalEnumCraft[T]): Bool = that =/= this
 
@@ -86,6 +88,8 @@ class SpinalEnum(var defaultEncoding: SpinalEnumEncoding = native) extends Namea
   /** Contains all elements of the enumeration */
   @dontName val elements = ArrayBuffer[SpinalEnumElement[this.type]]()
 
+  def getSignature() : Any = List(getName(""), defaultEncoding.getSignature(), isPrefixEnable, isGlobalEnable, elements.map(_.getSignature()).toList)
+
   def apply() = craft()
   def apply(encoding: SpinalEnumEncoding) = craft(encoding)
 
@@ -122,7 +126,7 @@ class SpinalEnum(var defaultEncoding: SpinalEnumEncoding = native) extends Namea
 /**
   * Hardware representation of an enumeration
   */
-class SpinalEnumCraft[T <: SpinalEnum](val spinalEnum: T) extends BaseType with InferableEnumEncodingImpl  with BaseTypePrimitives[SpinalEnumCraft[T]]  with DataPrimitives[SpinalEnumCraft[T]] {
+class SpinalEnumCraft[T <: SpinalEnum](var spinalEnum: SpinalEnum) extends BaseType with InferableEnumEncodingImpl  with BaseTypePrimitives[SpinalEnumCraft[T]]  with DataPrimitives[SpinalEnumCraft[T]] {
 
   override def getTypeObject: Any = TypeEnum
 
@@ -133,6 +137,7 @@ class SpinalEnumCraft[T <: SpinalEnum](val spinalEnum: T) extends BaseType with 
   override private[core] def canSymplifyIt = super.canSymplifyIt && (this.encodingChoice == InferableEnumEncodingImplChoiceUndone)
 
   override def getDefinition: SpinalEnum = spinalEnum
+  override def swapEnum(e: SpinalEnum) = spinalEnum = e
 
   private[spinal] override def _data: SpinalEnumCraft[T] = this
 
@@ -234,7 +239,7 @@ class SpinalEnumCraft[T <: SpinalEnum](val spinalEnum: T) extends BaseType with 
 /**
   * Node representation which contains the value of an SpinalEnumElement
   */
-class EnumLiteral[T <: SpinalEnum](val senum: SpinalEnumElement[T]) extends Literal with InferableEnumEncodingImpl {
+class EnumLiteral[T <: SpinalEnum](var senum: SpinalEnumElement[_ <: SpinalEnum]) extends Literal with InferableEnumEncodingImpl {
 
   override def getTypeObject: Any = TypeEnum
 
@@ -255,12 +260,13 @@ class EnumLiteral[T <: SpinalEnum](val senum: SpinalEnumElement[T]) extends Lite
   override def hasPoison() = false
 
   override def getDefinition: SpinalEnum = senum.spinalEnum
+  override def swapEnum(e: SpinalEnum) = senum = e.elements(senum.position)
 
   private[core] override def getDefaultEncoding(): SpinalEnumEncoding = senum.spinalEnum.defaultEncoding
 }
 
 
-class EnumPoison(val senum: SpinalEnum) extends Literal with InferableEnumEncodingImpl {
+class EnumPoison(var senum: SpinalEnum) extends Literal with InferableEnumEncodingImpl {
 
   override def getTypeObject: Any = TypeEnum
 
@@ -280,6 +286,7 @@ class EnumPoison(val senum: SpinalEnum) extends Literal with InferableEnumEncodi
   }
 
   override def getDefinition: SpinalEnum = senum
+  override def swapEnum(e: SpinalEnum) = senum = e
   override def hasPoison() = true
   private[core] override def getDefaultEncoding(): SpinalEnumEncoding = senum.defaultEncoding
 }
@@ -297,6 +304,8 @@ trait SpinalEnumEncoding extends Nameable with ScalaLocated{
   def getElement[T <: SpinalEnum](element: BigInt, senum : T): SpinalEnumElement[T]
 
   def isNative: Boolean = false
+
+  def getSignature() : Any = this
 }
 
 

--- a/core/src/main/scala/spinal/core/internals/Analog.scala
+++ b/core/src/main/scala/spinal/core/internals/Analog.scala
@@ -63,7 +63,7 @@ class AnalogDriverSInt extends AnalogDriverBitVector {
 }
 
 
-class AnalogDriverEnum(enumDef: SpinalEnum) extends AnalogDriver with InferableEnumEncodingImpl {
+class AnalogDriverEnum(var enumDef: SpinalEnum) extends AnalogDriver with InferableEnumEncodingImpl {
 
   override def opName = "AnalogDriver(Enum, Bool)"
 
@@ -76,5 +76,7 @@ class AnalogDriverEnum(enumDef: SpinalEnum) extends AnalogDriver with InferableE
   override private[core] def getDefaultEncoding(): SpinalEnumEncoding = enumDef.defaultEncoding
 
   override def getDefinition: SpinalEnum = enumDef
+
+  override def swapEnum(e: SpinalEnum) = enumDef = e
 }
 

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -344,10 +344,11 @@ object Operator {
     class RandomExpSInt(kind : RandomExpKind, width : Int) extends RandomExpBitVector(kind, width) {
       override def getTypeObject = TypeSInt
     }
-    class RandomExpEnum(enumDef: SpinalEnum, kind : RandomExpKind) extends RandomExp(kind) with InferableEnumEncodingImpl{
+    class RandomExpEnum(var enumDef: SpinalEnum, kind : RandomExpKind) extends RandomExp(kind) with InferableEnumEncodingImpl{
       override def getTypeObject = TypeEnum
       override private[core] def getDefaultEncoding(): SpinalEnumEncoding = enumDef.defaultEncoding
       override def getDefinition: SpinalEnum = enumDef
+      override def swapEnum(e: SpinalEnum) = enumDef = e
     }
 
     abstract class Past(val delay : Int) extends UnaryOperator
@@ -377,7 +378,7 @@ object Operator {
       override def opName: String = "$past(SInt)"
     }
 
-    class PastEnum(enumDef: SpinalEnum, delay : Int) extends Past(delay)  with InferableEnumEncodingImpl{
+    class PastEnum(var enumDef: SpinalEnum, delay : Int) extends Past(delay)  with InferableEnumEncodingImpl{
       override def getTypeObject = TypeEnum
       override def opName: String = "$past(Enum)"
 
@@ -386,6 +387,7 @@ object Operator {
       override type T = Expression with EnumEncoded
       override private[core] def getDefaultEncoding(): SpinalEnumEncoding = enumDef.defaultEncoding
       override def getDefinition: SpinalEnum = enumDef
+      override def swapEnum(e: SpinalEnum) = enumDef = e
     }
 
 
@@ -1028,7 +1030,7 @@ object Operator {
     */
   object Enum{
 
-    class Equal(enumDef: SpinalEnum) extends BinaryOperator with InferableEnumEncodingImpl {
+    class Equal(var enumDef: SpinalEnum) extends BinaryOperator with InferableEnumEncodingImpl {
       override def getTypeObject: Any = TypeBool
 
       override def opName: String = "Enum === Enum"
@@ -1037,6 +1039,7 @@ object Operator {
       override type T = Expression with EnumEncoded
       override private[core] def getDefaultEncoding(): SpinalEnumEncoding = enumDef.defaultEncoding
       override def getDefinition: SpinalEnum = enumDef
+      override def swapEnum(e: SpinalEnum) = enumDef = e
 
       override def simplifyNode: Expression = {
         if (left.getDefinition.elements.size < 2)
@@ -1046,7 +1049,7 @@ object Operator {
       }
     }
 
-    class NotEqual(enumDef: SpinalEnum) extends BinaryOperator with InferableEnumEncodingImpl {
+    class NotEqual(var enumDef: SpinalEnum) extends BinaryOperator with InferableEnumEncodingImpl {
       override def getTypeObject: Any = TypeBool
       override def opName: String = "Enum =/= Enum"
       override def normalizeInputs: Unit = {InputNormalize.enumImpl(this)}
@@ -1054,6 +1057,7 @@ object Operator {
       override type T = Expression with EnumEncoded
       override private[core] def getDefaultEncoding(): SpinalEnumEncoding = enumDef.defaultEncoding
       override def getDefinition: SpinalEnum = enumDef
+      override def swapEnum(e: SpinalEnum) = enumDef = e
 
       override def simplifyNode: Expression = {
         if (left.getDefinition.elements.size < 2)
@@ -1143,7 +1147,7 @@ class CastEnumToBits extends Cast with Widthable {
 }
 
 /** Bits -> Enum */
-class CastBitsToEnum(val enumDef: SpinalEnum) extends Cast with InferableEnumEncodingImpl {
+class CastBitsToEnum(var enumDef: SpinalEnum) extends Cast with InferableEnumEncodingImpl {
   override type T <: Expression with WidthProvider
   override def opName: String = "Bits -> Enum"
   override private[core] def getDefaultEncoding(): SpinalEnumEncoding = enumDef.defaultEncoding
@@ -1154,16 +1158,18 @@ class CastBitsToEnum(val enumDef: SpinalEnum) extends Cast with InferableEnumEnc
   }
 
   override def getTypeObject: Any = TypeEnum
+  override def swapEnum(e: SpinalEnum) = enumDef = e
 }
 
 /** Enum -> Enum */
-class CastEnumToEnum(enumDef: SpinalEnum) extends Cast with  InferableEnumEncodingImpl {
+class CastEnumToEnum(var enumDef: SpinalEnum) extends Cast with  InferableEnumEncodingImpl {
   override type T <: Expression with EnumEncoded
   override def opName: String = "Enum -> Enum"
 
   override private[core] def getDefaultEncoding(): SpinalEnumEncoding = enumDef.defaultEncoding
   override def getDefinition: SpinalEnum = enumDef
   override def getTypeObject: Any = TypeEnum
+  override def swapEnum(e: SpinalEnum) = enumDef = e
 }
 
 
@@ -1267,7 +1273,7 @@ class MultiplexerSInt extends MultiplexerWidthable {
 }
 
 /** Enum multiplexer */
-class MultiplexerEnum(enumDef: SpinalEnum) extends Multiplexer with InferableEnumEncodingImpl {
+class MultiplexerEnum(var enumDef: SpinalEnum) extends Multiplexer with InferableEnumEncodingImpl {
   override type T = Expression with EnumEncoded
   override def opName: String = s"mux of Enum"
   override def getDefinition: SpinalEnum = enumDef
@@ -1279,6 +1285,7 @@ class MultiplexerEnum(enumDef: SpinalEnum) extends Multiplexer with InferableEnu
     }
   }
   override def getTypeObject: Any = TypeEnum
+  override def swapEnum(e: SpinalEnum) = enumDef = e
 }
 
 
@@ -1359,7 +1366,7 @@ class BinaryMultiplexerSInt extends BinaryMultiplexerWidthable {
 }
 
 /** Enum binary multiplexer */
-class BinaryMultiplexerEnum(enumDef : SpinalEnum) extends BinaryMultiplexer with InferableEnumEncodingImpl {
+class BinaryMultiplexerEnum(var enumDef : SpinalEnum) extends BinaryMultiplexer with InferableEnumEncodingImpl {
   override type T = Expression with EnumEncoded
   override def opName: String = "Bool ? Bits | Bits"
   override def getDefinition: SpinalEnum = enumDef
@@ -1369,6 +1376,7 @@ class BinaryMultiplexerEnum(enumDef : SpinalEnum) extends BinaryMultiplexer with
     whenFalse = InputNormalize.enumImpl(this, whenFalse)
   }
   override def getTypeObject: Any = TypeEnum
+  override def swapEnum(e: SpinalEnum) = enumDef = e
 }
 
 

--- a/core/src/main/scala/spinal/core/internals/Node.scala
+++ b/core/src/main/scala/spinal/core/internals/Node.scala
@@ -239,6 +239,7 @@ trait EnumEncoded{
   def getDefinition: SpinalEnum
   //Only used in the inferation phase
   def swapEncoding(encoding : SpinalEnumEncoding)
+  def swapEnum(e : SpinalEnum)
 }
 
 

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -1036,7 +1036,6 @@ class PhaseCollectAndNameEnum(pc: PhaseContext) extends PhaseMisc{
     for(e <- enumSet){
       signatureToEnums.getOrElseUpdate(e.getSignature(), ArrayBuffer[SpinalEnum]()) += e
     }
-    println(signatureToEnums.map("- " + _).mkString("\n"))
 
     val enumsToMerge =  mutable.LinkedHashMap[SpinalEnum, SpinalEnum]()
     for((_, list) <- signatureToEnums) {

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -21,7 +21,6 @@
 package spinal.core.internals
 
 import java.io.{BufferedWriter, File, FileWriter}
-
 import scala.collection.mutable.ListBuffer
 import spinal.core._
 import spinal.core.fiber.Engine
@@ -995,26 +994,26 @@ class PhaseCollectAndNameEnum(pc: PhaseContext) extends PhaseMisc{
 
   override def impl(pc : PhaseContext): Unit = {
     import pc._
+
+    //Collect all SpinalEnum
     walkDeclarations {
       case senum: SpinalEnumCraft[_] => enums.getOrElseUpdate(senum.spinalEnum, null) //Encodings will be added later
       case _ =>
     }
 
-    val scope = pc.globalScope.newChild("")
-
+    //Provide a basic name for each of them (not unique)
     enums.keys.foreach(e => {
       val name = if(e.isNamed)
         e.getName()
       else
         e.getClass.getSimpleName.replace("$","")
 
-      e.setName(scope.allocateName(name))
+      e.setName(name)
     })
 
     for (enumDef <- enums.keys) {
       Misc.reflect(enumDef, (name, obj) => {
         obj match {
-//          case obj: Nameable => obj.setName(scope.getUnusedName(name), Nameable.DATAMODEL_WEAK)
           case obj: Nameable => obj.setName(name, Nameable.DATAMODEL_WEAK)
           case _ =>
         }
@@ -1022,11 +1021,43 @@ class PhaseCollectAndNameEnum(pc: PhaseContext) extends PhaseMisc{
 
       for (e <- enumDef.elements) {
         if (e.isUnnamed) {
-//          e.setName(scope.getUnusedName("e" + e.position), Nameable.DATAMODEL_WEAK)
           e.setName("e" + e.position, Nameable.DATAMODEL_WEAK)
         }
       }
     }
+
+    //Identify similar enums in order to merge them
+    val enumSet = mutable.LinkedHashSet[SpinalEnum]()
+    walkDeclarations {
+      case senum: SpinalEnumCraft[_] => enumSet += senum.spinalEnum
+      case _ =>
+    }
+    val signatureToEnums = mutable.LinkedHashMap[Any, ArrayBuffer[SpinalEnum]]()
+    for(e <- enumSet){
+      signatureToEnums.getOrElseUpdate(e.getSignature(), ArrayBuffer[SpinalEnum]()) += e
+    }
+    println(signatureToEnums.map("- " + _).mkString("\n"))
+
+    val enumsToMerge =  mutable.LinkedHashMap[SpinalEnum, SpinalEnum]()
+    for((_, list) <- signatureToEnums) {
+      val target = list.head
+      for(tail <- list.tail){
+        enumsToMerge(tail) = target
+        enums -= tail
+      }
+    }
+
+    //Merge similar enums
+    walkExpression {
+      case e : EnumEncoded => enumsToMerge.get(e.getDefinition).foreach(e.swapEnum)
+      case _ =>
+    }
+
+    //Provide unique name for all remaining enums
+    val scope = pc.globalScope.newChild("")
+    enums.keys.foreach(e => {
+      e.setName(scope.allocateName(e.getName()))
+    })
   }
 }
 

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -260,7 +260,7 @@ package object sim {
       case bt: BitVector          => bt #= value
       case bt: SpinalEnumCraft[_] => {
         assert(value < bt.spinalEnum.elements.length)
-        bt #= bt.spinalEnum.elements(value.toInt)
+        setBigInt(bt, value)
       }
     }
 
@@ -427,8 +427,8 @@ package object sim {
 
     def randomize(): SpinalEnumElement[T] = {
       val e = bt.spinalEnum.elements(Random.nextInt(bt.spinalEnum.elements.length))
-      bt #= e
-      e
+      setBigInt(bt, bt.encoding.getValue(e))
+      e.asInstanceOf[SpinalEnumElement[T]]
     }
   }
 

--- a/tester/src/test/scala/spinal/tester/code/Debug.scala
+++ b/tester/src/test/scala/spinal/tester/code/Debug.scala
@@ -1354,5 +1354,15 @@ object PlayFsmBugA extends App {
 
   SpinalVerilog(new Component {
     val sub0, sub1 = new test001
+
+    def create() = {
+      val myEnum = new SpinalEnum {
+        val A, B, C = newElement
+      }.setName("miaou")
+      myEnum.B()
+    }
+
+    val x = create()
+    val y = create()
   })
 }


### PR DESCRIPTION
Closes #331

# Context, Motivation & Description

Merge duplicated SpinalEnum definition based on their signature in order to allow deduplifcation of, for instance, a given FSM instanciated multiple times in differnt part of the herarchy

# Impact on code generation

Less enum <3


So, if you have some code which use a lot of enum, you are welcome trying this PR on your side.
I tested it on SaxonSoc dual core, seems fine.