### PR TITLE
Fix subdivideIn(..., n bit) for corner cases

### DIFF
--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -299,27 +299,41 @@ abstract class BitVector extends BaseType with Widthable {
   }
 
   /**
-    * Split the BitVector into x slice
-    * @example {{{ val res = myBits.subdiviedIn(3 slices) }}}
-    * @param sliceCount the width of the slice
-    * @return a Vector of slices
-    */
-  def subdivideIn(sliceCount: SlicesCount, strict : Boolean): Vec[T] = {
-    require(!strict || this.getWidth % sliceCount.value == 0)
-    val sliceWidth = widthOf(this) / sliceCount.value + (if(widthOf(this) % sliceCount.value != 0) 1 else 0)
-    val w = getWidth
-    Vec((0 until sliceCount.value).map(i => this(i * sliceWidth, (w-i * sliceWidth) min sliceWidth bits).asInstanceOf[T]))
+   * Split the BitVector into x slice
+   *
+   * @example {{{ val res = myBits.subdivideIn(3 slices) }}}
+   * @param sliceCount the width of the slice
+   * @param strict     allow `subdivideIn` to generate vectors with varying size
+   * @return a Vector of slices
+   */
+  def subdivideIn(sliceCount: SlicesCount, strict: Boolean): Vec[T] = {
+    val width = getWidth
+    val dividesEvenly = width % sliceCount.value == 0
+    require(!strict || dividesEvenly,
+      s"subdivideIn can't evenly divide $width bit into ${sliceCount.value} slices as required by strict=true")
+    val sliceWidth = width / sliceCount.value + (if (!dividesEvenly) 1 else 0)
+    Vec(
+      (0 until sliceCount.value)
+        .map(i => this (i * sliceWidth, (width - i * sliceWidth) min sliceWidth bits).asInstanceOf[T])
+    )
   }
 
   /**
-    * Split the BitVector into slice of x bits
-    * * @example {{{ val res = myBits.subdiviedIn(3 bits) }}}
-    * @param sliceWidth the width of the slice
-    * @return a Vector of slices
-    */
-  def subdivideIn(sliceWidth: BitCount, strict : Boolean): Vec[T] = {
-    require(!strict || this.getWidth % sliceWidth.value == 0)
-    subdivideIn((this.getWidth + sliceWidth.value - 1) / sliceWidth.value slices, strict)
+   * Split the BitVector into slice of x bits
+   *
+   * @example {{{ val res = myBits.subdivideIn(3 bits) }}}
+   * @param sliceWidth the width of the slice
+   * @param strict     allow `subdivideIn` to generate vectors with varying size
+   * @return a Vector of slices
+   */
+  def subdivideIn(sliceWidth: BitCount, strict: Boolean): Vec[T] = {
+    val width = widthOf(this)
+    require(!strict || width % sliceWidth.value == 0,
+      s"subdivideIn can't evenly divide $width bit into ${sliceWidth.value} bit slices, as required by strict=true")
+    Vec(
+      (0 until width by sliceWidth.value)
+        .map(i => this.apply(i until ((i + sliceWidth.value) min width)).asInstanceOf[T])
+    )
   }
 
 

--- a/tester/src/test/scala/spinal/tester/scalatest/BitVectorTests.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/BitVectorTests.scala
@@ -1,0 +1,73 @@
+package spinal.tester.scalatest
+
+import spinal.core._
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core.formal.{FormalConfig, SpinalFormalConfig}
+import spinal.lib.formal.SpinalFormalFunSuite
+
+import scala.language.postfixOps
+
+class SubdivideInTestErrors extends AnyFunSuite {
+  import CheckTester._
+  def testInvalidStrict(width: Int, sliceWidth: BitCount): Unit =
+    test(s"$width bit Bits can't be divided into ${sliceWidth.value} bits evenly (strict)") {
+      generationShouldFail(new Component {
+        val x = in port Bits(width bit)
+        x.subdivideIn(sliceWidth)
+      })
+    }
+  def testInvalidStrict(width: Int, sliceCount: SlicesCount): Unit =
+    test(s"$width bit Bits can't be divides into ${sliceCount.value} slices evenly (strict)") {
+      generationShouldFail(new Component {
+        val x = in port Bits(width bit)
+        x.subdivideIn(sliceCount)
+      })
+    }
+
+  testInvalidStrict(8, 7 bit)
+  testInvalidStrict(9, 4 bit)
+  testInvalidStrict(8, 3 slices)
+  testInvalidStrict(9, 4 slices)
+  testInvalidStrict(2, 3 slices) // more slices than possible
+}
+
+class SubdivideInTest extends SpinalFormalFunSuite {
+  case class SliceDutBits(width: Int, sliceWidth: BitCount) extends Component {
+    val i = Bits(width bit)
+    val o = Bits(width bit)
+    val split = i.subdivideIn(sliceWidth, strict = false)
+
+    if (width % sliceWidth.value == 0)
+      split.foreach(s => assert(s.getWidth == sliceWidth.value))
+    else
+      split.dropRight(1).foreach(s => assert(s.getWidth == sliceWidth.value))
+
+    o := Cat(split)
+    assert(i === o)
+  }
+
+  case class SliceDutSlices(width: Int, slicesCount: SlicesCount) extends Component {
+    val i = Bits(width bit)
+    val o = Bits(width bit)
+    val split = i.subdivideIn(slicesCount, strict = false)
+    assert(split.size == slicesCount.value, s"split into ${split.size} slices, not ${slicesCount.value}")
+
+    o := Cat(split)
+    assert(i === o)
+  }
+  
+  test("mix of slicing operations") {
+    SpinalFormalConfig(_keepDebugInfo = true)
+      .withBMC(5)
+      .withProve(5)
+      .doVerify(new Component {
+        val dut_8_2bit = SliceDutBits(8, 2 bit) // default case
+        val dut_8_5bit = SliceDutBits(8, 5 bit) // uneven case, https://github.com/SpinalHDL/SpinalHDL/issues/1049
+        val dut_9_4bit = SliceDutBits(9, 4 bit) // odd width
+        val dut_2_3bit = SliceDutBits(2, 3 bit) // width smaller than sliceWidth
+        val dut_8_2slices = SliceDutSlices(8, 2 slices) // default case
+        val dut_8_3slices = SliceDutSlices(8, 3 slices) // uneven case
+        val dut_9_4slices = SliceDutSlices(9, 4 slices) // odd width
+      }.setDefinitionName("BitVectorTests_SubdivideInTest"))
+  }
+}


### PR DESCRIPTION
When splitting 8 into 5 the old algorithm would generate an inconsistent result with other cases as it would generate two slices of 4 bit. In most other cases subdivideIn would generate the expected width as long as possible, and have a smaller last element.

If this is actually expected behavior I'd update the documentation to mention it.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1049 

# Impact on code generation

None

# Checklist

- [x] Unit tests were added