### PR TITLE
Add ethernet udp tx/rx module

### DIFF
--- a/lib/src/main/scala/spinal/lib/ethernet/Axi4StreamConditionalJoin.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/Axi4StreamConditionalJoin.scala
@@ -1,0 +1,42 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import spinal.lib.Stream
+import spinal.lib.bus.amba4.axis.Axi4Stream.Axi4StreamBundle
+
+object Axi4StreamConditionalJoin {
+
+  /** Convert a tuple of streams into a stream of tuples
+    * source stream1 has higher priority
+    */
+  def apply[T1 <: Axi4StreamBundle, T2 <: Axi4StreamBundle](
+      source1: Stream[T1],
+      source2: Stream[T2],
+      source1Select: Bool,
+      source2Select: Bool
+  ): Stream[TupleBundle2[T1, T2]] = {
+    val sources = Seq(source1, source2)
+    val combined = Stream(
+      TupleBundle2(
+        source1.payloadType,
+        source2.payloadType
+      )
+    )
+    combined.valid := (sources(0).valid && sources(1).valid) |
+      ((source1Select) && sources(0).valid)
+    sources(0).ready := combined.fire
+    sources(1).ready := source2Select & combined.fire
+    //    if (useKeep/useLast/useUser)
+    combined.payload._1.keep := source1.fire ? source1.payload.keep | 0
+    combined.payload._2.keep := source2.fire ? source2.payload.keep | 0
+    if (source1.user != null & source2.user != null) {
+      combined.payload._1.user := source1.fire ? source1.payload.user | 0
+      combined.payload._2.user := source2.fire ? source2.payload.user | 0
+    }
+    combined.payload._1.data := source1.fire ? source1.payload.data | 0
+    combined.payload._2.data := source2.fire ? source2.payload.data | 0
+    combined.payload._1.last := source1.fire ? source1.payload.last | False
+    combined.payload._2.last := source2.fire ? source2.payload.last | False
+    combined
+  }
+}

--- a/lib/src/main/scala/spinal/lib/ethernet/EthernetHeader.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/EthernetHeader.scala
@@ -1,0 +1,47 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import EthernetProtocolConstant._
+import scala.collection.mutable
+
+object EthernetHeader {
+  def apply(array: Array[Bits]): Array[Bits] = {
+    val gen = new EthernetHeader
+    require(
+      array.length == gen.header.length,
+      s"Initializing parameters not enough! Require ${gen.header.length} but gave ${array.length}"
+    )
+    gen.header.zipWithIndex.foreach { case (data, idx) =>
+      data := array(idx)
+    }
+    gen.header
+  }
+
+  def unapply(header: Bits): (Array[String], Array[Bits]) = {
+    val gen = new EthernetHeader
+    val bitWidth = gen.frameFieldInit.values.sum
+    require(
+      bitWidth == header.getWidth,
+      s"Initializing parameters not enough! Require ${bitWidth} but gave ${header.getWidth}"
+    )
+    val asLittleEnd = header.subdivideIn(bitWidth / 8 slices).reduce(_ ## _)
+    val tmp = asLittleEnd
+      .sliceBy(gen.frameFieldInit.values.toList.reverse)
+      .reverse
+      .toArray
+    gen.header.zipWithIndex.foreach { case (data, idx) =>
+      data := tmp(idx)
+    }
+    (gen.frameFieldInit.keys.toArray, gen.header)
+  }
+}
+
+case class EthernetHeader() extends FrameHeader {
+  val frameFieldInit = mutable.LinkedHashMap(
+    "dstMAC" -> MAC_ADDR_WIDTH,
+    "srcMAC" -> MAC_ADDR_WIDTH,
+    "ethType" -> ETH_TYPE_WIDTH
+  )
+  val header: Array[Bits] =
+    EthernetProtocolHeaderConstructor(frameFieldInit).constructHeader()
+}

--- a/lib/src/main/scala/spinal/lib/ethernet/HeaderGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/HeaderGenerator.scala
@@ -1,0 +1,243 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.amba4.axis.{Axi4Stream, Axi4StreamConfig}
+import spinal.lib.ethernet.EthernetProtocolConstant._
+
+case class HeaderGeneratorGenerics(
+    DATA_WIDTH: Int = DATA_WIDTH,
+    DATA_BYTE_CNT: Int = DATA_BYTE_CNT,
+    DATA_USE_TLAST: Boolean = true,
+    DATA_USE_TUSER: Boolean = true,
+    DATA_USE_TKEEP: Boolean = true,
+    DATA_USE_TSTRB: Boolean = false,
+    DATA_TUSER_WIDTH: Int = 1,
+    INPUT_BUFFER_DEPTH: Int = 4
+)
+class HeaderGenerator(
+    HeaderGeneratorConfig: HeaderGeneratorGenerics
+//    arpCacheConfig: ArpCacheGenerics
+) extends Component {
+  val headerAxisOutConfig = Axi4StreamConfig(
+    dataWidth = HeaderGeneratorConfig.DATA_BYTE_CNT,
+    userWidth = HeaderGeneratorConfig.DATA_TUSER_WIDTH,
+    useKeep = HeaderGeneratorConfig.DATA_USE_TKEEP,
+    useLast = HeaderGeneratorConfig.DATA_USE_TLAST,
+    useUser = HeaderGeneratorConfig.DATA_USE_TUSER
+  )
+  val io = new Bundle {
+    val metaIn = slave Stream MetaInterface()
+
+    val headerAxisOut = master(Axi4Stream(headerAxisOutConfig))
+  }
+  val ipLenReg = Reg(UInt(IP_LENGTH_WIDTH bits)) init 0
+  val udpLenReg = Reg(UInt(UDP_LENGTH_WIDTH bits)) init 0
+  val ipIdReg = Reg(UInt(IDENTIFICATION_WIDTH bits)) init 0
+  val ipChecksumReg = Reg(UInt(IP_HEADER_CHECKSUM_WIDTH bits)) init 0
+  val generateDone = Bool()
+
+  val packetLenMax =
+    ((MTU + ETH_HEADER_LENGTH) / DATA_BYTE_CNT.toFloat).ceil.toInt
+  val packetLen = Reg(UInt(log2Up(packetLenMax) bits)) init 0
+
+  val dataLoaded = Reg(Bool()) init False
+  val metaRegs = Reg(MetaInterface())
+
+  val sendHeaderCycle = (HEADER_TOTAL_LENGTH / DATA_BYTE_CNT.toFloat).ceil.toInt
+  val sendHeaderLastLeft = HEADER_TOTAL_LENGTH % DATA_BYTE_CNT
+  val sendingCnt = Counter(sendHeaderCycle)
+  val needFragment = Reg(Bool()) init False
+
+  val metaSetValid = !dataLoaded | generateDone
+  io.metaIn.ready := True & metaSetValid
+  when(io.metaIn.fire) {
+    dataLoaded := True
+  } elsewhen (generateDone) {
+    dataLoaded := False
+  }
+
+  when(io.metaIn.fire) {
+    metaRegs.srcPort := io.metaIn.srcPort
+    metaRegs.dstPort := io.metaIn.dstPort
+    metaRegs.IpAddr := io.metaIn.IpAddr
+    metaRegs.MacAddr := io.metaIn.MacAddr
+    when(io.metaIn.dataLen > MAX_DATA_NUM) {
+      metaRegs.dataLen := io.metaIn.dataLen - (MTU - IP_HEADER_LENGTH - UDP_HEADER_LENGTH)
+      needFragment := True
+      ipLenReg := IP_LENGTH_MAX
+      udpLenReg := UDP_LENGTH_MAX
+      packetLen := packetLenMax - 1
+    } otherwise {
+      needFragment := False
+      ipLenReg := io.metaIn.dataLen.resize(
+        IP_LENGTH_WIDTH
+      ) + IP_HEADER_LENGTH + UDP_HEADER_LENGTH
+      udpLenReg := io.metaIn.dataLen.resize(IP_LENGTH_WIDTH) + UDP_HEADER_LENGTH
+      packetLen := ((((io.metaIn.dataLen + HEADER_TOTAL_LENGTH) % HeaderGeneratorConfig.DATA_BYTE_CNT) =/= 0) ? U(
+        1,
+        log2Up(packetLenMax) bits
+      ) | U(
+        0,
+        log2Up(packetLenMax) bits
+      )) + ((io.metaIn.dataLen + HEADER_TOTAL_LENGTH) >> 5)
+        .takeLow(log2Up(packetLenMax))
+        .asUInt - 1
+    }
+  } elsewhen (io.headerAxisOut.lastFire & needFragment) {
+    when(metaRegs.dataLen > MAX_DATA_NUM) {
+      needFragment := True
+      ipLenReg := IP_LENGTH_MAX
+      metaRegs.dataLen := metaRegs.dataLen - MAX_DATA_NUM
+      packetLen := packetLenMax - 1
+    } otherwise {
+      needFragment := False
+      ipLenReg := io.metaIn.dataLen.resize(
+        IP_LENGTH_WIDTH
+      ) + IP_HEADER_LENGTH + UDP_HEADER_LENGTH
+      udpLenReg := io.metaIn.dataLen.resize(IP_LENGTH_WIDTH) + UDP_HEADER_LENGTH
+      packetLen := ((((io.metaIn.dataLen + HEADER_TOTAL_LENGTH) % HeaderGeneratorConfig.DATA_BYTE_CNT) =/= 0) ? U(
+        1,
+        log2Up(packetLenMax) bits
+      ) | U(
+        0,
+        log2Up(packetLenMax) bits
+      )) + ((io.metaIn.dataLen + HEADER_TOTAL_LENGTH) >> 5)
+        .takeLow(log2Up(packetLenMax))
+        .asUInt - 1
+    }
+  }
+
+  when(generateDone) {
+    ipIdReg := ipIdReg + 1
+  }
+
+  val ethHeader = EthernetHeader(
+    Array(
+      metaRegs.MacAddr,
+      SRC_MAC_ADDR,
+      ETH_TYPE
+    )
+  )
+
+  val ipv4Header = IPv4Header(
+    Array(
+      IP_VERSION,
+      IHL,
+      DSCP,
+      ECN,
+      ipLenReg.asBits,
+      ipIdReg.asBits,
+      FLAGS,
+      FRAGMENT_OFFSET,
+      TTL,
+      PROTOCOL,
+      ipChecksumReg.asBits,
+      SRC_IP_ADDR,
+      metaRegs.IpAddr
+    )
+  )
+  val udpHeader = UDPHeader(
+    Array(
+      metaRegs.srcPort,
+      metaRegs.dstPort,
+      udpLenReg.asBits,
+      UDP_CHECKSUM
+    )
+  )
+
+  val ethIpUdpHeader = generate(Seq(ethHeader, ipv4Header, udpHeader))
+  val ethIpHeader = generate(Seq(ethHeader, ipv4Header))
+  val udpSent = Reg(Bool()) init False
+
+  io.headerAxisOut.data := sendingCnt.mux(
+    0 -> ethIpUdpHeader(sendingCnt),
+    1 -> ethIpUdpHeader(sendingCnt).rotateRight(sendHeaderLastLeft * BYTE_WIDTH)
+  )
+
+  //  32'xffff_ffff or 32'xffc0_0000
+  io.headerAxisOut.keep := sendingCnt.mux(
+    0 -> Bits(HeaderGeneratorConfig.DATA_BYTE_CNT bits).setAll(),
+    1 -> B(
+      HeaderGeneratorConfig.DATA_BYTE_CNT bits,
+      (HeaderGeneratorConfig.DATA_BYTE_CNT - 1 downto HeaderGeneratorConfig.DATA_BYTE_CNT - sendHeaderLastLeft) -> true,
+      default -> false
+    )
+  )
+
+  io.headerAxisOut.user := sendingCnt.mux(
+    0 -> generateControlSignal(0, True, packetLen),
+    1 -> generateControlSignal(sendHeaderLastLeft, False, packetLen)
+  )
+
+  io.headerAxisOut.valid := dataLoaded
+  when(io.headerAxisOut.fire) {
+    sendingCnt.increment()
+    when(sendingCnt.lsb) {
+      io.headerAxisOut.last := True
+    } otherwise {
+      io.headerAxisOut.last := False
+    }
+    when(sendingCnt.lsb & needFragment) {
+      udpSent := True
+      generateDone := False
+    } elsewhen (sendingCnt.lsb & !needFragment) {
+      generateDone := True
+      udpSent := False
+    } otherwise {
+      generateDone := False
+    }
+  } otherwise {
+    io.headerAxisOut.last := False
+    generateDone := False
+  }
+
+  def getHeaderWidth(header: Seq[Array[Bits]]): Int = {
+    var len: Int = 0
+    header.foreach { protocol =>
+      protocol.foreach { data =>
+        len += data.getBitsWidth
+      }
+    }
+    len
+  }
+
+  def mergeHeader(header: Seq[Array[Bits]]): Vec[Bits] = {
+    val headerWidth: Int = getHeaderWidth(header)
+
+    val tmp = header.flatten
+      .reduce(_ ## _)
+      .subdivideIn(BYTE_WIDTH bits)
+      .reduce(_ ## _)
+      .resize(
+        ((headerWidth / HeaderGeneratorConfig.DATA_WIDTH.toFloat).ceil * HeaderGeneratorConfig.DATA_WIDTH).toInt bits
+      )
+      .subdivideIn(HeaderGeneratorConfig.DATA_WIDTH bits)
+
+    tmp
+  }
+
+  def generate(headers: Seq[Array[Bits]]): Vec[Bits] = {
+    val header = mergeHeader(headers)
+    header
+  }
+
+  /**   31  24      19          13     12      7    0
+    *   ┌────┬──────┬───────────┬──────┬───────┬────┐
+    *   │0x5A│      │ packetLen │ LSel │ Shift │0xA5│
+    *   └────┴──────┴───────────┴──────┴───────┴────┘
+    */
+  def generateControlSignal(
+      shiftLen: Int,
+      lastSelect: Bool,
+      packetLen: UInt
+  ): Bits = {
+    val controlHeader = B"8'xa5"
+    val controlTail = B"8'x5a"
+    val shiftBits = B(shiftLen, log2Up(DATA_BYTE_CNT) bits)
+    val ret = controlTail ## B(0, 4 bits) ##
+      packetLen ## lastSelect ## shiftBits ## controlHeader
+    ret
+  }
+
+}

--- a/lib/src/main/scala/spinal/lib/ethernet/HeaderRecognizer.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/HeaderRecognizer.scala
@@ -1,0 +1,239 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.amba4.axis._
+
+import scala.collection.mutable
+
+case class HeaderRecognizerGenerics(
+    SRC_IP_ADDR: String = "c0a80104",
+    SRC_MAC_ADDR: String = "fccffccffccf",
+    DATA_WIDTH: Int = 256,
+    DATA_BYTE_CNT: Int = 32,
+    OCTETS: Int = 8,
+    DATA_USE_TLAST: Boolean = true,
+    DATA_USE_TUSER: Boolean = false,
+    DATA_USE_TKEEP: Boolean = true,
+    DATA_USE_TSTRB: Boolean = false,
+    DATA_TUSER_WIDTH: Int = 1,
+    INPUT_BUFFER_DEPTH: Int = 4
+)
+
+class HeaderRecognizer(
+    HeaderConfig: HeaderRecognizerGenerics
+) extends Component {
+  val headerAxisOutConfig = Axi4StreamConfig(
+    dataWidth = HeaderConfig.DATA_BYTE_CNT,
+    userWidth = HeaderConfig.DATA_TUSER_WIDTH,
+    useKeep = HeaderConfig.DATA_USE_TKEEP,
+    useLast = HeaderConfig.DATA_USE_TLAST,
+    useUser = HeaderConfig.DATA_USE_TUSER
+  )
+  val io = new Bundle {
+    val dataAxisIn = slave(Axi4Stream(headerAxisOutConfig))
+
+    val metaOut = master Stream MetaInterface()
+    val dataAxisOut = master(Axi4Stream(headerAxisOutConfig))
+  }
+
+  val recognizerRunning = Reg(Bool()) init False
+  val recognizerStart = recognizerRunning.rise()
+  val (packetStream, packetReg) = StreamFork2(io.dataAxisIn)
+  val packetStreamReg = packetReg stage ()
+  val combineData = packetStream.payload.data ## packetStreamReg.payload.data
+
+  val setMeta = recognizerStart & packetStream.fire
+
+//  need redesign
+  val (ethHeaderName, ethHeaderExtract) =
+    EthernetHeader.unapply(combineData.takeLow(112))
+  val (ipv4HeaderName, ipv4HeaderExtract) =
+    IPv4Header.unapply(combineData.dropLow(112).takeLow(160))
+  val (udpHeaderName, udpHeaderExtract) =
+    UDPHeader.unapply(combineData.dropLow(272).takeLow(64))
+
+  val ethHeaderExtractReg = Array.tabulate(ethHeaderExtract.length) { idx =>
+    val dataReg: Bits = RegNextWhen(ethHeaderExtract(idx), setMeta)
+    dataReg
+  }
+  val ipv4HeaderExtractReg = Array.tabulate(ipv4HeaderExtract.length) { idx =>
+    val dataReg: Bits = RegNextWhen(ipv4HeaderExtract(idx), setMeta)
+    dataReg
+  }
+  val udpHeaderExtractReg = Array.tabulate(udpHeaderExtract.length) { idx =>
+    val dataReg: Bits = RegNextWhen(udpHeaderExtract(idx), setMeta)
+    dataReg
+  }
+
+  val ethHeader = ethHeaderName.zip(ethHeaderExtract).toMap
+  val ipv4Header = ipv4HeaderName.zip(ipv4HeaderExtract).toMap
+  val udpHeader = udpHeaderName.zip(udpHeaderExtract).toMap
+  val ethHeaderReg = ethHeaderName.zip(ethHeaderExtractReg).toMap
+  val ipv4HeaderReg = ipv4HeaderName.zip(ipv4HeaderExtractReg).toMap
+  val udpHeaderReg = udpHeaderName.zip(udpHeaderExtractReg).toMap
+
+  val addrCorrect = Reg(Bool()) init False
+  val checked = Reg(Bool()) init False
+  val dataLen = Reg(UInt(13 bits)) init 0
+  val shiftLen = Reg(UInt(5 bits)) init 0
+  val isUdp = Reg(Bool()) init False
+
+  val packetLenMax =
+    ((1500 + 14) / HeaderConfig.DATA_BYTE_CNT.toFloat).ceil.toInt
+  val packetLen = Reg(UInt(log2Up(packetLenMax) bits)) init 0
+
+  when(recognizerStart) {
+    checked.set()
+    when(ethHeader("dstMAC") === HeaderConfig.SRC_MAC_ADDR.asHex) {
+      when(ipv4Header("dstAddr") === HeaderConfig.SRC_IP_ADDR.asHex) {
+        when(ethHeader("ethType") === B"16'x08_00") {
+          when(ipv4Header("protocol") === B"8'x11") {
+            isUdp := True
+            when(
+              ipv4Header("flags") === B"3'b0" && ipv4Header(
+                "fragmentOffset"
+              ) === B"13'b0"
+            ) {
+//              val name instead para
+              dataLen := (ipv4Header("ipLen").asUInt - 28).resized
+              shiftLen := 22
+              packetLen := ((((ipv4Header(
+                "ipLen"
+              ).asUInt + 14) % HeaderConfig.DATA_BYTE_CNT) =/= 0) ? U(
+                1,
+                log2Up(packetLenMax) bits
+              ) | U(0, log2Up(packetLenMax) bits)) + ((ipv4Header(
+                "ipLen"
+              ).asUInt + 14) >> 5)
+                .takeLow(log2Up(packetLenMax))
+                .asUInt - 1
+            } // TODO: Fragment not support
+          }
+        }
+        addrCorrect.set()
+      } otherwise {
+        addrCorrect.clear()
+      }
+    } otherwise {
+      addrCorrect.clear()
+    }
+  } elsewhen (packetStream.lastFire) {
+    checked.clear()
+  } elsewhen (io.metaOut.fire) {
+    isUdp.clear()
+  }
+
+  val metaCfg = Stream(MetaInterface())
+
+  metaCfg.valid := True & isUdp.rise()
+
+  metaCfg.payload.dataLen := dataLen
+  metaCfg.payload.MacAddr := ethHeaderReg("srcMAC")
+  metaCfg.payload.IpAddr := ipv4HeaderReg("srcAddr")
+  metaCfg.payload.srcPort := udpHeaderReg("srcPort")
+  metaCfg.payload.dstPort := udpHeaderReg("dstPort")
+
+  io.metaOut << metaCfg.stage()
+
+  when(packetStream.lastFire) {
+    recognizerRunning.clear()
+  } elsewhen (packetStream.fire) {
+    recognizerRunning.set()
+  }
+
+  def rotateLeftByte(data: Bits, bias: UInt): Bits = {
+    val result = cloneOf(data)
+    val byteNum: Int = data.getWidth / HeaderConfig.OCTETS
+    switch(bias) {
+      for (idx <- 0 until byteNum) {
+        is(idx) {
+          result := data.takeLow((byteNum - idx) * 8) ## data.takeHigh(idx * 8)
+        }
+      }
+    }
+    result
+  }
+
+  def rotateLeftBit(data: Bits, bias: UInt): Bits = {
+    val result = cloneOf(data)
+    val bitWidth = data.getWidth
+    switch(bias) {
+      for (idx <- 0 until bitWidth) {
+        is(idx) {
+          result := data.takeLow(bitWidth - idx) ## data.takeHigh(idx)
+        }
+      }
+    }
+    result
+  }
+
+  def byteMaskData(byteMask: Bits, data: Bits): Bits = {
+    val dataWidth = HeaderConfig.DATA_BYTE_CNT
+    val maskWidth = byteMask.getWidth
+    val sliceWidth = data.getWidth / dataWidth
+    require(
+      maskWidth == dataWidth,
+      s"ByteMaskData maskWidth${maskWidth} != dataWidth${dataWidth}"
+    )
+    val spiltAsSlices = data.subdivideIn(maskWidth slices)
+    val arrMaskedByte = Array.tabulate(spiltAsSlices.length) { idx =>
+      byteMask(idx) ? B(0, sliceWidth bits) | spiltAsSlices(idx)
+    }
+    val maskedData = arrMaskedByte.reverse.reduceLeft(_ ## _)
+    maskedData
+  }
+
+  def generateByteMask(len: UInt): Bits = {
+    val res = Bits(HeaderConfig.DATA_BYTE_CNT bits)
+    switch(len) {
+      for (idx <- 0 until HeaderConfig.DATA_BYTE_CNT) {
+        if (idx == 0) {
+          is(idx) {
+            res := Bits(HeaderConfig.DATA_BYTE_CNT bits).setAll()
+          }
+        } else {
+          is(idx) {
+            res := B(
+              HeaderConfig.DATA_BYTE_CNT bits,
+              (HeaderConfig.DATA_BYTE_CNT - 1 downto HeaderConfig.DATA_BYTE_CNT - idx) -> true,
+              default -> false
+            )
+          }
+        }
+      }
+    }
+    res
+  }
+
+  val dataStreamRegValid = (addrCorrect && checked) | addrCorrect
+  val dataStreamValid = (addrCorrect && checked)
+
+  val dataStreamReg = packetStreamReg takeWhen (dataStreamRegValid) stage ()
+  val dataStream = packetStream takeWhen (dataStreamValid) stage ()
+
+  val dataJoinStream =
+    Axi4StreamConditionalJoin(dataStreamReg, dataStream, True, True) stage ()
+  val maskStage = packetStream.clone()
+  val mask =
+    RegNextWhen(generateByteMask(shiftLen), isUdp & dataStreamReg.fire) init 0
+
+  maskStage.arbitrationFrom(dataJoinStream)
+  maskStage.data := byteMaskData(
+    ~mask,
+    dataJoinStream.payload._1.data
+  ) | byteMaskData(mask, dataJoinStream.payload._2.data)
+  maskStage.keep := byteMaskData(
+    ~mask,
+    dataJoinStream.payload._1.keep
+  ) | byteMaskData(mask, dataJoinStream.payload._2.keep)
+  maskStage.last := dataJoinStream.payload._1.last
+
+  val shiftStage = maskStage.clone()
+  shiftStage.arbitrationFrom(maskStage)
+  shiftStage.data := rotateLeftByte(maskStage.data, shiftLen)
+  shiftStage.keep := rotateLeftBit(maskStage.keep, shiftLen)
+  shiftStage.last := maskStage.last
+
+  io.dataAxisOut <-< shiftStage
+}

--- a/lib/src/main/scala/spinal/lib/ethernet/IPv4Header.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/IPv4Header.scala
@@ -1,0 +1,58 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import EthernetProtocolConstant._
+
+import scala.collection.mutable
+
+object IPv4Header {
+  def apply(array: Array[Bits]): Array[Bits] = {
+    val gen = new IPv4Header
+    require(
+      array.length == gen.header.length,
+      s"Initializing parameters not enough! Require ${gen.header.length} but gave ${array.length}"
+    )
+    gen.header.zipWithIndex.foreach { case (data, idx) =>
+      data := array(idx)
+    }
+    gen.header
+  }
+
+  def unapply(header: Bits): (Array[String], Array[Bits]) = {
+    val gen = new IPv4Header
+    val bitWidth = gen.frameFieldInit.values.sum
+    require(
+      bitWidth == header.getWidth,
+      s"Initializing parameters not enough! Require ${bitWidth} but gave ${header.getWidth}"
+    )
+    val asLittleEnd = header.subdivideIn(bitWidth / 8 slices).reduce(_ ## _)
+    val tmp = asLittleEnd
+      .sliceBy(gen.frameFieldInit.values.toList.reverse)
+      .reverse
+      .toArray
+    gen.header.zipWithIndex.foreach { case (data, idx) =>
+      data := tmp(idx)
+    }
+    (gen.frameFieldInit.keys.toArray, gen.header)
+  }
+}
+
+case class IPv4Header() extends Bundle with FrameHeader {
+  val frameFieldInit = mutable.LinkedHashMap(
+    "protocolVersion" -> IP_VERSION_WIDTH,
+    "internetHeaderLength" -> IHL_WIDTH,
+    "differentiatedServicesCodePoint" -> DSCP_WIDTH,
+    "explicitCongestionNotification" -> ECN_WIDTH,
+    "ipLen" -> IP_LENGTH_WIDTH,
+    "identification" -> IDENTIFICATION_WIDTH,
+    "flags" -> FLAGS_WIDTH,
+    "fragmentOffset" -> FRAGMENT_OFFSET_WIDTH,
+    "ttl" -> TTL_WIDTH,
+    "protocol" -> PROTOCOL_WIDTH,
+    "ipChecksum" -> IP_HEADER_CHECKSUM_WIDTH,
+    "srcAddr" -> IP_ADDR_WIDTH,
+    "dstAddr" -> IP_ADDR_WIDTH
+  )
+  val header: Array[Bits] =
+    EthernetProtocolHeaderConstructor(frameFieldInit).constructHeader()
+}

--- a/lib/src/main/scala/spinal/lib/ethernet/MetaInterface.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/MetaInterface.scala
@@ -1,0 +1,26 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import spinal.lib._
+
+import EthernetProtocolConstant._
+
+object MetaInterfaceConstrant {
+  val PACKET_TOTAL_MAX = 4096
+  val PACKET_TOTAL_LEN_WIDTH = log2Up(PACKET_TOTAL_MAX)   // 0 ~ 4096
+}
+
+import ethernet.MetaInterfaceConstrant._
+
+case class MetaInterface()
+    extends Bundle
+    with IMasterSlave {
+  val dataLen = UInt(PACKET_TOTAL_LEN_WIDTH bits)
+  val MacAddr = Bits(MAC_ADDR_WIDTH bits)
+  val IpAddr = Bits(IP_ADDR_WIDTH bits)
+  val dstPort = Bits(UDP_PORT_WIDTH bits)
+  val srcPort = Bits(UDP_PORT_WIDTH bits)
+  override def asMaster(): Unit = {
+    out(dataLen, MacAddr, IpAddr, dstPort, srcPort)
+  }
+}

--- a/lib/src/main/scala/spinal/lib/ethernet/ProtocolHeader.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/ProtocolHeader.scala
@@ -1,0 +1,137 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import spinal.core.internals.Operator
+import spinal.core.sim._
+import spinal.lib
+import spinal.lib._
+import spinal.lib.bus.amba4.axis.{Axi4Stream, Axi4StreamConfig}
+import spinal.lib.fsm._
+
+import scala.collection.mutable
+import scala.math.pow
+
+object EthernetProtocolConstant {
+  val DATA_WIDTH = 256
+  val BYTE_WIDTH = 8
+  val DATA_BYTE_CNT = DATA_WIDTH / BYTE_WIDTH
+
+  val SRC_MAC_ADDR = 0x0123456789abcL
+  val SRC_IP_ADDR = 0xc0a80101L
+
+  val ETH_TYPE = 0x0800
+  val IP_VERSION = 0x4
+  val IHL = 0x5
+  val DSCP = 0x0
+  val ECN = 0x0
+  val FLAGS = 0x2
+  val FRAGMENT_OFFSET = 0x0
+  val TTL = 0x40
+  val PROTOCOL = 0x11
+
+  val UDP_CHECKSUM = 0x0000
+
+  val ETH_HEADER_LENGTH = 14
+  val IP_HEADER_LENGTH = 20
+  val UDP_HEADER_LENGTH = 8
+  val HEADER_TOTAL_LENGTH =
+    ETH_HEADER_LENGTH + IP_HEADER_LENGTH + UDP_HEADER_LENGTH
+
+  val MTU = 1500
+  val IP_LENGTH_MAX = MTU
+  val UDP_LENGTH_MAX = IP_LENGTH_MAX - IP_HEADER_LENGTH
+
+  val MAX_DATA_NUM = MTU - IP_HEADER_LENGTH - UDP_HEADER_LENGTH
+  val MIN_DATA_NUM =
+    22 // MIN_TRANSACTION_NUM(64) - MAC_LEN(14) - IP_LEN(20) - UDP_LEN(8)
+
+  val MAC_ADDR_WIDTH = 48
+  val ETH_TYPE_WIDTH = 16
+
+  val IP_VERSION_WIDTH = 4
+  val IHL_WIDTH = 4
+  val DSCP_WIDTH = 6
+  val ECN_WIDTH = 2
+  val IP_LENGTH_WIDTH = 16
+  val IDENTIFICATION_WIDTH = 16
+  val FLAGS_WIDTH = 3
+  val FRAGMENT_OFFSET_WIDTH = 13
+  val TTL_WIDTH = 8
+  val PROTOCOL_WIDTH = 8
+  val IP_HEADER_CHECKSUM_WIDTH = 16
+  val IP_ADDR_WIDTH = 32
+
+  val UDP_PORT_WIDTH = 16
+  val UDP_LENGTH_WIDTH = 16
+  val UDP_CHECKSUM_WIDTH = 16
+}
+
+import EthernetProtocolConstant._
+case class EthernetProtocolHeaderConstructor(
+    initField: mutable.LinkedHashMap[String, Int]
+) extends Bundle {
+  def constructHeader(): Array[Bits] = {
+    val fieldName: Array[String] = initField.keys.toArray
+    val fieldWidth: Array[Int] = initField.values.toArray
+    val protocolField = List.tabulate[Bits](initField.size) { index =>
+      val tmp: Bits =
+        Bits(fieldWidth(index) bits) setName fieldName(index)
+      tmp
+    }
+    protocolField.toArray
+  }
+
+}
+// interface workshop
+trait FrameHeader {
+  val frameFieldInit: mutable.LinkedHashMap[String, Int]
+  val header: Array[Bits]
+}
+
+//object ARPHeader {
+//  def apply(array: Array[Bits]): Array[Bits] = {
+//    val gen = new ARPHeader
+//    require(
+//      array.length == gen.header.length,
+//      s"Initializing parameters not enough! Require ${gen.header.length} but gave ${array.length}"
+//    )
+//    gen.header.zipWithIndex.foreach { case (data, idx) =>
+//      data := array(idx)
+//    }
+//    gen.header
+//  }
+//
+//  def unapply(header: Bits): (Array[String], Array[Bits]) = {
+//    val gen = new ARPHeader
+//    val bitWidth = gen.frameFieldInit.values.sum
+//    require(
+//      bitWidth == header.getWidth,
+//      s"Initializing parameters not enough! Require ${bitWidth} but gave ${header.getWidth}"
+//    )
+//    val asLittleEnd = header.subdivideIn(bitWidth / 8 slices).reduce(_ ## _)
+//    val tmp = asLittleEnd
+//      .sliceBy(gen.frameFieldInit.values.toList.reverse)
+//      .reverse
+//      .toArray
+//    gen.header.zipWithIndex.foreach { case (data, idx) =>
+//      data := tmp(idx)
+//    }
+//    (gen.frameFieldInit.keys.toArray, gen.header)
+//  }
+//}
+//
+//case class ARPHeader() extends FrameHeader {
+//  val frameFieldInit = mutable.LinkedHashMap(
+//    "hardwareType" -> 2 * 8,
+//    "protocolType" -> 2 * 8,
+//    "hardwareLen" -> 8,
+//    "protocolLen" -> 8,
+//    "operation" -> 2 * 8,
+//    "senderHardwareAddr" -> 6 * 8,
+//    "senderProtocolAddr" -> 4 * 8,
+//    "targetHardwareAddr" -> 6 * 8,
+//    "targetProtocolAddr" -> 4 * 8
+//  )
+//  val header: Array[Bits] =
+//    EthernetProtocolHeaderConstructor(frameFieldInit).constructHeader()
+//}

--- a/lib/src/main/scala/spinal/lib/ethernet/UDPHeader.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/UDPHeader.scala
@@ -1,0 +1,49 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import EthernetProtocolConstant._
+
+import scala.collection.mutable
+
+object UDPHeader {
+  def apply(array: Array[Bits]): Array[Bits] = {
+    val gen = new UDPHeader
+    require(
+      array.length == gen.header.length,
+      s"Initializing parameters not enough! Require ${gen.header.length} but gave ${array.length}"
+    )
+    gen.header.zipWithIndex.foreach { case (data, idx) =>
+      data := array(idx)
+    }
+    gen.header
+  }
+
+  def unapply(header: Bits): (Array[String], Array[Bits]) = {
+    val gen = new UDPHeader
+    val bitWidth = gen.frameFieldInit.values.sum
+    require(
+      bitWidth == header.getWidth,
+      s"Initializing parameters not enough! Require ${bitWidth} but gave ${header.getWidth}"
+    )
+    val asLittleEnd = header.subdivideIn(bitWidth / 8 slices).reduce(_ ## _)
+    val tmp = asLittleEnd
+      .sliceBy(gen.frameFieldInit.values.toList.reverse)
+      .reverse
+      .toArray
+    gen.header.zipWithIndex.foreach { case (data, idx) =>
+      data := tmp(idx)
+    }
+    (gen.frameFieldInit.keys.toArray, gen.header)
+  }
+}
+
+case class UDPHeader() extends Bundle with FrameHeader {
+  val frameFieldInit = mutable.LinkedHashMap(
+    "srcPort" -> UDP_PORT_WIDTH,
+    "dstPort" -> UDP_PORT_WIDTH,
+    "len" -> UDP_LENGTH_WIDTH,
+    "udpChecksum" -> UDP_CHECKSUM_WIDTH
+  )
+  val header: Array[Bits] =
+    EthernetProtocolHeaderConstructor(frameFieldInit).constructHeader()
+}

--- a/lib/src/main/scala/spinal/lib/ethernet/UDPRx.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/UDPRx.scala
@@ -1,0 +1,55 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.amba4.axis._
+import spinal.core.Mem
+import ethernet.PacketMTUEnum
+import spinal.core.internals.Operator
+import spinal.lib.fsm._
+
+import java.util.Calendar
+import scala.math._
+
+case class RxGenerics(
+    IP_ADDR_WIDTH: Int = 32,
+    PORT_WIDTH: Int = 16,
+    DATA_WIDTH: Int = 256,
+    DATA_BYTE_CNT: Int = 32,
+    OCTETS: Int = 8,
+    DATA_USE_TLAST: Boolean = true,
+    DATA_USE_TUSER: Boolean = true,
+    DATA_USE_TKEEP: Boolean = true,
+    DATA_USE_TSTRB: Boolean = false,
+    DATA_TUSER_WIDTH: Int = 1,
+    INPUT_BUFFER_DEPTH: Int = 256
+)
+
+class RxTop(
+    rxConfig: RxGenerics,
+    headerConfig: HeaderRecognizerGenerics
+) extends Component {
+  val dataAxisCfg = Axi4StreamConfig(
+    dataWidth = rxConfig.DATA_BYTE_CNT,
+    userWidth = rxConfig.DATA_TUSER_WIDTH,
+    useStrb = rxConfig.DATA_USE_TSTRB,
+    useKeep = rxConfig.DATA_USE_TKEEP,
+    useLast = rxConfig.DATA_USE_TLAST,
+    useUser = rxConfig.DATA_USE_TUSER
+  )
+
+  val io = new Bundle {
+
+    val dataAxisIn = slave(Axi4Stream(dataAxisCfg))
+    val metaOut = master Stream MetaInterface()
+    val dataAxisOut = master(Axi4Stream(dataAxisCfg))
+  }
+
+  val dataBuffered = io.dataAxisIn.queue(rxConfig.INPUT_BUFFER_DEPTH)
+
+  val headerRecognizer = new HeaderRecognizer(headerConfig)
+  headerRecognizer.io.dataAxisIn << dataBuffered
+
+  io.dataAxisOut <-< headerRecognizer.io.dataAxisOut
+  io.metaOut <-< headerRecognizer.io.metaOut
+}

--- a/lib/src/main/scala/spinal/lib/ethernet/UDPTx.scala
+++ b/lib/src/main/scala/spinal/lib/ethernet/UDPTx.scala
@@ -1,0 +1,211 @@
+package spinal.lib.ethernet
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba4.axis._
+import spinal.core.Mem
+import ethernet.PacketMTUEnum
+import spinal.core.internals.Operator
+import spinal.lib.bus.amba4.axis.Axi4Stream.Axi4StreamBundle
+import spinal.lib.fsm._
+
+import java.util.Calendar
+import scala.math._
+
+case class TxGenerics(
+    IP_ADDR_WIDTH: Int = 32,
+    PORT_WIDTH: Int = 16,
+    DATA_WIDTH: Int = 256,
+    DATA_BYTE_CNT: Int = 32,
+    OCTETS: Int = 8,
+    DATA_USE_TLAST: Boolean = true,
+    DATA_USE_TUSER: Boolean = true,
+    DATA_USE_TKEEP: Boolean = true,
+    DATA_USE_TSTRB: Boolean = false,
+    DATA_TUSER_WIDTH: Int = 1,
+    INPUT_BUFFER_DEPTH: Int = 256
+)
+
+
+class TxTop(
+    txConfig: TxGenerics,
+//    arpCacheConfig: ArpCacheGenerics,
+    headerConfig: HeaderGeneratorGenerics
+) extends Component {
+  val dataAxisCfg = Axi4StreamConfig(
+    dataWidth = txConfig.DATA_BYTE_CNT,
+    userWidth = txConfig.DATA_TUSER_WIDTH,
+    useStrb = txConfig.DATA_USE_TSTRB,
+    useKeep = txConfig.DATA_USE_TKEEP,
+    useLast = txConfig.DATA_USE_TLAST,
+    useUser = txConfig.DATA_USE_TUSER
+  )
+
+  val io = new Bundle {
+    val metaIn = slave Stream MetaInterface()
+
+    val dataAxisIn = slave(Axi4Stream(dataAxisCfg))
+    val dataAxisOut = master(Axi4Stream(dataAxisCfg))
+  }
+
+  val dataBuffered = io.dataAxisIn.queue(txConfig.INPUT_BUFFER_DEPTH)
+  val metaBuffered = io.metaIn.queue(headerConfig.INPUT_BUFFER_DEPTH)
+
+  val headerGenerator =
+    new HeaderGenerator(headerConfig)
+  headerGenerator.io.metaIn << metaBuffered
+  val headerBuffered = headerGenerator.io.headerAxisOut.queue(16)
+  val forkedStream = StreamFork(dataBuffered, 2)
+
+  val dataBufferedReg = forkedStream(0).stage()
+
+  val streamMuxReg = Reg(UInt(1 bits)) init 0
+  val streamJoinReg0 = Reg(Bool()) init False
+  val streamJoinReg1 = Reg(Bool()) init False
+
+  val invalidData = Bool()
+
+  val selectedStream =
+    StreamMux(
+      streamMuxReg,
+      Vec(headerBuffered, dataBufferedReg)
+    ) s2mPipe () throwWhen (invalidData)
+
+  val joinedStream = Axi4StreamConditionalJoin(
+    selectedStream,
+    forkedStream(1),
+    streamJoinReg0,
+    streamJoinReg1
+  ) m2sPipe ()
+
+  when(forkedStream(1).lastFire) {
+    streamJoinReg1 := False
+  } elsewhen (selectedStream.fire & !streamMuxReg.asBool) {
+    streamJoinReg1 := True
+  }
+
+  when(headerBuffered.lastFire) {
+    streamMuxReg := 1
+  } elsewhen (dataBufferedReg.lastFire | invalidData) {
+    streamMuxReg := 0
+  }
+
+  when(forkedStream(1).lastFire) {
+    streamJoinReg0 := True
+  } elsewhen (selectedStream.lastFire | invalidData) {
+    streamJoinReg0 := False
+  }
+
+  //  redesign
+  def rotateLeftByte(data: Bits, bias: UInt): Bits = {
+    val result = cloneOf(data)
+    val byteNum: Int = data.getWidth / txConfig.OCTETS
+    switch(bias) {
+      for (idx <- 0 until byteNum) {
+        is(idx) {
+          result := data.takeLow((byteNum - idx) * 8) ## data.takeHigh(idx * 8)
+        }
+      }
+    }
+    result
+  }
+
+  def rotateLeftBit(data: Bits, bias: UInt): Bits = {
+    val result = cloneOf(data)
+    val bitWidth = data.getWidth
+    switch(bias) {
+      for (idx <- 0 until bitWidth) {
+        is(idx) {
+          result := data.takeLow(bitWidth - idx) ## data.takeHigh(idx)
+        }
+      }
+    }
+    result
+  }
+  def byteMaskData(byteMask: Bits, data: Bits): Bits = {
+    val dataWidth = txConfig.DATA_BYTE_CNT
+    val maskWidth = byteMask.getWidth
+    val sliceWidth = data.getWidth / dataWidth
+    require(
+      maskWidth == dataWidth,
+      s"ByteMaskData maskWidth${maskWidth} != dataWidth${dataWidth}"
+    )
+    val spiltAsSlices = data.subdivideIn(maskWidth slices)
+    val arrMaskedByte = Array.tabulate(spiltAsSlices.length) { idx =>
+      byteMask(idx) ? B(0, sliceWidth bits) | spiltAsSlices(idx)
+    }
+    val maskedData = arrMaskedByte.reverse.reduceLeft(_ ## _)
+    maskedData
+  }
+
+  def generateByteMask(len: UInt): Bits = {
+    val res = Bits(txConfig.DATA_BYTE_CNT bits)
+    switch(len) {
+      for (idx <- 0 until txConfig.DATA_BYTE_CNT) {
+        if (idx == 0) {
+          is(idx) {
+            res := Bits(txConfig.DATA_BYTE_CNT bits).setAll()
+          }
+        } else {
+          is(idx) {
+            res := B(
+              txConfig.DATA_BYTE_CNT bits,
+              (txConfig.DATA_BYTE_CNT - 1 downto txConfig.DATA_BYTE_CNT - idx) -> true,
+              default -> false
+            )
+          }
+        }
+      }
+    }
+    res
+  }
+
+  val mask = Reg(Bits(txConfig.DATA_BYTE_CNT bits)) init 0
+  val shiftLen = Reg(UInt(log2Up(txConfig.DATA_BYTE_CNT) bits)) init 0
+  val packetLen = selectedStream.user(19 downto 14).asUInt
+
+  val maskStage = dataBufferedReg.clone()
+  val cntTrigger = selectedStream.fire && (selectedStream.user.takeLow(
+    8
+  ) === B"8'xA5") && (selectedStream.user
+    .takeHigh(8) === B"8'x5A") && selectedStream.user(13)
+
+  when(selectedStream.fire) {
+    when(
+      (selectedStream.user.takeLow(8) === B"8'xA5") && (selectedStream.user
+        .takeHigh(8) === B"8'x5A")
+    ) {
+      mask := generateByteMask(selectedStream.user(12 downto 8).asUInt)
+      shiftLen := selectedStream.user(12 downto 8).asUInt
+    }
+  }
+
+  val transactionCounter = new StreamTransactionCounter(6)
+  transactionCounter.io.ctrlFire := cntTrigger
+  transactionCounter.io.targetFire := maskStage.fire
+  transactionCounter.io.count := packetLen
+
+  invalidData := transactionCounter.io.done & streamJoinReg0
+
+  maskStage.arbitrationFrom(joinedStream)
+  maskStage.data := byteMaskData(
+    ~mask,
+    joinedStream.payload._1.data
+  ) | byteMaskData(mask, joinedStream.payload._2.data)
+  maskStage.keep := byteMaskData(
+    ~mask,
+    joinedStream.payload._1.keep
+  ) | byteMaskData(mask, joinedStream.payload._2.keep)
+  maskStage.user := 0
+  maskStage.last := transactionCounter.io.last
+
+  val shiftStage = maskStage.clone()
+  shiftStage.arbitrationFrom(maskStage)
+  shiftStage.data := rotateLeftByte(maskStage.data, shiftLen)
+  shiftStage.keep := rotateLeftBit(maskStage.keep, shiftLen)
+  shiftStage.user := 0
+  shiftStage.last := maskStage.last
+
+  io.dataAxisOut <-< shiftStage
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description
The udp project is [here](https://github.com/jjyy-Huang/SpinalHDL-ethernet.git).
- The goal of this PR is to create a UDP/IP Tx/Rx module with SpinalHDL for Xilinx 100GbE Ethernet-Subsystem (MRMAC/CMAC).

- the module support following features:
  - UDP Tx/Rx without checksum
  - IP Tx/Rx
  - Ethernet Frame Layer2 (pre-add MAC adn EtherType)
  - 256b data width
  - Fully pipeline

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
Zero

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?

# TODO
- [ ] Redesign Rx module control logic
- [ ] Add ARP request module
- [ ] Add ICMP module
- [ ] I/O data support 384b/512b
- [ ] Use cocotb for verification
