### PR TITLE
feat: add comparison operators to PhysicalNumber

### DIFF
--- a/core/src/main/scala/spinal/core/Units.scala
+++ b/core/src/main/scala/spinal/core/Units.scala
@@ -80,7 +80,14 @@ abstract class PhysicalNumber[T <: PhysicalNumber[_]](protected val value: BigDe
   def /(that: BigDecimal) = newInstance(this.value / that)
   def %(that: BigDecimal) = newInstance(this.value % that)
 
-  def max(that: T) = newInstance(value.max(that.value))
+  def <(that: T): Boolean = this.value < that.value
+  def <=(that: T): Boolean = this.value <= that.value
+  def >(that: T): Boolean = this.value > that.value
+  def >=(that: T): Boolean = this.value >= that.value
+
+  def abs: T = newInstance(this.value.abs)
+  def max(that: T): T = newInstance(this.value.max(that.value))
+  def min(that: T): T = newInstance(this.value.min(that.value))
 
   def toInt        = value.toInt
   def toLong       = value.toLong

--- a/core/src/test/scala/spinal/core/PhysicalNumbers.scala
+++ b/core/src/test/scala/spinal/core/PhysicalNumbers.scala
@@ -1,0 +1,37 @@
+package spinal.core
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PhysicalNumbers extends AnyFunSuite {
+  val hz100 = 100 Hz
+  val hz100_2 = 100 Hz
+  val hz200 = 200 Hz
+  val ms2 = 100 sec
+
+  test("Comparisons") {
+    assert(hz100 == hz100)
+    assert(hz100 == hz100_2)
+    assert(hz100_2 == hz100)
+    assert(hz100 != hz200)
+    assert(hz200 != ms2)
+    assert(hz100 != null)
+
+    assert(hz100 < hz200)
+    assert(!(hz200 < hz100))
+    assert(!(hz100 < hz100_2))
+
+    assert(hz200 > hz100)
+    assert(!(hz100 > hz200))
+    assert(!(hz100 < hz100_2))
+
+    assert(hz100 <= hz200)
+    assert(hz100 <= hz100_2)
+    assert(!(hz200 <= hz100))
+
+    assert(hz100 >= hz100_2)
+    assert(hz200 >= hz100)
+    assert(!(hz100 >= hz200))
+
+    assert(hz100.hashCode() == hz100_2.hashCode())
+  }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

In code for checking frequencies/times are in range, e.g. for calculating&checking PLL parameters it's much more readable when PhysicalNumbers can be compared directly and with units, instead of having to go through `toBigDecimal`.

```
assert(fdiv_freq < 420MHz)
//vs
assert(fdiv_freq.toBigDecimal < 420000000L)
``` 

# Impact on code generation

None

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
