### PR TITLE
Fix resized data handling in tuple assignment

### DIFF
--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -527,13 +527,14 @@ package object core extends BaseTypeFactory with BaseTypeCast {
   class TuplePimperBase(product: Product){
     def elements = product.productIterator.asInstanceOf[Iterator[Data]]
     def := [T<:Data](_right : T): Unit ={
-      val right = _right.asBits
       val leftWidth = elements.map(_.getBitsWidth).sum
-      var rightOp = right
-      if(right.hasTag(tagAutoResize)){
-        rightOp = right.resize(leftWidth bits)
-      }
-      assert(rightOp.getWidth == leftWidth, s"Width missmatch (${right.getWidth} != $leftWidth")
+      val rightOp =
+        if(_right.hasTag(tagAutoResize))
+          _right.asBits.resize(leftWidth bits)
+        else
+          _right.asBits
+      assert(rightOp.getWidth == leftWidth, s"Width missmatch (${rightOp.getWidth} != $leftWidth)")
+
       var offset = 0
       for(e <- elements.toList.reverse){
         e.assignFromBits(rightOp(offset, e.getBitsWidth bits))

--- a/tester/src/test/scala/spinal/tester/scalatest/TuplePimperBaseTest.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/TuplePimperBaseTest.scala
@@ -1,0 +1,68 @@
+package spinal.tester.scalatest
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import spinal.core.sim._
+
+class TuplePimperBaseTest extends AnyFunSuite {
+  test("tuple_assignment_matching") {
+    SimConfig.compile(new Component {
+      val right = in port Bits(4 bit)
+      val lefth = out port Bits(2 bit)
+      val leftl = out port Bits(2 bit)
+      (lefth, leftl) := right
+    }).doSim { dut =>
+      for (_ <- 0 to 1000) {
+        val expected = dut.right.randomize().toInt
+        sleep(1)
+        assert(dut.leftl.toInt == (expected & 0x3))
+        assert(dut.lefth.toInt == (expected >> 2))
+      }
+    }
+  }
+
+  test("tuple_assignment_multiple") {
+    SimConfig.compile(new Component {
+      val righth = in port Bool()
+      val rightl = in port Bits(3 bit)
+      val lefth = out port Bits(2 bit)
+      val leftl = out port Bits(2 bit)
+      (lefth, leftl) := (righth, rightl)
+    }).doSim { dut =>
+      for (_ <- 0 to 1000) {
+        val expectedh = dut.righth.randomize().toInt
+        val expectedl = dut.rightl.randomize().toInt
+        val expected = (expectedh << 3) + expectedl
+        sleep(1)
+        assert(dut.leftl.toInt == (expected & 0x3))
+        assert(dut.lefth.toInt == (expected >> 2))
+      }
+    }
+  }
+
+  test("tuple_assignment_resized") {
+    SimConfig.compile(new Component {
+      val right = in port Bits(3 bit)
+      val leftl = out port Bits(2 bit)
+      val lefth = out port Bits(2 bit)
+      (lefth, leftl) := right.resized
+    }).doSim { dut =>
+      for (_ <- 0 to 1000) {
+        val expected = dut.right.randomize().toInt
+        sleep(1)
+        assert(dut.leftl.toInt == (expected & 0x3))
+        assert(dut.lefth.toInt == (expected >> 2))
+      }
+    }
+  }
+
+  test("tuple_assignment_width_mismatch") {
+    import CheckTester._
+    generationShouldFail(new Component {
+      val right = in port Bits(3 bit)
+      val left0 = out port Bits(2 bit)
+      val left1 = out port Bits(2 bit)
+      (left1, left0) := right
+    })
+  }
+}


### PR DESCRIPTION
Since `asBits` creates a copy (w/o attributes) we have to check the original, not the copy for possible resize attributes.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1044 

# Checklist

- [x] Unit tests were added
- ~[ ] API changes are or will be documented:~
