### PR TITLE
Use match-case when computing GHDL time flag

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -271,8 +271,9 @@ object SpinalGhdlBackend {
   def apply[T <: Component](config: SpinalGhdlBackendConfig[T]) : Backend = {
     val vconfig = new GhdlBackendConfig()
     vconfig.analyzeFlags = config.simulatorFlags.mkString(" ")
-    if (config.timePrecision != null) {
-      vconfig.elaborationFlags = s"--time-resolution=${config.timePrecision.decompose._2}"
+    config.timePrecision match {
+      case null =>
+      case t => vconfig.elaborationFlags = s"--time-resolution=${t.decompose._2}"
     }
     vconfig.runFlags = config.simulatorFlags.mkString(" ")
     vconfig.logSimProcess = config.enableLogging


### PR DESCRIPTION


# Context, Motivation & Description

Formatting match to other simulator time checks. Avoids using `!=` operator.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

None.
