### PR TITLE
Make APB3CCToggle sensitive to PSEL

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba3/apb/Apb3CCToggle.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/apb/Apb3CCToggle.scala
@@ -36,8 +36,9 @@ import spinal.lib.fsm._
   * @param busConfig  Apb3 configuration
   * @param inClk      Input Clock Domain
   * @param outClk     Output Clock Domain
+  * @param selIds     Sequence indicating to which PSEL(x) signals the component replies to.
   */
-class Apb3CCToggle(busConfig: Apb3Config, inClk: ClockDomain, outClk: ClockDomain) extends Component {
+class Apb3CCToggle(busConfig: Apb3Config, inClk: ClockDomain, outClk: ClockDomain, selIds: Seq[Int] = Seq(0)) extends Component {
 
   val io = new Bundle{
     val input  = slave(Apb3(busConfig))
@@ -67,7 +68,8 @@ class Apb3CCToggle(busConfig: Apb3Config, inClk: ClockDomain, outClk: ClockDomai
 
       val sIdle: State = new State with EntryPoint{
         whenIsActive{
-          when(io.input.PENABLE && hit === target){
+          val selHit = selIds.map(io.input.PSEL(_)).reduce(_||_)
+          when(io.input.PENABLE && selHit && hit === target){
             target := !target
             goto(sAccess)
           }

--- a/tester/src/test/scala/spinal/tester/scalatest/PR990TesterDut.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/PR990TesterDut.scala
@@ -1,0 +1,73 @@
+package spinal.tester.scalatest
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config, Apb3Decoder, Apb3SlaveFactory}
+
+class PR990TesterDut extends Component {
+    val io = new Bundle {
+        val apb = slave(Apb3(Apb3Config(16, 32)))
+
+        val otherclk = in(Bool())
+    }
+
+    val ourApb = Apb3(Apb3Config(12, 32))
+    Apb3SlaveFactory(ourApb).read(U(0xcafe), 0)
+
+    val otherCd = ClockDomain(io.otherclk, reset=ClockDomain.current.reset)
+    val otherarea = new ClockingArea(otherCd) {
+        val bus = Apb3(Apb3Config(12, 32))
+        Apb3SlaveFactory(bus).read(U(0xbeef), 0)
+    }
+
+    val otherInputApb = Apb3(Apb3Config(12, 32))
+    otherInputApb.crossClockDomainToggle(ClockDomain.current, otherCd) >> otherarea.bus
+
+    Apb3Decoder(
+        master = io.apb,
+        Seq(
+            ourApb -> (0x0000, 4 KiB),
+            otherInputApb -> (0x1000, 4 KiB)
+        )
+    )
+}
+
+class PR990Tester extends SpinalSimFunSuite {
+    test("ccexercise") {
+        val sim =SpinalSimConfig().allOptimisation.compile(new PR990TesterDut)
+        sim.doSimUntilVoid("ccexercise") { dut =>
+            val mainCd = dut.clockDomain
+            val otherCd = dut.otherCd
+            mainCd.forkStimulus(10)
+            otherCd.forkStimulus(17)
+
+            val apb = new Apb3Driver(dut.io.apb, mainCd)
+
+            mainCd.waitSampling()
+
+            /**
+              * This is a regression test for PR 990. The first read will trigger
+              * the unfixed Apb3CCToggle to perform a transaction on the output side.
+              *
+              * The second read is to prime PRDATA with data that is wrong.
+              *
+              * The third read will be terminated too early because the CDC is now
+              * ready with the read data for the first transaction. Since we primed
+              * PRDATA, the pattern will not be the expected 0xbeef.
+              *
+              * With the fix, the tests should pass.
+              */
+
+            assert(apb.read(0x0000) == 0xcafe)
+            apb.read(0x0004)
+            mainCd.waitSampling(11)
+            assert(apb.read(0x1000) == 0xbeef)
+
+            mainCd.waitSampling(10)
+
+            simSuccess()
+        }
+    }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

`Apb3CCToggle` does not consider the `PSEL` signal. The internal state machine is activated by bus traffic for other slaves. Under the right timing conditions this can lead to the input side of the CDC replying to transactions too early, giving wrong read data.

The fix is to make `Apb3CCToggle` look at the `PSEL` signal before performing work. 

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

None, except for slightly changed component logic.
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added 
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
