### PR TITLE
Add Vhdl/Verilog assignements comments to traceback to the original Scala code

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -1,5 +1,7 @@
 package spinal.core
 
+import spinal.idslplugin.Location
+
 import scala.collection.mutable.ArrayBuffer
 import scala.math.BigDecimal.RoundingMode
 
@@ -1096,7 +1098,7 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
   def rounded(rounding  : RoundType): AFix = truncated(saturation = false, overflow = false, rounding = rounding)
   def rounded: AFix = this.rounded(getTrunc.rounding)
 
-  override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+  override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
     that match {
       case af: AFix =>
         val trunc = af.getTag(classOf[TagAFixTruncated])

--- a/core/src/main/scala/spinal/core/BaseType.scala
+++ b/core/src/main/scala/spinal/core/BaseType.scala
@@ -21,6 +21,8 @@
 package spinal.core
 
 import spinal.core.internals._
+import spinal.idslplugin.Location
+
 import scala.collection.Seq
 import scala.collection.mutable.ArrayBuffer
 
@@ -212,15 +214,15 @@ abstract class BaseType extends Data with DeclarationStatement with StatementDou
     } else None
   }
 
-  override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+  override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
     def statement(that : Expression) = kind match {
       case `DataAssign` =>
-        DataAssignmentStatement(target = target.asInstanceOf[Expression], source = that)
+        DataAssignmentStatement(target = target.asInstanceOf[Expression], source = that).setLocation(loc)
       case `InitAssign` =>
         if(!isReg)
           LocatedPendingError(s"Try to set initial value of a data that is not a register ($this)")
-        InitAssignmentStatement(target = target.asInstanceOf[Expression], source = that)
-      case `InitialAssign` => InitialAssignmentStatement(target = target.asInstanceOf[Expression], source = that)
+        InitAssignmentStatement(target = target.asInstanceOf[Expression], source = that).setLocation(loc)
+      case `InitialAssign` => InitialAssignmentStatement(target = target.asInstanceOf[Expression], source = that).setLocation(loc)
     }
     if(isFrozen()){
       LocatedPendingError(s"FROZEN ASSIGNED :\n$this := $that")
@@ -244,7 +246,7 @@ abstract class BaseType extends Data with DeclarationStatement with StatementDou
     super.removeStatement()
   }
 
-  private[core] override def autoConnect(that: Data): Unit = autoConnectBaseImpl(that)
+  private[core] override def autoConnect(that: Data)(implicit loc: Location): Unit = autoConnectBaseImpl(that)
 
   override def flatten: Seq[BaseType] = Seq(this)
 

--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -21,6 +21,8 @@
 package spinal.core
 
 import spinal.core.internals._
+import spinal.idslplugin.Location
+
 import scala.collection.mutable.ArrayBuffer
 
 
@@ -332,7 +334,7 @@ abstract class BitVector extends BaseType with Widthable {
     val bool = wrapWithBool(extract)
 
     bool.compositeAssign = new Assignable {
-      override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind : AnyRef): Unit = that match {
+      override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind : AnyRef)(implicit loc: Location): Unit = that match {
         case that: Bool         => BitVector.this.compositAssignFrom(that,BitAssignmentFixed(BitVector.this, bitId), kind)
         //        case that: DontCareNode => BitVector.this.assignFrom(that, BitAssignmentFixed(BitVector.this, new DontCareNodeFixed(Bool(), 1), bitId), conservative = true)
       }
@@ -347,7 +349,7 @@ abstract class BitVector extends BaseType with Widthable {
     extract.bitId = bitId
     val bool =  wrapWithBool(extract)
     bool.compositeAssign = new Assignable  {
-      override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind : AnyRef): Unit = that match {
+      override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind : AnyRef)(implicit loc: Location): Unit = that match {
         case x: Bool         => BitVector.this.compositAssignFrom(that, BitAssignmentFloating(BitVector.this, bitId), kind)
 //        case x: DontCareNode => BitVector.this.assignFrom(that,BitAssignmentFloating(BitVector.this, new DontCareNodeFixed(Bool(), 1), bitId), true)
       }
@@ -366,7 +368,7 @@ abstract class BitVector extends BaseType with Widthable {
       access.checkHiLo
       val ret = wrapWithWeakClone(access)
       ret.compositeAssign = new Assignable {
-        override def assignFromImpl(that: AnyRef, target : AnyRef, kind : AnyRef): Unit = target match {
+        override def assignFromImpl(that: AnyRef, target : AnyRef, kind : AnyRef)(implicit loc: Location): Unit = target match {
           case x: BitVector                => BitVector.this.compositAssignFrom(that, RangedAssignmentFixed(BitVector.this, hi, lo), kind)
 //          case x: DontCareNode             => BitVector.this.assignFrom(that,new RangedAssignmentFixed(BitVector.this, new DontCareNodeFixed(BitVector.this, hi - lo + 1), hi, lo), true)
           case x: BitAssignmentFixed       => BitVector.this.apply(lo + x.bitId).compositAssignFrom(that, BitVector.this, kind)
@@ -383,14 +385,14 @@ abstract class BitVector extends BaseType with Widthable {
   }
 
   /** Extract a range of bits of the BitVector */
-  def newExtract(offset: UInt, size: Int, extract : BitVectorRangedAccessFloating): this.type = {
+  def newExtract(offset: UInt, size: Int, extract : BitVectorRangedAccessFloating)(implicit loc: Location): this.type = {
     if (size != 0) {
       extract.source = this
       extract.size   = size
       extract.offset = offset
       val ret = wrapWithWeakClone(extract)
       ret.compositeAssign = new Assignable {
-        override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind : AnyRef): Unit = target match {
+        override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind : AnyRef)(implicit loc: Location): Unit = target match {
           case x: BitVector                => BitVector.this.compositAssignFrom(that,RangedAssignmentFloating(BitVector.this, offset, size), kind)
 //          case x: DontCareNode             => BitVector.this.assignFrom(that,new RangedAssignmentFloating(BitVector.this, new DontCareNodeFixed(BitVector.this, size), offset, size bit), true)
           case x: BitAssignmentFixed       => BitVector.this.apply(offset + x.bitId).compositAssignFrom(that, BitVector.this, kind)

--- a/core/src/main/scala/spinal/core/Bits.scala
+++ b/core/src/main/scala/spinal/core/Bits.scala
@@ -21,6 +21,7 @@
 package spinal.core
 
 import spinal.core.internals._
+import spinal.idslplugin.Location
 
 /**
   * Bits factory used for instance by the IODirection to create a in/out Bits

--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -33,7 +33,7 @@ trait BoolFactory {
   def Bool(u: Unit = ()): Bool = new Bool
 
   /** Create a new Bool with a value */
-  def Bool(value: Boolean): Bool = BoolLiteral(value, Bool().setAsTypeNode())
+  def Bool(value: Boolean)(implicit loc: Location): Bool = BoolLiteral(value, Bool().setAsTypeNode())
 }
 
 /**

--- a/core/src/main/scala/spinal/core/Bundle.scala
+++ b/core/src/main/scala/spinal/core/Bundle.scala
@@ -22,7 +22,7 @@ package spinal.core
 
 import scala.collection.mutable.ArrayBuffer
 import spinal.core.internals._
-import spinal.idslplugin.ValCallback
+import spinal.idslplugin.{Location, ValCallback}
 
 import scala.collection.mutable
 
@@ -156,7 +156,7 @@ class Bundle extends MultiData with Nameable with ValCallbackRec {
     }
   }
 
-  private[core] override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+  private[core] override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
     that match {
       case that: Bundle =>
         if (!this.getClass.isAssignableFrom(that.getClass)) SpinalError("Bundles must have the same final class to" +

--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -22,6 +22,8 @@ package spinal.core
 
 import scala.collection.mutable.ArrayBuffer
 import spinal.core.internals._
+import spinal.idslplugin.Location
+
 import scala.collection.Seq
 
 object DataAssign
@@ -40,7 +42,7 @@ trait DataPrimitives[T <: Data]{
   def =/=(that: T): Bool = _data isNotEqualTo that
 
   /** Assign a data to this */
-  def := (that: T): Unit = _data assignFrom that
+  def := (that: T)(implicit loc: Location): Unit = _data assignFrom that
 
   /** Use as \= to have the same behavioral as VHDL variable */
   def \(that: T): T = {
@@ -83,7 +85,7 @@ trait DataPrimitives[T <: Data]{
   }
 
   /** Auto connection between two data */
-  def <>(that: T): Unit = _data autoConnect that
+  def <>(that: T)(implicit loc: Location): Unit = _data autoConnect that
 
   /** Set initial value to a data */
   def init(that: T): T = {
@@ -380,7 +382,7 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
     this
   }
 
-  final def assignFrom(that: AnyRef, target: AnyRef = this) = compositAssignFrom(that, target, DataAssign)
+  final def assignFrom(that: AnyRef, target: AnyRef = this) (implicit loc: Location)= compositAssignFrom(that, target, DataAssign)
 
   final def initFrom(that: AnyRef, target: AnyRef = this) = (that, target) match {
     case (init: Data, target: Data) if ! target.isReg =>
@@ -492,9 +494,9 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
     addTag(spinal.core.noBackendCombMerge)
   }
 
-  private[core] def autoConnect(that: Data): Unit// = (this.flatten, that.flatten).zipped.foreach(_ autoConnect _)
+  private[core] def autoConnect(that: Data)(implicit loc: Location): Unit// = (this.flatten, that.flatten).zipped.foreach(_ autoConnect _)
 
-  private[core] def autoConnectBaseImpl(that: Data): Unit = {
+  private[core] def autoConnectBaseImpl(that: Data)(implicit loc: Location): Unit = {
 
     def getTrueIoBaseType(that: Data): Data = that.getRealSource.asInstanceOf[Data]
 
@@ -740,13 +742,13 @@ trait DataWrapper extends Data{
   override def flatten: Seq[BaseType] = ???
   override def getBitsWidth: Int = ???
   override private[core] def isEqualTo(that: Any): Bool = ???
-  override private[core] def autoConnect(that: Data): Unit = ???
+  override private[core] def autoConnect(that: Data)(implicit loc: Location): Unit = ???
   override def assignFromBits(bits: Bits): Unit = ???
   override def assignFromBits(bits: Bits, hi: Int, low: Int): Unit = ???
   override def getZero: DataWrapper.this.type = ???
   override private[core] def isNotEqualTo(that: Any): Bool = ???
   override def flattenLocalName: Seq[String] = ???
-  override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = ???
+  override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = ???
   override def setAsReg(): DataWrapper.this.type = ???
   override def setAsComb(): DataWrapper.this.type = ???
   override def freeze(): DataWrapper.this.type = ???

--- a/core/src/main/scala/spinal/core/Enum.scala
+++ b/core/src/main/scala/spinal/core/Enum.scala
@@ -21,6 +21,8 @@
 package spinal.core
 
 import spinal.core.internals._
+import spinal.idslplugin.Location
+
 import scala.collection.mutable.ArrayBuffer
 
 
@@ -145,7 +147,7 @@ class SpinalEnumCraft[T <: SpinalEnum](val spinalEnum: T) extends BaseType with 
   @deprecated("Use =/= instead","???")
   def !==(that: SpinalEnumElement[T]): Bool = this =/= that
 
-  private[core] override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = that match{
+  private[core] override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = that match{
     case that : SpinalEnumCraft[T]          => super.assignFromImpl(that, target, kind)
     case that : Expression with EnumEncoded => super.assignFromImpl(that, target, kind)
     //    case that : DontCareNodeEnum => super.assignFromImpl(that, conservative)

--- a/core/src/main/scala/spinal/core/FixedPoint.scala
+++ b/core/src/main/scala/spinal/core/FixedPoint.scala
@@ -21,6 +21,7 @@
 package spinal.core
 
 import spinal.core.internals.ScopeStatement
+import spinal.idslplugin.Location
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -239,7 +240,7 @@ abstract class XFix[T <: XFix[T, R], R <: BitVector with Num[R]](val maxExp: Int
     ret
   }
 
-  override def autoConnect(that: Data): Unit = autoConnectBaseImpl(that)
+  override def autoConnect(that: Data)(implicit loc: Location): Unit = autoConnectBaseImpl(that)
 
   def truncated: this.type = {
     val copy = cloneOf(this)
@@ -259,7 +260,7 @@ abstract class XFix[T <: XFix[T, R], R <: BitVector with Num[R]](val maxExp: Int
     t
   }
 
-  override private[spinal] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+  override private[spinal] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
     that match {
       case that if this.getClass.isAssignableFrom(that.getClass) =>
         val t = that.asInstanceOf[T]

--- a/core/src/main/scala/spinal/core/Mem.scala
+++ b/core/src/main/scala/spinal/core/Mem.scala
@@ -21,6 +21,8 @@
 package spinal.core
 
 import spinal.core.internals._
+import spinal.idslplugin.Location
+
 import scala.collection.Seq
 
 trait ReadUnderWritePolicy {
@@ -222,12 +224,12 @@ class Mem[T <: Data](val wordType: HardType[T], val wordCount: Int) extends Decl
     this
   }
 
-  def apply(address: UInt): T = {
+  def apply(address: UInt)(implicit loc: Location): T = {
     val ret = readAsync(address)
     val asyncPort = dlcLast.asInstanceOf[MemReadAsync]
 
     ret.compositeAssign = new Assignable {
-      override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+      override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
         write(address, that.asInstanceOf[T])
         asyncPort.removeStatement()
         ret.flatten.foreach(_.removeAssignments())

--- a/core/src/main/scala/spinal/core/MultiData.scala
+++ b/core/src/main/scala/spinal/core/MultiData.scala
@@ -21,6 +21,7 @@
 package spinal.core
 
 import spinal.core.internals.Operator
+import spinal.idslplugin.Location
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.Seq
@@ -184,7 +185,7 @@ abstract class MultiData extends Data {
     }
   }
 
-  private[core] override def autoConnect(that: Data): Unit = {
+  private[core] override def autoConnect(that: Data)(implicit loc: Location): Unit = {
     that match {
       case that: MultiData => zippedMap(that, _ autoConnect _)
       case _               => SpinalError(s"Function autoConnect is not implemented between $this and $that")

--- a/core/src/main/scala/spinal/core/SInt.scala
+++ b/core/src/main/scala/spinal/core/SInt.scala
@@ -21,6 +21,7 @@
 package spinal.core
 
 import spinal.core.internals._
+import spinal.idslplugin.Location
 
 /**
   * SInt factory used for instance by the IODirection to create a in/out SInt

--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -149,6 +149,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         anonymSignalUniqueness         : Boolean = false,
                         inlineConditionalExpression    : Boolean = false,
                         nameWhenByFile                 : Boolean = true,
+                        var genLineComments            : Boolean = true,
                         noRandBoot                     : Boolean = false,
                         randBootFixValue               : Boolean = true,
                         noAssert                       : Boolean = false,
@@ -163,8 +164,8 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         rtlHeader                      : String = null,
                         scopeProperties                : mutable.LinkedHashMap[ScopeProperty[_], Any] = mutable.LinkedHashMap[ScopeProperty[_], Any](),
                         private [core] var _withEnumString : Boolean = true,
-                        var enumPrefixEnable                 : Boolean = true,
-                        var enumGlobalEnable                 : Boolean = false,
+                        var enumPrefixEnable           : Boolean = true,
+                        var enumGlobalEnable           : Boolean = false,
                         bitVectorWidthMax              : Int = 4096
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)
@@ -223,6 +224,15 @@ case class SpinalConfig(mode                           : SpinalMode = null,
 
   def withGlobalEnum: this.type ={
     enumGlobalEnable = true
+    this
+  }
+
+  def withoutLineComment: this.type = {
+    genLineComments = false
+    this
+  }
+  def withLineComment: this.type = {
+    genLineComments = true
     this
   }
 }

--- a/core/src/main/scala/spinal/core/Struct.scala
+++ b/core/src/main/scala/spinal/core/Struct.scala
@@ -1,7 +1,7 @@
 package spinal.core
 
 import spinal.core.internals.{Suffixable, TypeStruct}
-import spinal.idslplugin.ValCallback
+import spinal.idslplugin.{Location, ValCallback}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -157,7 +157,7 @@ abstract class SpinalStruct(val typeName: String = null) extends BaseType with N
     }
   }
 
-  private[core] override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+  private[core] override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
     that match {
       case that: SpinalStruct =>
         if (!this.getClass.isAssignableFrom(that.getClass)) SpinalError("Structs must have the same final class to" +
@@ -181,7 +181,7 @@ abstract class SpinalStruct(val typeName: String = null) extends BaseType with N
     }
   }
 
-  private[core] override def autoConnect(that: Data): Unit = {
+  private[core] override def autoConnect(that: Data)(implicit loc: Location): Unit = {
     that match {
       case that: SpinalStruct => {
         this autoConnectBaseImpl that

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -27,6 +27,7 @@ import spinal.core.fiber.Handle
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, Stack}
 import spinal.core.internals._
+import spinal.idslplugin.Location
 
 trait DummyTrait
 object DummyObject extends DummyTrait
@@ -261,7 +262,7 @@ trait NameableByComponent extends Nameable with GlobalDataUser {
 trait Assignable {
   /* private[core] */var compositeAssign: Assignable = null
 
-  /*private[core] */final def compositAssignFrom(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+  /*private[core] */final def compositAssignFrom(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
     if (compositeAssign != null) {
       compositeAssign.compositAssignFrom(that, target, kind)
     } else {
@@ -269,7 +270,7 @@ trait Assignable {
     }
   }
 
-  private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit
+  private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit
 
   def getRealSourceNoRec: Any
 

--- a/core/src/main/scala/spinal/core/UInt.scala
+++ b/core/src/main/scala/spinal/core/UInt.scala
@@ -21,6 +21,7 @@
 package spinal.core
 
 import spinal.core.internals._
+import spinal.idslplugin.Location
 
 import scala.collection.mutable.ArrayBuffer
 

--- a/core/src/main/scala/spinal/core/Vec.scala
+++ b/core/src/main/scala/spinal/core/Vec.scala
@@ -21,6 +21,7 @@
 package spinal.core
 
 import spinal.core.internals.{BitAssignmentFixed, BitAssignmentFloating, BitVectorAssignmentExpression, RangedAssignmentFixed, RangedAssignmentFloating}
+import spinal.idslplugin.Location
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -69,7 +70,7 @@ trait VecFactory {
 
 class VecAccessAssign[T <: Data](enables: Seq[Bool], tos: Seq[BaseType], vec: Vec[T]) extends Assignable {
 
-  override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+  override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
     for ((enable, to) <- (enables, tos).zipped) {
       when(enable) {
         val thatSafe = that /*match {
@@ -261,7 +262,7 @@ class Vec[T <: Data](var _dataType : HardType[T], val vec: Vector[T]) extends Mu
     }
 
     ret.compositeAssign = new Assignable {
-      override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+      override private[core] def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
         for ((e, idx) <- vec.zipWithIndex) {
           when(oneHot(idx)) {
             e.compositAssignFrom(that, target,kind)
@@ -274,7 +275,7 @@ class Vec[T <: Data](var _dataType : HardType[T], val vec: Vector[T]) extends Mu
     ret
   }
 
-  private[core] override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+  private[core] override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
     that match {
       case that: Vec[T] =>
         if (that.vec.size != this.vec.size) throw new Exception("Can't assign Vec with a different size")

--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -230,8 +230,8 @@ package object core extends BaseTypeFactory with BaseTypeCast {
   /**
     * True / False definition
     */
-  def True  = Bool(true)
-  def False = Bool(false)
+  def True(implicit loc: Location)  = Bool(true)
+  def False(implicit loc: Location) = Bool(false)
 
 
   /**

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -582,6 +582,8 @@ class ComponentEmitterVerilog(
     length.toString + "'d" + str
   }
 
+  def emitLocation(that : AssignmentStatement) : String = if(that.locationString != null) " // " + that.locationString else ""
+
   def emitAsynchronousAsAsign(process: AsyncProcess) = process.leafStatements.size == 1 && process.leafStatements.head.parentScope == process.nameableTargets.head.rootScopeStatement
 
   def emitAsynchronous(process: AsyncProcess): Unit = {
@@ -590,7 +592,7 @@ class ComponentEmitterVerilog(
         process.leafStatements.head match {
           case s: AssignmentStatement =>
             if (!s.target.isInstanceOf[Suffixable]) {
-              logics ++= s"  assign ${emitAssignedExpression(s.target)} = ${emitExpression(s.source)};\n"
+              logics ++= s"  assign ${emitAssignedExpression(s.target)} = ${emitExpression(s.source)};${emitLocation(s)}\n"
             }
         }
       case _ =>
@@ -655,7 +657,7 @@ class ComponentEmitterVerilog(
         closeSubs()
 
         statement match {
-          case assignment: AssignmentStatement  => b ++= s"${tab}${emitAssignedExpression(assignment.target)} ${assignmentKind} ${emitExpression(assignment.source)};\n"
+          case assignment: AssignmentStatement  => b ++= s"${tab}${emitAssignedExpression(assignment.target)} ${assignmentKind} ${emitExpression(assignment.source)};${emitLocation(assignment)}\n"
           case assertStatement: AssertStatement => {
             val cond = emitExpression(assertStatement.cond)
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -109,6 +109,7 @@ class ComponentEmitterVhdl(
         portMaps += s"${baseType.getName()} : ${emitDirection(baseType)} ${emitDataType(baseType)}${getBaseTypeSignalInitialisation(baseType)}"
     )
   }
+  def emitLocation(that : AssignmentStatement) : String = if(that.locationString != null) " --" + that.locationString else ""
 
   override def wrapSubInput(io: BaseType): Unit = {
     if (referencesOverrides.contains(io))
@@ -715,7 +716,7 @@ class ComponentEmitterVhdl(
     assignment match {
       case _ =>
         if (!assignment.target.isInstanceOf[SpinalStruct])
-          s"$tab${emitAssignedExpression(assignment.target)} ${assignmentKind} ${emitExpression(assignment.source)};\n"
+          s"$tab${emitAssignedExpression(assignment.target)} ${assignmentKind} ${emitExpression(assignment.source)};${emitLocation(assignment)}\n"
         else
           ""
     }

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -21,6 +21,7 @@
 package spinal.core.internals
 
 import spinal.core._
+import spinal.idslplugin.Location
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -2483,7 +2484,7 @@ class SIntLiteral extends BitVectorLiteral{
   * Bool literal
   */
 object BoolLiteral {
-  def apply(value: Boolean, on: Bool): Bool = {
+  def apply(value: Boolean, on: Bool)(implicit loc: Location): Bool = {
     on.assignFrom(new BoolLiteral(value))
     on
   }

--- a/core/src/main/scala/spinal/core/internals/Statement.scala
+++ b/core/src/main/scala/spinal/core/internals/Statement.scala
@@ -321,7 +321,7 @@ abstract class AssignmentStatement extends LeafStatement with StatementDoubleLin
   var locationString : String = null
 
   def setLocation(loc : Location): this.type ={
-    if(globalData.config.genLineComments) locationString = s"${loc.file}.scala l${loc.line}"
+    if(globalData.config.genLineComments) locationString = s"@[${loc.file}.scala ${loc.line}:${loc.col}]"
     this
   }
 

--- a/core/src/main/scala/spinal/core/internals/Statement.scala
+++ b/core/src/main/scala/spinal/core/internals/Statement.scala
@@ -321,7 +321,7 @@ abstract class AssignmentStatement extends LeafStatement with StatementDoubleLin
   var locationString : String = null
 
   def setLocation(loc : Location): this.type ={
-    locationString = s"${loc.file}.scala l${loc.line}"
+    if(globalData.config.genLineComments) locationString = s"${loc.file}.scala l${loc.line}"
     this
   }
 

--- a/core/src/main/scala/spinal/core/internals/Statement.scala
+++ b/core/src/main/scala/spinal/core/internals/Statement.scala
@@ -318,6 +318,12 @@ object AssignmentStatement{
 
 abstract class AssignmentStatement extends LeafStatement with StatementDoubleLinkedContainerElement[BaseType, AssignmentStatement]{
   var target, source: Expression = null
+  var locationString : String = null
+
+  def setLocation(loc : Location): this.type ={
+    locationString = s"${loc.file}.scala l${loc.line}"
+    this
+  }
 
   override def rootScopeStatement = finalTarget.rootScopeStatement
 

--- a/idslpayload/src/main/scala/spinal/idslplugin/Macro.scala
+++ b/idslpayload/src/main/scala/spinal/idslplugin/Macro.scala
@@ -5,7 +5,7 @@ import scala.reflect.macros.blackbox.Context
 
 
 
-class Location(val file : String, val line: Int)
+class Location(val file : String, val line: Int, val col : Int)
 
 object Location {
   implicit def capture: Location = macro locationMacro
@@ -15,10 +15,11 @@ object Location {
 
 //    val className = Option(x.enclosingClass).map(_.symbol.toString).getOrElse("")
 //    val methodName = Option(x.enclosingMethod).map(_.symbol.toString).getOrElse("")
-    val pos = x.enclosingPosition
+    val pos  = x.enclosingPosition
     val line =  pos.line
+    val col  =  pos.column
     val file =  pos.source.toString().replace(".scala", "")
 //    val where = s"${line}"
-    reify(new Location(x.literal(file).splice, x.literal(line).splice))
+    reify(new Location(x.literal(file).splice, x.literal(line).splice, x.literal(col).splice))
   }
 }

--- a/lib/src/main/scala/spinal/lib/io/TriState.scala
+++ b/lib/src/main/scala/spinal/lib/io/TriState.scala
@@ -1,6 +1,7 @@
 package spinal.lib.io
 
 import spinal.core._
+import spinal.idslplugin.Location
 import spinal.lib.IMasterSlave
 
 case class TriState[T <: Data](dataType : HardType[T]) extends Bundle with IMasterSlave{
@@ -51,7 +52,7 @@ case class TriStateArray(width : Int) extends Bundle with IMasterSlave{
     //Define a fonction which redirect write access of a userSignal to another signal
     def writePatch(userSignal : BaseType, realSignal : BaseType) : Unit = {
       userSignal.compositeAssign = new Assignable {
-        override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = that match {
+        override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = that match {
           case that: BaseType => realSignal.compositAssignFrom(that, realSignal, kind)
         }
         override def getRealSourceNoRec: BaseType = userSignal

--- a/tester/src/test/scala/spinal/tester/code/Debug.scala
+++ b/tester/src/test/scala/spinal/tester/code/Debug.scala
@@ -188,15 +188,19 @@ object Tesasdadt {
 object Debug2 extends App{
 
   def gen = new Component{
-    val x = False
+    val x = True
+    val y = False
     when(True){
-      x := True
+      y := True
     }
-    val y = True
 
     val a,b,c = UInt(8 bits)
     c := a + b + 1
 
+    val src = in Bool()
+    val dst = Bool()
+
+    src <> dst
 
 //    val io = new Bundle {
 //      val i = in Bits (5 bits)

--- a/tester/src/test/scala/spinal/tester/code/Debug.scala
+++ b/tester/src/test/scala/spinal/tester/code/Debug.scala
@@ -9,6 +9,7 @@ import spinal.core.fiber.Handle
 import spinal.core.internals.Operator
 import spinal.lib._
 import spinal.core.sim._
+import spinal.idslplugin.Location
 import spinal.lib.bus.amba4.axilite.AxiLite4
 import spinal.lib.eda.bench.{Bench, Rtl, XilinxStdTargets}
 import spinal.lib.fsm._
@@ -186,22 +187,30 @@ object Tesasdadt {
 
 object Debug2 extends App{
 
-
-  SpinalConfig(allowOutOfRangeLiterals = false).includeFormal.generateSystemVerilog(new Component{
-
-    val io = new Bundle {
-      val i = in Bits (5 bits)
-      val o = out Bits (3 bits)
+  def gen = new Component{
+    val x = False
+    when(True){
+      x := True
     }
+    val y = True
 
-    switch(io.i) {
-      is(M"----1") { io.o := 0 }
-      is(M"---1-") { io.o := 1 }
-      is(M"--1--") { io.o := 2 }
-      is(M"-1---") { io.o := 3 }
-      is(M"1----") { io.o := 4 }
-      default{ io.o.assignDontCare()}
-    }
+    val a,b,c = UInt(8 bits)
+    c := a + b + 1
+
+
+//    val io = new Bundle {
+//      val i = in Bits (5 bits)
+//      val o = out Bits (3 bits)
+//    }
+//
+//    switch(io.i) {
+//      is(M"----1") { io.o := 0 }
+//      is(M"---1-") { io.o := 1 }
+//      is(M"--1--") { io.o := 2 }
+//      is(M"-1---") { io.o := 3 }
+//      is(M"1----") { io.o := 4 }
+//      default{ io.o.assignDontCare()}
+//    }
 
 //    val input = in(AFix.SQ(8 bit, 8 bit))
 //    val i = AFix.SQ(8 bit, 8 bit)
@@ -384,8 +393,10 @@ object Debug2 extends App{
 //    }
 
     setDefinitionName("miaou")
-  })
+  }
 
+  SpinalConfig(allowOutOfRangeLiterals = false).includeFormal.generateSystemVerilog(gen)
+  SpinalConfig(allowOutOfRangeLiterals = false).includeFormal.generateVhdl(gen)
 }
 
 //object MyEnum extends  spinal.core.MacroTest.mkObject("asd")
@@ -1147,7 +1158,7 @@ object PlayPackedData extends App{
       ret
     }
 
-    override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef): Unit = {
+    override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = {
       that match {
         case that: PackedData[_] =>
           ???

--- a/tester/src/test/scala/spinal/tester/scalatest/VVerilatorCacheTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/VVerilatorCacheTester.scala
@@ -11,7 +11,7 @@ import spinal.lib.Delay
 import java.io.PrintStream
 
 
-object VerilatorCacheTester {
+object VVerilatorCacheTester {
   case class ComponentA(n: Int, x: BigInt) extends Component {
     val io = new Bundle {
       val x = out Bits(n bits)
@@ -74,8 +74,8 @@ object VerilatorCacheTester {
   }
 }
 
-class VerilatorCacheTester extends AnyFunSuite {
-  import VerilatorCacheTester._
+class VVerilatorCacheTester extends AnyFunSuite {
+  import VVerilatorCacheTester._
 
   val cacheDir = new File(SimConfig._workspacePath + "/.cache_cachetest")
 

--- a/tester/src/test/scala/spinal/tester/scalatest/VerilatorCacheTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/VerilatorCacheTester.scala
@@ -11,7 +11,7 @@ import spinal.lib.Delay
 import java.io.PrintStream
 
 
-object VVerilatorCacheTester {
+object VerilatorCacheTester {
   case class ComponentA(n: Int, x: BigInt) extends Component {
     val io = new Bundle {
       val x = out Bits(n bits)
@@ -74,8 +74,8 @@ object VVerilatorCacheTester {
   }
 }
 
-class VVerilatorCacheTester extends AnyFunSuite {
-  import VVerilatorCacheTester._
+class VerilatorCacheTester extends AnyFunSuite {
+  import VerilatorCacheTester._
 
   val cacheDir = new File(SimConfig._workspacePath + "/.cache_cachetest")
 


### PR DESCRIPTION
# Context, Motivation & Description

Add Vhdl/Verilog assignements comments to traceback to the original Scala code : 

```scala
    val x = True
    val y = False
    when(True){
      y := True
    }

    val a,b,c = UInt(8 bits)
    c := a + b + 1

    val src = in Bool()
    val dst = Bool()

    src <> dst
```

```verilog
module miaou (
  input               src
);

  wire       [7:0]    _zz_c;
  wire                x;
  reg                 y;
  wire                when_Debug_l193;
  wire       [7:0]    a;
  wire       [7:0]    b;
  wire       [7:0]    c;
  wire                dst;

  assign _zz_c = (a + b);
  assign x = 1'b1; // Debug.scala l191
  always @(*) begin
    y = 1'b0; // Debug.scala l192
    if(when_Debug_l193) begin
      y = 1'b1; // Debug.scala l194
    end
  end

  assign when_Debug_l193 = 1'b1; // Debug.scala l193
  assign c = (_zz_c + 8'h01); // Debug.scala l198
  assign dst = src; // Debug.scala l203

endmodule
```

# Impact on code generation

Lot of comments everywhere on my screen
