### PR TITLE
[regif] fix readData hold issue for the reason of security

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
@@ -371,9 +371,8 @@ trait BusIf extends BusIfBase {
         }
       }
     }.otherwise{
-      //async should give a value avoid latch
-      //remove else statement when readSync case for lowerPower consideration
-      if(!readSync){readData := 0 }
+      //do not keep readData after read for the reason of security risk
+      readData  := readDefaultValue
       readError := False
     }
   }


### PR DESCRIPTION
add defaultValue on readData else branch avoid security risk 
```verilog
if(readAsk) begin
  ......
else  begin   
   readData  <= defaultValue;
   readError <= False       ;
end
```