### PR TITLE
AxiLite4: Add read only and write only driver classes

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axilite/sim/AxiLite4Driver.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axilite/sim/AxiLite4Driver.scala
@@ -2,8 +2,9 @@ package spinal.lib.bus.amba4.axilite.sim
 
 import spinal.core._
 import spinal.core.sim._
+import spinal.lib.Stream
 import spinal.lib.bus.amba4.axilite._
-import spinal.lib.sim.StreamDriver
+import spinal.lib.sim.{StreamDriver, StreamMonitor, StreamReadyRandomizer}
 
 import scala.collection.mutable
 
@@ -86,4 +87,86 @@ case class AxiLite4Driver(axi : AxiLite4, clockDomain : ClockDomain) {
     clockDomain.waitSamplingWhere(wQueue.isEmpty && awQueue.isEmpty)
     clockDomain.waitSamplingWhere(axi.b.ready.toBoolean && axi.b.valid.toBoolean)
   }
+}
+
+class AxiLite4ReadOnlySlaveAgent(ar: Stream[AxiLite4Ax], r: Stream[AxiLite4R], clockDomain: ClockDomain) {
+
+  val busConfig = ar.config
+
+  val arQueueDepth = 1
+
+  def doRead(addr: BigInt): Unit = {
+    r.payload.data.randomize()
+
+    val aligned = (addr & busConfig.bytePerWord-1) == 0
+    if (aligned) {
+      r.payload.resp #= 0
+    } else {
+      r.payload.resp #= 2
+    }
+  }
+
+  var arQueue = mutable.Queue[BigInt]()
+
+  val arMonitor = StreamMonitor(ar, clockDomain){_ =>
+    val beatAddr = ar.addr.toBigInt
+
+    arQueue += beatAddr
+  }
+
+  val rDriver = StreamDriver(r, clockDomain){_ =>
+    if (arQueue.nonEmpty) {
+      doRead(arQueue.dequeue())
+      true
+    } else {
+      false
+    }
+  }
+
+  val arRandomizer = StreamReadyRandomizer(ar, clockDomain, () => arQueue.size < arQueueDepth)
+}
+
+class AxiLite4WriteOnlySlaveAgent(aw: Stream[AxiLite4Ax], w: Stream[AxiLite4W], b: Stream[AxiLite4B], clockDomain: ClockDomain) {
+
+  val busConfig = aw.config
+
+  val awQueueDepth = 1
+
+  val awQueue = mutable.Queue[BigInt]()
+  val wQueue = mutable.Queue[(BigInt, BigInt)]()
+
+  def onWrite(addr: BigInt, data: BigInt, strb: BigInt): Unit = {
+    val aligned = (addr & busConfig.bytePerWord - 1) == 0
+    if (aligned) {
+      b.payload.resp #= 0
+    } else {
+      b.payload.resp #= 2
+    }
+  }
+
+  val awMonitor = StreamMonitor(aw, clockDomain) { _ =>
+    val beatAddr = aw.addr.toBigInt
+
+    awQueue += beatAddr
+  }
+
+  val wMonitor = StreamMonitor(w, clockDomain) { _ =>
+    val strb = w.strb.toBigInt
+    val data = w.data.toBigInt
+    wQueue += ((data, strb))
+  }
+
+  val bDriver = StreamDriver(b, clockDomain){_ =>
+    if (awQueue.nonEmpty && wQueue.nonEmpty) {
+      val addr = awQueue.dequeue()
+      val (data, resp) = wQueue.dequeue()
+      onWrite(addr, data, resp)
+      true
+    } else {
+      false
+    }
+  }
+
+  val awRandomizer = StreamReadyRandomizer(aw, clockDomain, () => awQueue.size < awQueueDepth)
+  val wRandomizer = StreamReadyRandomizer(w, clockDomain)
 }


### PR DESCRIPTION
# Context, Motivation & Description

Add drivers for AxiLite4 read only and write only channels.  These are designed to replicate some of the features the Axi4 sim drivers have. This supports future Axi to AxiLite4 tests.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
