### PR TITLE
Fix crash when Mem word type is zero bits

### DIFF
--- a/core/src/main/scala/spinal/core/Mem.scala
+++ b/core/src/main/scala/spinal/core/Mem.scala
@@ -124,7 +124,7 @@ class Mem[T <: Data](val wordType: HardType[T], val wordCount: Int) extends Decl
 
   var forceMemToBlackboxTranslation = false
   val _widths = wordType().flatten.map(t => t.getBitsWidth).toVector //Force to fix width of each wire
-  val width   = _widths.reduce(_ + _)
+  val width   = _widths.sum
 
 
   def byteCount = ((width+7)/8)*wordCount


### PR DESCRIPTION
# Context, Motivation & Description

Fixes a small bug when making a memory with a zero with type. For example, queuing a stream of an empty bundle. This should be identical to the previous reduce method but won't error if the list is empty.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

N/A


# Checklist

N/A
