### PR TITLE
Add GHDL sim backend support for different waveform formats.

### DIFF
--- a/sim/src/main/scala/spinal/sim/GhdlBackend.scala
+++ b/sim/src/main/scala/spinal/sim/GhdlBackend.scala
@@ -28,7 +28,7 @@ class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
   }
 
   if (!(Array(WaveFormat.DEFAULT, WaveFormat.NONE) contains format)) {
-
+    wavePath = wavePath.split('.').init ++ Seq(format.ext) mkString "."
     if (format == WaveFormat.GHW) {
       runFlags += " --wave=" + wavePath
     } else {

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -40,7 +40,7 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
   val pluginsPath     = config.pluginsPath     
   val workspacePath   = config.workspacePath   
   val workspaceName   = config.workspaceName   
-  val wavePath        = config.wavePath        
+  var wavePath        = config.wavePath        
   val waveFormat      = config.waveFormat      
   val analyzeFlags    = config.analyzeFlags
   var runFlags        = config.runFlags        


### PR DESCRIPTION
GHDL supports different kinds of waveforms; add support for this in our backend.

This does not affect code generation.