### PR TITLE
Retide the generated files by tester/test cases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ sim/xsim.dir/
 *.lst
 
 simWorkspace/
+cocotbWorkspace/
 tmp/
 null/
 command

--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -131,7 +131,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         defaultConfigForClockDomains   : ClockDomainConfig = ClockDomainConfig(),
                         onlyStdLogicVectorAtTopLevelIo : Boolean = false,
                         defaultClockDomainFrequency    : IClockDomainFrequency = UnknownFrequency(),
-                        targetDirectory                : String = ".",
+                        targetDirectory                : String = SpinalConfig.defaultTargetDirectory,
                         oneFilePerComponent            : Boolean = false,
                         netlistFileName                : String = null,
                         dumpWave                       : DumpWaveConfig = null,
@@ -262,6 +262,8 @@ object SpinalConfig{
       case None         => ???
     }
   }
+
+  var defaultTargetDirectory: String = "."
 }
 
 

--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -268,7 +268,7 @@ object SpinalConfig{
     }
   }
 
-  var defaultTargetDirectory: String = "."
+  var defaultTargetDirectory: String = System.getenv().getOrDefault("SPINAL_TARGET_DIR", ".")
 }
 
 

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -1230,12 +1230,14 @@ class PhaseDevice(pc : PhaseContext) extends PhaseMisc{
     if(pc.config.device.isVendorDefault || pc.config.device.vendor == Device.XILINX.vendor) {
       pc.walkDeclarations {
         case mem: Mem[_] => {
-          var hit = false
+          var hit, withWrite = false
           mem.foreachStatements {
             case port: MemReadAsync => hit = true
-            case _ =>
+            case port: MemWrite => withWrite = true
+            case port: MemReadWrite => withWrite = true
+            case port: MemReadSync =>
           }
-          if (hit) mem.addAttribute("ram_style", "distributed") //Vivado stupid gambling workaround Synth 8-6430
+          if (hit && withWrite) mem.addAttribute("ram_style", "distributed") //Vivado stupid gambling workaround Synth 8-6430
         }
         case bt: BaseType => {
           if (bt.isReg && (bt.hasTag(crossClockDomain) || bt.hasTag(crossClockBuffer))) {

--- a/tester/src/main/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
+++ b/tester/src/main/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Await
 import scala.sys.process._
 
-abstract class SpinalTesterCocotbBase extends SpinalAnyFunSuite /* with BeforeAndAfterAll with ParallelTestExecution*/ {
+abstract class SpinalTesterCocotbBase extends AnyFunSuite /* with BeforeAndAfterAll with ParallelTestExecution*/ {
   def workspaceRoot = "./cocotbWorkspace"
   def waveFolder = sys.env.getOrElse("WAVES_DIR", new File(workspaceRoot).getAbsolutePath)
   var withWaveform = false
@@ -18,14 +18,13 @@ abstract class SpinalTesterCocotbBase extends SpinalAnyFunSuite /* with BeforeAn
   var cocotbMustPass = true
   var genHdlSuccess = false
   var waveDepth = 99
-  var cocotbWorkspace = "./cocotbWorkspace"
   def noVhdl = false
   def noVerilog = false
 
   def genVhdl: Unit ={
     try {
-      new File(cocotbWorkspace).mkdirs()
-      backendConfig(SpinalConfig(mode = VHDL, targetDirectory=cocotbWorkspace)).generate(createToplevel)
+      new File(workspaceRoot).mkdirs()
+      backendConfig(SpinalConfig(mode = VHDL, targetDirectory=workspaceRoot)).generate(createToplevel)
       genHdlSuccess = true
     } catch {
       case e: Throwable => {
@@ -39,8 +38,8 @@ abstract class SpinalTesterCocotbBase extends SpinalAnyFunSuite /* with BeforeAn
 
   def genVerilog: Unit ={
     try {
-      new File(cocotbWorkspace).mkdirs()
-      backendConfig(SpinalConfig(mode = Verilog, targetDirectory=cocotbWorkspace, dumpWave = if(withWaveform) DumpWaveConfig(depth = waveDepth,vcdPath = waveFolder + "/" + getName + "_verilog.vcd") else null)).generate(createToplevel)
+      new File(workspaceRoot).mkdirs()
+      backendConfig(SpinalConfig(mode = Verilog, targetDirectory=workspaceRoot, dumpWave = if(withWaveform) DumpWaveConfig(depth = waveDepth,vcdPath = waveFolder + "/" + getName + "_verilog.vcd") else null)).generate(createToplevel)
       genHdlSuccess = true
     } catch {
       case e: Throwable => {

--- a/tester/src/main/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
+++ b/tester/src/main/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
@@ -5,8 +5,8 @@ import spinal.core._
 
 import scala.sys.process._
 
-abstract class SpinalTesterGhdlBase extends SpinalAnyFunSuite  {
-
+abstract class SpinalTesterGhdlBase extends AnyFunSuite  {
+  def workspaceRoot = "./simWorkspace"
   var withWaveform = false
   var elaborateMustFail = false
   var checkHDLMustFail = false
@@ -28,7 +28,7 @@ abstract class SpinalTesterGhdlBase extends SpinalAnyFunSuite  {
 
   def getLibraryName = "lib_" + getName
   def elaborate: Unit = {
-    backendConfig(SpinalConfig()).generateVhdl(createToplevel)
+    backendConfig(SpinalConfig(targetDirectory = workspaceRoot)).generateVhdl(createToplevel)
   }
 
   def backendConfig(config: SpinalConfig) : SpinalConfig = {
@@ -46,12 +46,12 @@ abstract class SpinalTesterGhdlBase extends SpinalAnyFunSuite  {
 
 
   def checkHDL(mustSuccess: Boolean): Unit = {
-    val comp = s"ghdl -a --ieee=synopsys --work=$getLibraryName --workdir=$simWorkspacePath $simWorkspacePath/$getName.vhd tester/src/test/resources/${getName}_tb.vhd"
+    val comp = s"ghdl -a --ieee=synopsys --work=$getLibraryName --workdir=$workspaceRoot $workspaceRoot/$getName.vhd tester/src/test/resources/${getName}_tb.vhd"
     println("GHDL compilation " + comp)
     assert(((comp !) == 0) == mustSuccess, if (mustSuccess) "compilation fail" else "Compilation has not fail :(")
 
 
-    val elab = s"ghdl -e --ieee=synopsys --work=$getLibraryName --workdir=$simWorkspacePath ${getName}_tb"
+    val elab = s"ghdl -e --ieee=synopsys --work=$getLibraryName --workdir=$workspaceRoot ${getName}_tb"
     println("GHDL elaborate " + elab)
     assert(((elab !) == 0) == mustSuccess, if (mustSuccess) "compilation fail" else "Compilation has not fail :(")
   }
@@ -64,7 +64,7 @@ abstract class SpinalTesterGhdlBase extends SpinalAnyFunSuite  {
   def simulateHDLWithFail : Unit= simulateHDL(false)
 
   def simulateHDL(mustSuccess : Boolean): Unit = {
-    val run = s"ghdl -r --ieee=synopsys --work=$getLibraryName --workdir=$simWorkspacePath ${getName}_tb --ieee-asserts=disable ${if (!withWaveform) "" else s" --vcd=$getName.vcd"}"
+    val run = s"ghdl -r --ieee=synopsys --work=$getLibraryName --workdir=$workspaceRoot ${getName}_tb --ieee-asserts=disable ${if (!withWaveform) "" else s" --vcd=$getName.vcd"}"
     println("GHDL run " + run)
     val ret = (run !)
     assert(!mustSuccess || ret == 0,"Simulation fail")

--- a/tester/src/test/python/spinal/common/Makefile.sim
+++ b/tester/src/test/python/spinal/common/Makefile.sim
@@ -1,7 +1,7 @@
 COMMON_PATH:=${abspath ${dir ${lastword ${MAKEFILE_LIST}}}}
 
 export PYTHONPATH:=$(COMMON_PATH)/../..
-SPINALROOT=${COMMON_PATH}/../../../../../..
+SPINALROOT=${COMMON_PATH}/../../../../../../cocotbWorkspace
 
 ifeq ($(TOPLEVEL_LANG),vhdl)
 	SIM ?= ghdl

--- a/tester/src/test/scala/spinal/tester/code/Play2.scala
+++ b/tester/src/test/scala/spinal/tester/code/Play2.scala
@@ -691,7 +691,7 @@ object PlayB8 {
 
   def main(args: Array[String]): Unit = {
 //    SpinalConfig(mode = VHDL,targetDirectory="temp/myDesign").generate(new UartCtrl)
-    SpinalConfig.shell(Seq("-aa"))(new UartCtrl)
+    spinal.core.SpinalConfig.shell(Seq("-aa"))(new UartCtrl)
   }
 }
 

--- a/tester/src/test/scala/spinal/tester/code/package.scala
+++ b/tester/src/test/scala/spinal/tester/code/package.scala
@@ -1,5 +1,25 @@
 package spinal.tester
 
-package object code {
-  import spinal.tester.SpinalConfig
+import spinal.core._
+
+package object code {    
+  val simWorkspacePath = spinal.tester.simWorkspacePath
+  
+  def SpinalConfig(
+      mode: SpinalMode = null,
+      dumpWave: DumpWaveConfig = null,
+      defaultConfigForClockDomains: ClockDomainConfig = ClockDomainConfig(),
+      defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency(),
+      allowOutOfRangeLiterals: Boolean = false,
+      verbose: Boolean = false,
+      targetDirectory: String = simWorkspacePath
+  ) = spinal.core.SpinalConfig(
+    mode = mode,
+    dumpWave = dumpWave,
+    targetDirectory = targetDirectory,
+    allowOutOfRangeLiterals = allowOutOfRangeLiterals,
+    verbose = verbose,
+    defaultConfigForClockDomains = defaultConfigForClockDomains,
+    defaultClockDomainFrequency = defaultClockDomainFrequency
+  )
 }

--- a/tester/src/test/scala/spinal/tester/code/package.scala
+++ b/tester/src/test/scala/spinal/tester/code/package.scala
@@ -1,24 +1,48 @@
 package spinal.tester
 
+import scala.collection.mutable.ArrayBuffer
 import spinal.core._
 
-package object code {    
+package object code {
   val simWorkspacePath = spinal.tester.simWorkspacePath
-  
+  import spinal.core.internals.Phase
+
   def SpinalConfig(
       mode: SpinalMode = null,
+      keepAll: Boolean = false,
+      inlineRom: Boolean = false,
+      oneFilePerComponent: Boolean = false,
+      genVhdlPkg: Boolean = true,
+      netlistFileName: String = null,
       dumpWave: DumpWaveConfig = null,
       defaultConfigForClockDomains: ClockDomainConfig = ClockDomainConfig(),
       defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency(),
+      removePruned: Boolean = false,
       allowOutOfRangeLiterals: Boolean = false,
       verbose: Boolean = false,
+      mergeAsyncProcess: Boolean = false,
+      transformationPhases: ArrayBuffer[Phase] = ArrayBuffer[Phase](),
+      rtlHeader: String = null,
+      randBootFixValue: Boolean = true,
+      noAssert: Boolean = false,
       targetDirectory: String = simWorkspacePath
   ) = spinal.core.SpinalConfig(
     mode = mode,
+    keepAll = keepAll,
+    inlineRom = inlineRom,
+    oneFilePerComponent = oneFilePerComponent,
+    genVhdlPkg = genVhdlPkg,
+    netlistFileName = netlistFileName,
     dumpWave = dumpWave,
     targetDirectory = targetDirectory,
+    removePruned = removePruned,
     allowOutOfRangeLiterals = allowOutOfRangeLiterals,
     verbose = verbose,
+    mergeAsyncProcess = mergeAsyncProcess,
+    transformationPhases = transformationPhases,
+    rtlHeader = rtlHeader,
+    randBootFixValue = randBootFixValue,
+    noAssert = noAssert,
     defaultConfigForClockDomains = defaultConfigForClockDomains,
     defaultClockDomainFrequency = defaultClockDomainFrequency
   )

--- a/tester/src/test/scala/spinal/tester/code/package.scala
+++ b/tester/src/test/scala/spinal/tester/code/package.scala
@@ -1,5 +1,5 @@
 package spinal.tester
 
 package object code {
-    def SpinalConfig() = spinal.core.SpinalConfig(targetDirectory = simWorkspacePath)
+  import spinal.tester.SpinalConfig
 }

--- a/tester/src/test/scala/spinal/tester/code/package.scala
+++ b/tester/src/test/scala/spinal/tester/code/package.scala
@@ -1,0 +1,5 @@
+package spinal.tester
+
+package object code {
+    def SpinalConfig() = spinal.core.SpinalConfig(targetDirectory = simWorkspacePath)
+}

--- a/tester/src/test/scala/spinal/tester/code/package.scala
+++ b/tester/src/test/scala/spinal/tester/code/package.scala
@@ -5,45 +5,5 @@ import spinal.core._
 
 package object code {
   val simWorkspacePath = spinal.tester.simWorkspacePath
-  import spinal.core.internals.Phase
-
-  def SpinalConfig(
-      mode: SpinalMode = null,
-      keepAll: Boolean = false,
-      inlineRom: Boolean = false,
-      oneFilePerComponent: Boolean = false,
-      genVhdlPkg: Boolean = true,
-      netlistFileName: String = null,
-      dumpWave: DumpWaveConfig = null,
-      defaultConfigForClockDomains: ClockDomainConfig = ClockDomainConfig(),
-      defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency(),
-      removePruned: Boolean = false,
-      allowOutOfRangeLiterals: Boolean = false,
-      verbose: Boolean = false,
-      mergeAsyncProcess: Boolean = false,
-      transformationPhases: ArrayBuffer[Phase] = ArrayBuffer[Phase](),
-      rtlHeader: String = null,
-      randBootFixValue: Boolean = true,
-      noAssert: Boolean = false,
-      targetDirectory: String = simWorkspacePath
-  ) = spinal.core.SpinalConfig(
-    mode = mode,
-    keepAll = keepAll,
-    inlineRom = inlineRom,
-    oneFilePerComponent = oneFilePerComponent,
-    genVhdlPkg = genVhdlPkg,
-    netlistFileName = netlistFileName,
-    dumpWave = dumpWave,
-    targetDirectory = targetDirectory,
-    removePruned = removePruned,
-    allowOutOfRangeLiterals = allowOutOfRangeLiterals,
-    verbose = verbose,
-    mergeAsyncProcess = mergeAsyncProcess,
-    transformationPhases = transformationPhases,
-    rtlHeader = rtlHeader,
-    randBootFixValue = randBootFixValue,
-    noAssert = noAssert,
-    defaultConfigForClockDomains = defaultConfigForClockDomains,
-    defaultClockDomainFrequency = defaultClockDomainFrequency
-  )
+  type SpinalAnyFunSuite = spinal.tester.SpinalAnyFunSuite
 }

--- a/tester/src/test/scala/spinal/tester/package.scala
+++ b/tester/src/test/scala/spinal/tester/package.scala
@@ -1,0 +1,5 @@
+package spinal
+
+package object tester {
+    val simWorkspacePath = "./simWorkspace"
+}

--- a/tester/src/test/scala/spinal/tester/package.scala
+++ b/tester/src/test/scala/spinal/tester/package.scala
@@ -1,5 +1,25 @@
 package spinal
 
+import spinal.core._
+
 package object tester {
-    val simWorkspacePath = "./simWorkspace"
+  val simWorkspacePath = "./simWorkspace"
+
+  def SpinalConfig(
+      mode: SpinalMode = null,
+      dumpWave: DumpWaveConfig = null,
+      defaultConfigForClockDomains: ClockDomainConfig = ClockDomainConfig(),
+      defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency(),
+      allowOutOfRangeLiterals: Boolean = false,
+      verbose: Boolean = false,
+      targetDirectory: String = simWorkspacePath
+  ) = spinal.core.SpinalConfig(
+    mode = mode,
+    dumpWave = dumpWave,
+    targetDirectory = targetDirectory,
+    allowOutOfRangeLiterals = allowOutOfRangeLiterals,
+    verbose = verbose,
+    defaultConfigForClockDomains = defaultConfigForClockDomains,
+    defaultClockDomainFrequency = defaultClockDomainFrequency
+  )
 }

--- a/tester/src/test/scala/spinal/tester/package.scala
+++ b/tester/src/test/scala/spinal/tester/package.scala
@@ -4,22 +4,4 @@ import spinal.core._
 
 package object tester {
   val simWorkspacePath = "./simWorkspace"
-
-  def SpinalConfig(
-      mode: SpinalMode = null,
-      dumpWave: DumpWaveConfig = null,
-      defaultConfigForClockDomains: ClockDomainConfig = ClockDomainConfig(),
-      defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency(),
-      allowOutOfRangeLiterals: Boolean = false,
-      verbose: Boolean = false,
-      targetDirectory: String = simWorkspacePath
-  ) = spinal.core.SpinalConfig(
-    mode = mode,
-    dumpWave = dumpWave,
-    targetDirectory = targetDirectory,
-    allowOutOfRangeLiterals = allowOutOfRangeLiterals,
-    verbose = verbose,
-    defaultConfigForClockDomains = defaultConfigForClockDomains,
-    defaultClockDomainFrequency = defaultClockDomainFrequency
-  )
 }

--- a/tester/src/test/scala/spinal/tester/package.scala
+++ b/tester/src/test/scala/spinal/tester/package.scala
@@ -1,7 +1,11 @@
 package spinal
 
+import org.scalatest.funsuite.AnyFunSuite
 import spinal.core._
 
 package object tester {
   val simWorkspacePath = "./simWorkspace"
+  class SpinalAnyFunSuite extends AnyFunSuite {
+    SpinalConfig.defaultTargetDirectory = simWorkspacePath
+  }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
@@ -12,7 +12,7 @@ import spinal.lib.{master, slave}
 import scala.collection.mutable
 import scala.util.Random
 
-class Axi4UpsizerTester extends AnyFunSuite {
+class Axi4UpsizerTester extends SpinalAnyFunSuite {
 
   def writeTester(dut : Axi4WriteOnlyUpsizer): Unit ={
     dut.clockDomain.forkStimulus(10)
@@ -130,7 +130,7 @@ class Axi4UpsizerTester extends AnyFunSuite {
   }
 }
 
-class Axi4DownsizerTester extends AnyFunSuite {
+class Axi4DownsizerTester extends SpinalAnyFunSuite {
 
     def writeTester(dut: Axi4WriteOnlyDownsizer, pipelined: Boolean = false): Unit = {
         dut.clockDomain.forkStimulus(10)
@@ -327,7 +327,7 @@ class Axi4DownsizerTester extends AnyFunSuite {
     }
 }
 
-class Axi4IdRemoverTester extends AnyFunSuite {
+class Axi4IdRemoverTester extends SpinalAnyFunSuite {
 
   def writeTester(dut : Axi4WriteOnlyIdRemover): Unit ={
     dut.clockDomain.forkStimulus(10)

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4SharedOnChipRamTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4SharedOnChipRamTester.scala
@@ -55,7 +55,7 @@ case class Axi4SharedOnChipRamMultiPortWithSoftresetFixture(config: Axi4Config, 
     io.axis(1).toShared() >> port1
 }
 
-class Axi4SharedOnChipRamMultiPortTester extends AnyFunSuite {
+class Axi4SharedOnChipRamMultiPortTester extends SpinalAnyFunSuite {
 
     val memory  = mutable.HashMap[BigInt, Byte]()
     val regions = mutable.Set[SizeMapping]()

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4SimAgentTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4SimAgentTester.scala
@@ -31,7 +31,7 @@ case class Axi4PassthroughFixture(config: Axi4Config) extends Component {
     io.output.b >> io.input.b
 }
 
-class Axi4SimAgentTester extends AnyFunSuite {
+class Axi4SimAgentTester extends SpinalAnyFunSuite {
 
     def writeTester(dut: Axi4PassthroughFixture): Unit = {
         dut.clockDomain.forkStimulus(10)

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4StreamSimpleWidthAdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4StreamSimpleWidthAdapterTester.scala
@@ -33,7 +33,7 @@ case class Axi4StreamSimpleWidthAdapterFixture(inSize: Int, outSize: Int, useLas
   Axi4StreamSimpleWidthAdapter(io.axis_s.stage(), io.axis_m)
 }
 
-class Axi4StreamSimpleWidthAdapterTester extends AnyFunSuite {
+class Axi4StreamSimpleWidthAdapterTester extends SpinalAnyFunSuite {
 
   case class Axi4CheckByte(val data: BigInt = 0,
                            val strb: Boolean = false,

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4StreamTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4StreamTester.scala
@@ -35,7 +35,7 @@ case class Axi4StreamFragmentFixture[T <: Data](config: Axi4StreamConfig, outTyp
   io.m_axis << Axi4Stream(io.s_data.stage())
 }
 
-class Axi4StreamTester extends AnyFunSuite {
+class Axi4StreamTester extends SpinalAnyFunSuite {
 
   def duplexTest(dut: Axi4StreamEndianFixture[Bits]): Unit = {
     dut.clockDomain.forkStimulus(10)

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4StreamWidthAdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4StreamWidthAdapterTester.scala
@@ -32,7 +32,7 @@ case class Axi4StreamWidthAdapterFixture(inSize: Int, outSize: Int, compact: Boo
   Axi4StreamWidthAdapter(io.axis_s, io.axis_m, compact = compact)
 }
 
-class Axi4StreamWidthAdapterTester extends AnyFunSuite {
+class Axi4StreamWidthAdapterTester extends SpinalAnyFunSuite {
 
   case class Axi4CheckByte(val data: BigInt = 0,
                            val strb: Boolean = false,

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4ToAxiLite4Tester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4ToAxiLite4Tester.scala
@@ -24,7 +24,7 @@ class Axi4ToAxiLite4TesterComp(config: Axi4Config) extends Component {
   io.axi.toLite() >> io.axilite
 }
 
-class Axi4ToAxiLite4Tester extends AnyFunSuite {
+class Axi4ToAxiLite4Tester extends SpinalAnyFunSuite {
 
   def tester(dut: Axi4ToAxiLite4TesterComp): Unit = {
     dut.clockDomain.forkStimulus(10)

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4UnburstTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4UnburstTester.scala
@@ -9,7 +9,7 @@ import spinal.lib.sim.ScoreboardInOrder
 
 import scala.util.Random
 
-class Axi4UnburstTester extends AnyFunSuite {
+class Axi4UnburstTester extends SpinalAnyFunSuite {
 
   def tester_readonly(dut: Axi4ReadOnlyUnburster): Unit = {
     dut.clockDomain.forkStimulus(10)

--- a/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryDoubleRead.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryDoubleRead.scala
@@ -42,7 +42,7 @@ object TestTopLevel {
 
 }
 
-class BusSlaveFactoryDoubleReadTester extends AnyFunSuite {
+class BusSlaveFactoryDoubleReadTester extends SpinalAnyFunSuite {
 
   test("BusSlaveFactoryDoubleRead") {
 

--- a/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
@@ -528,7 +528,7 @@ class RepeatabilityTester extends AnyFunSuite{
 
   test("Apb3I2cCtrlGraph"){
     val dut = SpinalConfig(defaultClockDomainFrequency = FixedFrequency(50 MHz)).generateVerilog(new Apb3I2cCtrl(configI2C)).toplevel
-    assert(GraphUtils.countNames(dut) == 225)
+    assert(GraphUtils.countNames(dut) == 227)
   }
 
   test("UartGraph"){

--- a/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/ChecksTester.scala
@@ -41,7 +41,7 @@ object CheckTester{
   }
 }
 
-class ChecksTester extends AnyFunSuite  {
+class ChecksTester extends SpinalAnyFunSuite  {
   import CheckTester._
 
 
@@ -505,7 +505,7 @@ class ChecksTester extends AnyFunSuite  {
 
 }
 
-class RepeatabilityTester extends AnyFunSuite{
+class RepeatabilityTester extends SpinalAnyFunSuite{
   var checkOutputHashCounter = 0
   def checkOutputHash(gen : => Component): Unit ={
     checkOutputHashCounter = checkOutputHashCounter + 1
@@ -556,7 +556,7 @@ class RepeatabilityTester extends AnyFunSuite{
   }
 }
 
-class NameingTester extends AnyFunSuite {
+class NameingTester extends SpinalAnyFunSuite {
   import CheckTester._
 
 

--- a/tester/src/test/scala/spinal/tester/scalatest/CoreMiscTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/CoreMiscTester.scala
@@ -5,7 +5,7 @@ import spinal.core._
 import spinal.core.sim._
 import spinal.lib._
 import scala.util.Random
-class CoreMiscTester extends AnyFunSuite{
+class CoreMiscTester extends SpinalAnyFunSuite{
   test("SlowArea"){
     SimConfig.withConfig(SpinalConfig(defaultClockDomainFrequency = FixedFrequency(4000 Hz))).compile(new Component{
       val counter = out(RegInit(U"0000"))

--- a/tester/src/test/scala/spinal/tester/scalatest/CrossClockCheckerTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/CrossClockCheckerTester.scala
@@ -44,7 +44,7 @@ class CrossClockCheckerTesterC extends Component{
 }
 
 
-class CrossClockCheckerTester extends AnyFunSuite{
+class CrossClockCheckerTester extends SpinalAnyFunSuite{
   import CheckTester._
 
   test("a") {
@@ -174,7 +174,7 @@ class SyncronousCheckerTesterD(v : Int) extends Component{
   }
 }
 
-class SyncronousCheckerTester extends AnyFunSuite{
+class SyncronousCheckerTester extends SpinalAnyFunSuite{
   import CheckTester._
 
   test("a") { generationShouldPass(new SyncronousCheckerTesterA) }

--- a/tester/src/test/scala/spinal/tester/scalatest/DataAnalyzerTest.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/DataAnalyzerTest.scala
@@ -3,7 +3,7 @@ package spinal.tester.scalatest
 import spinal.core._
 import org.scalatest.funsuite._
 
-class DataAnalyzerTest extends AnyFunSuite {
+class DataAnalyzerTest extends SpinalAnyFunSuite {
 
   case class TestModule() extends Module {
     val io = new Bundle {

--- a/tester/src/test/scala/spinal/tester/scalatest/InOutTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/InOutTester.scala
@@ -211,7 +211,7 @@ class InOutTester3CocotbBoot extends SpinalTesterCocotbBase {
 }
 
 
-class InOutTester4 extends AnyFunSuite {
+class InOutTester4 extends SpinalAnyFunSuite {
   case class A() extends Component {
     val data=inout(Analog(Bool()))
   }

--- a/tester/src/test/scala/spinal/tester/scalatest/Issue963Tester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Issue963Tester.scala
@@ -27,7 +27,7 @@ import spinal.core.sim._
 // [info] Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
 // [info] *** 1 TEST FAILED ***
 
-class Issue963Tester extends AnyFunSuite {
+class Issue963Tester extends SpinalAnyFunSuite {
   test("Minimal example for Issue963 which fails Spinal elaboration") {
     class Dut extends Component {
       val io = new Bundle {

--- a/tester/src/test/scala/spinal/tester/scalatest/LatchTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/LatchTester.scala
@@ -4,7 +4,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import spinal.core._
 import spinal.core.sim._
 
-class LatchTester extends AnyFunSuite {
+class LatchTester extends SpinalAnyFunSuite {
   test("bad latch") {
     var didRaise = false
 

--- a/tester/src/test/scala/spinal/tester/scalatest/RegIfAxiLite4Tester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/RegIfAxiLite4Tester.scala
@@ -47,7 +47,7 @@ class RegIfTester extends Component {
   io.o_z := RegNextWhen(io.o, io.bus.b.fire || io.bus.r.fire) init(0)
 }
 
-class RegIfAxiLite4Tester extends AnyFunSuite {
+class RegIfAxiLite4Tester extends SpinalAnyFunSuite {
 
   def bitWidth = 32
 

--- a/tester/src/test/scala/spinal/tester/scalatest/RegIfBasicAccessTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/RegIfBasicAccessTester.scala
@@ -4,18 +4,18 @@ import org.scalatest.funsuite.AnyFunSuite
 import spinal.tester.generator.regif.{BasicTest, RegIfStrbTesterSim}
 
 
-class RegIfBasicRtlGenerater extends AnyFunSuite{
+class RegIfBasicRtlGenerater extends SpinalAnyFunSuite{
   test("gen_demo_regbank"){BasicTest.genrtl("demo")}
   test("gen_apb4_regbank"){BasicTest.genrtl("apb4")}
   test("gen_apb3_regbank"){BasicTest.genrtl("apb3")}
 }
 
-class RegIfBasicAccessTester extends AnyFunSuite{
+class RegIfBasicAccessTester extends SpinalAnyFunSuite{
   test("regif_basic_access_tester_apb4"){BasicTest.main(Array("apb4"))}
   test("regif_basic_access_tester_apb3"){BasicTest.main(Array("apb3"))}
 }
 
-class RegIfStrbTester extends AnyFunSuite{
+class RegIfStrbTester extends SpinalAnyFunSuite{
   test("apb4_strb_tester"){RegIfStrbTesterSim.sim("all", false)}
   test("apb4_strb_debug"){RegIfStrbTesterSim.sim("debug", true)}
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/RomTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/RomTester.scala
@@ -142,7 +142,7 @@ class RomTesterCocotbBoot3 extends SpinalTesterCocotbBase {
   }
 }
 
-class SpinalSimRomTester extends AnyFunSuite {
+class SpinalSimRomTester extends SpinalAnyFunSuite {
   test("test1"){
     import spinal.core.sim._
     import spinal.sim._

--- a/tester/src/test/scala/spinal/tester/scalatest/RomTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/RomTester.scala
@@ -121,7 +121,7 @@ class RomTesterCocotbBoot2 extends SpinalTesterCocotbBase {
     super.genVerilog
     import scala.sys.process._
     s"rm $pythonTestLocation/RomTester2.v_toplevel_rom.bin".!
-    s"cp $cocotbWorkspace/RomTester2.v_toplevel_rom.bin $pythonTestLocation".!
+    s"cp $workspaceRoot/RomTester2.v_toplevel_rom.bin $pythonTestLocation".!
   }
 }
 
@@ -137,7 +137,7 @@ class RomTesterCocotbBoot3 extends SpinalTesterCocotbBase {
     import scala.sys.process._
     for(i <- 0 to 3) {
       s"rm $pythonTestLocation/RomTester3.v_toplevel_rom_symbol$i.bin".!
-      s"cp $cocotbWorkspace/RomTester3.v_toplevel_rom_symbol$i.bin $pythonTestLocation".!
+      s"cp $workspaceRoot/RomTester3.v_toplevel_rom_symbol$i.bin $pythonTestLocation".!
     }
   }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/RomTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/RomTester.scala
@@ -121,7 +121,7 @@ class RomTesterCocotbBoot2 extends SpinalTesterCocotbBase {
     super.genVerilog
     import scala.sys.process._
     s"rm $pythonTestLocation/RomTester2.v_toplevel_rom.bin".!
-    s"cp RomTester2.v_toplevel_rom.bin $pythonTestLocation".!
+    s"cp $cocotbWorkspace/RomTester2.v_toplevel_rom.bin $pythonTestLocation".!
   }
 }
 
@@ -137,7 +137,7 @@ class RomTesterCocotbBoot3 extends SpinalTesterCocotbBase {
     import scala.sys.process._
     for(i <- 0 to 3) {
       s"rm $pythonTestLocation/RomTester3.v_toplevel_rom_symbol$i.bin".!
-      s"cp RomTester3.v_toplevel_rom_symbol$i.bin $pythonTestLocation".!
+      s"cp $cocotbWorkspace/RomTester3.v_toplevel_rom_symbol$i.bin $pythonTestLocation".!
     }
   }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/SimBigIntPimperTest.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SimBigIntPimperTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import spinal.core.sim._
 import spinal.core.{BIG, Endianness, LITTLE}
 
-class SimBigIntPimperTest extends AnyFunSuite {
+class SimBigIntPimperTest extends SpinalAnyFunSuite {
   def toBytes(bi: BigInt, bits: Int = -1, endian: Endianness = LITTLE) =
     bi.toBytes(bits, endian).map(i => f"$i%02x").mkString(" ")
   test("positive") {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAFixTester.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable
 import scala.math.BigDecimal.RoundingMode
 import scala.util.Random
 
-class SpinalSimAFixTester extends AnyFunSuite {
+class SpinalSimAFixTester extends SpinalAnyFunSuite {
   def check(max : Int, min : Int, exp : Int)(f : AFix): Unit ={
     assert(f.maxRaw == max && f.minRaw == min && f.exp == exp)
   }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAccessSubComponents.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAccessSubComponents.scala
@@ -44,7 +44,7 @@ object SpinalSimAccessSubComponents {
 
 }
 
-class SpinalSimAccessSubComponents extends AnyFunSuite {
+class SpinalSimAccessSubComponents extends SpinalAnyFunSuite {
   SpinalSimTester { env =>
     import env._
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAvalonSTTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAvalonSTTester.scala
@@ -36,7 +36,7 @@ case class AvalonSTDelayAdapterFixture(config: AvalonSTConfig,
   AvalonSTDelayAdapter(io.s, io.m)
 }
 
-class AvalonSTTester extends AnyFunSuite {
+class AvalonSTTester extends SpinalAnyFunSuite {
 
   for(s2m <- List(false, true);
       m2s <- List(false, true);

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbAlignerTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbAlignerTester.scala
@@ -7,7 +7,7 @@ import spinal.core.sim.SimConfig
 import spinal.lib.bus.bmb.{BmbAligner, BmbDownSizerBridge, BmbParameter}
 import spinal.lib.bus.bmb.sim.BmbBridgeTester
 
-class SpinalSimBmbAlignerTester extends AnyFunSuite {
+class SpinalSimBmbAlignerTester extends SpinalAnyFunSuite {
   for(w <- List(false, true); r <- List(false, true);   if w || r) {
     val header = "_" + (if(w) "w" else "") + (if(r) "r" else "")
     test("BmbAligner_bypass" + header) {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbDecoderOutOfOrderTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbDecoderOutOfOrderTester.scala
@@ -16,7 +16,7 @@ import scala.util.Random
 
 
 
-class SpinalSimBmbDecoderOutOfOrderTester extends AnyFunSuite {
+class SpinalSimBmbDecoderOutOfOrderTester extends SpinalAnyFunSuite {
   def doIt(outputCount : Int, sourceCount : Int, withDefault : Boolean): Unit ={
     val p = BmbParameter(
       addressWidth = 20,
@@ -92,7 +92,7 @@ class SpinalSimBmbDecoderOutOfOrderTester extends AnyFunSuite {
 }
 
 
-class SpinalSimBmbDecoderInOrderTester extends AnyFunSuite {
+class SpinalSimBmbDecoderInOrderTester extends SpinalAnyFunSuite {
   for(pipelinedDecoder <- List(false, true);
       pipelinedHalfPipe <- List(false, true))
   test(s"t1_${pipelinedDecoder}_${pipelinedHalfPipe}") {
@@ -126,7 +126,7 @@ class SpinalSimBmbDecoderInOrderTester extends AnyFunSuite {
   }
 }
 
-class SpinalSimBmbDecoderInOrderPerSourceTester extends AnyFunSuite {
+class SpinalSimBmbDecoderInOrderPerSourceTester extends SpinalAnyFunSuite {
   test("t1") {
     val p = BmbParameter(
       addressWidth = 20,

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbExclusiveMonitorTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbExclusiveMonitorTester.scala
@@ -22,7 +22,7 @@ private object MODIFY
 private object WRITE_CMD
 private object WRITE_RSP
 
-class SpinalSimBmbExclusiveMonitorTester extends AnyFunSuite{
+class SpinalSimBmbExclusiveMonitorTester extends SpinalAnyFunSuite{
   test("miaou") {
     SimConfig.compile(
       new BmbExclusiveMonitor(

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbLengthSpliterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbLengthSpliterTester.scala
@@ -5,7 +5,7 @@ import spinal.core.sim.SimConfig
 import spinal.lib.bus.bmb.sim.BmbBridgeTester
 import spinal.lib.bus.bmb.{BmbAccessParameter, BmbAlignedSpliter, BmbParameter, BmbSourceParameter}
 
-class SpinalSimBmbLengthSpliterTester extends AnyFunSuite {
+class SpinalSimBmbLengthSpliterTester extends SpinalAnyFunSuite {
   for(w <- List(false, true); r <- List(false, true);   if w || r) {
     val header = "_" + (if (w) "w" else "") + (if (r) "r" else "")
     test("bypass" + header) {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbUnburstifyTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBmbUnburstifyTester.scala
@@ -5,7 +5,7 @@ import spinal.core.sim.SimConfig
 import spinal.lib.bus.bmb.sim.BmbBridgeTester
 import spinal.lib.bus.bmb.{BmbAccessParameter, BmbLengthFixer, BmbParameter, BmbSourceParameter, BmbUnburstify}
 
-class SpinalSimBmbUnburstifyTester extends AnyFunSuite {
+class SpinalSimBmbUnburstifyTester extends SpinalAnyFunSuite {
   test("miaou") {
     SimConfig.compile {
       val c = BmbUnburstify(

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBsbTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimBsbTester.scala
@@ -11,7 +11,7 @@ import spinal.lib.bus.bsb.sim.BsbBridgeTester
 import spinal.lib._
 import spinal.lib.system.dma.sg.{DmaSg, DmaSgTester, SgDmaTestsParameter}
 
-class SpinalSimBsbTester extends AnyFunSuite{
+class SpinalSimBsbTester extends SpinalAnyFunSuite{
   test("upsizerSparse"){
     SimConfig.doSim(new BsbUpSizerSparse(
       p = BsbParameter(

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimDmaSgTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimDmaSgTester.scala
@@ -10,7 +10,7 @@ import spinal.core.sim._
 import scala.util.Random
 import org.scalatest.{ParallelTestExecution, BeforeAndAfterAll}
 
-class SpinalSimDmaSgTester extends AnyFunSuite {
+class SpinalSimDmaSgTester extends SpinalAnyFunSuite {
   Random.setSeed(42)
   for((name, p) <- SgDmaTestsParameter(allowSmallerStreams = false)) test(name){
       SgDmaTestsParameter.test(p)

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimEncoding8b10b.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimEncoding8b10b.scala
@@ -7,7 +7,7 @@ import spinal.core._
 import spinal.core.sim._
 import spinal.lib.com.linecode.Encoding8b10b
 
-class Encoding8b10bTest extends AnyFunSuite {
+class Encoding8b10bTest extends SpinalAnyFunSuite {
 
   def encodeTestCase(dut: Encoding8b10b.Encoder, data: String, kWord: Boolean, encoded: String,
                      kError: Boolean) {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimLibTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimLibTester.scala
@@ -1,3 +1,5 @@
+package spinal.tester.scalatest
+
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.core._
 import spinal.core.sim._
@@ -8,7 +10,7 @@ import spinal.lib.sim.{FlowMonitor, StreamDriver, StreamMonitor, StreamReadyRand
 import scala.collection.mutable
 import scala.util.Random
 
-class SpinalSimLibTester extends AnyFunSuite {
+class SpinalSimLibTester extends SpinalAnyFunSuite {
   for (n <- 0 until 12) {
     test("Vec (op) Vec on " + n + " elements") {
       SimConfig.noOptimisation

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMacTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMacTester.scala
@@ -10,7 +10,7 @@ import spinal.lib.sim.{FlowMonitor, StreamDriver, StreamMonitor, StreamReadyRand
 import scala.collection.mutable
 import scala.util.Random
 
-class SpinalSimMacTester extends AnyFunSuite{
+class SpinalSimMacTester extends SpinalAnyFunSuite{
   def hexStringToFrame(str : String) = {
     val spaceLess = str.replace(" ","")
     Seq.tabulate[Int](spaceLess.size/2)(i => Integer.parseInt(spaceLess.substring(i*2, i*2+2), 16))

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
@@ -69,7 +69,7 @@ object SpinalSimTester{
   }
 }
 
-class SpinalSimTesterTest extends AnyFunSuite {
+class SpinalSimTesterTest extends SpinalAnyFunSuite {
   SpinalSimTester{ env =>
     import env._
 
@@ -79,7 +79,7 @@ class SpinalSimTesterTest extends AnyFunSuite {
   }
 }
 
-class SpinalSimFunSuite extends AnyFunSuite{
+class SpinalSimFunSuite extends SpinalAnyFunSuite{
   var tester : SpinalSimTester = null
   def SimConfig = tester.SimConfig
   var durationFactor = 0.0
@@ -109,7 +109,7 @@ class SpinalSimFunSuite extends AnyFunSuite{
   }
 }
 
-class SpinalSimMiscTester extends AnyFunSuite {
+class SpinalSimMiscTester extends SpinalAnyFunSuite {
   SpinalSimTester { env =>
     import env._
     var compiled: SimCompiled[tester.scalatest.SpinalSimMiscTester.SpinalSimMiscTesterCounter] = null

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimOneEntryRamTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimOneEntryRamTester.scala
@@ -135,7 +135,7 @@ class SpinalSimOneEntryRamTester extends SpinalSimFunSuite{
 }
 
 
-class SpinalSimRamTester extends AnyFunSuite {
+class SpinalSimRamTester extends SpinalAnyFunSuite {
   test("general") {
     SimConfig.withConfig(SpinalConfig(device = Device.XILINX)).compile(new Component {
       val ram = Mem(Bits(32 bits), 256)

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
@@ -5,7 +5,7 @@ import spinal.core._
 import spinal.lib._
 import spinal.core.sim._
 
-class SpinalSimPackedBundleTester extends AnyFunSuite {
+class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
   test("pack") {
     SimConfig.withWave.compile(new Component {
       val packedBundle = new PackedBundle {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPerfTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPerfTester.scala
@@ -23,7 +23,7 @@ object SpinalSimPerfTester {
 
 }
 
-class SpinalSimPerfTester extends AnyFunSuite {
+class SpinalSimPerfTester extends SpinalAnyFunSuite {
   SpinalSimTester { env =>
     import env._
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimRandomizeTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimRandomizeTester.scala
@@ -25,7 +25,7 @@ case class SimRandomizeTester() extends Component {
   }
 }
 
-class SpinalSimRandomizeTest extends AnyFunSuite {
+class SpinalSimRandomizeTest extends SpinalAnyFunSuite {
   val dut = SimConfig.compile { SimRandomizeTester() }
 
   test("randomize returns the value driven next") {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimSigmaDeltaTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimSigmaDeltaTester.scala
@@ -14,7 +14,7 @@ import spinal.lib.system.dma.sg.DmaSg
 
 import scala.collection.mutable
 
-class SpinalSimSigmaDeltaTester extends AnyFunSuite{
+class SpinalSimSigmaDeltaTester extends SpinalAnyFunSuite{
   test("a"){
     SimConfig.compile(
       BmbBsbToDeltaSigma(

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimSpiXdr.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimSpiXdr.scala
@@ -35,7 +35,7 @@ import scala.util.Random
 
 
 
-class SpinalSimSpiXdrMaster extends AnyFunSuite {
+class SpinalSimSpiXdrMaster extends SpinalAnyFunSuite {
   SpinalSimTester { env =>
     import env._
     var compiled: SimCompiled[SpiXdrMasterCtrl.TopLevel] = null

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamFifoMultiChannelSharedSpaceTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamFifoMultiChannelSharedSpaceTester.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
-class SpinalSimStreamFifoMultiChannelSharedSpaceTester extends AnyFunSuite {
+class SpinalSimStreamFifoMultiChannelSharedSpaceTester extends SpinalAnyFunSuite {
   test("t1") {
     SimConfig.compile(new StreamFifoMultiChannelSharedSpace(Bits(32 bits), 4, 16)).doSimUntilVoid(seed = 42) { dut =>
       val queueModel = ArrayBuffer.fill(4)(mutable.Queue[Long]())

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimUsbHostTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimUsbHostTester.scala
@@ -17,7 +17,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
-class SpinalSimUsbHostTester extends AnyFunSuite{
+class SpinalSimUsbHostTester extends SpinalAnyFunSuite{
   val seed = 59
   /*for(seed <- 55 until 88) */ test("host" + seed){
     val p = UsbOhciParameter(

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimUsbTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimUsbTester.scala
@@ -11,7 +11,7 @@ import spinal.lib.sim.{StreamDriver, StreamMonitor, StreamReadyRandomizer}
 import scala.collection.mutable
 import scala.util.Random
 
-class SpinalSimUsbTester extends AnyFunSuite{
+class SpinalSimUsbTester extends SpinalAnyFunSuite{
 //  implicit class UsbLsFsCtrlPimper(self : UsbHubLsFs.Ctrl)(implicit cd : ClockDomain){
 //    def init(): Unit = {
 //      self.tx.kind #= UsbHubLsFs.TxKind.NONE

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimVerilatorIoTest.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimVerilatorIoTest.scala
@@ -69,7 +69,7 @@ object SpinalSimVerilatorIoTest{
   }
 }
 
-class SpinalSimVerilatorIoTest extends AnyFunSuite {
+class SpinalSimVerilatorIoTest extends SpinalAnyFunSuite {
   SpinalSimTester { env =>
     import env._
     var compiled: SimCompiled[SpinalSimVerilatorIoTestTop] = null

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneAdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneAdapterTester.scala
@@ -23,7 +23,7 @@ class WishboneSimpleBusAdapted( configIn : WishboneConfig,
   val adapter = WishboneAdapter(io.busIN,io.busOUT,allowAddressResize,allowDataResize,allowTagResize)
 }
 
-class SpinalSimWishboneAdapterTester extends AnyFunSuite{
+class SpinalSimWishboneAdapterTester extends SpinalAnyFunSuite{
   def testBus(confIN:WishboneConfig,confOUT:WishboneConfig,allowAddressResize: Boolean = false,allowDataResize: Boolean = false,allowTagResize: Boolean = false, description : String = ""): Unit = {
     val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneSimpleBusAdapted(confIN,confOUT){val miaou = out(RegNext(False))})
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneArbiterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneArbiterTester.scala
@@ -45,7 +45,7 @@ case class WishboneMemoryHarness(config: WishboneConfig, size: Int) extends Comp
   ack := rEn & !ack
 }
 
-class SpinalSimWishboneArbiterTester extends AnyFunSuite{
+class SpinalSimWishboneArbiterTester extends SpinalAnyFunSuite{
   def testArbiter(config : WishboneConfig,size: Int,description : String = ""): Unit = {
     val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneArbiterComponent(config,size))
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
@@ -21,7 +21,7 @@ class WishboneDecoderComponent(config : WishboneConfig,decodings : Seq[SizeMappi
   val decoder = WishboneDecoder(io.busIN,outs)
 }
 
-class SpinalSimWishboneDecoderTester extends AnyFunSuite{
+class SpinalSimWishboneDecoderTester extends SpinalAnyFunSuite{
   def testDecoder(config : WishboneConfig,decodings : Seq[SizeMapping],description : String = ""): Unit = {
     val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneDecoderComponent(config,decodings){val miaou = out(RegNext(False))})
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimInterconTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimInterconTester.scala
@@ -30,7 +30,7 @@ class WishboneInterconComponent(config : WishboneConfig,n_masters: Int,decodings
   }
 }
 
-class SpinalSimWishboneSimInterconTester extends AnyFunSuite{
+class SpinalSimWishboneSimInterconTester extends SpinalAnyFunSuite{
   def testIntercon(config : WishboneConfig,decodings : Seq[SizeMapping],masters: Int,description : String = ""): Unit = {
     val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneInterconComponent(config,masters,decodings))
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimTester.scala
@@ -19,7 +19,7 @@ class wishbonesimplebus(config : WishboneConfig) extends Component{
   val ff = Reg(Bool())
   io.busmaster <> io.busslave
 }
-class SpinalSimWishboneSimTester extends AnyFunSuite{
+class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
 
   var compiled : SimCompiled[wishbonesimplebus] = null
   var compPipe : SimCompiled[wishbonesimplebus] = null

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
@@ -18,7 +18,7 @@ class WishboneSimpleSlave(config : WishboneConfig) extends Component{
   val reg = busCtrl.createReadWrite(Bits(busCtrl.busDataWidth bits),10)
 }
 
-class SpinalSimWishboneSlaveFactoryTester extends AnyFunSuite{
+class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
   def testBus(conf:WishboneConfig, description : String = ""): Unit = {
     val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneSimpleSlave(conf))
     fixture.doSim(description){ dut =>

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Await
 import scala.sys.process._
 
-abstract class SpinalTesterCocotbBase extends AnyFunSuite /* with BeforeAndAfterAll with ParallelTestExecution*/ {
+abstract class SpinalTesterCocotbBase extends SpinalAnyFunSuite /* with BeforeAndAfterAll with ParallelTestExecution*/ {
   def workspaceRoot = "./cocotbWorkspace"
   def waveFolder = sys.env.getOrElse("WAVES_DIR", new File(workspaceRoot).getAbsolutePath)
   var withWaveform = false

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
@@ -23,7 +23,7 @@ abstract class SpinalTesterCocotbBase extends AnyFunSuite /* with BeforeAndAfter
   def genVhdl: Unit ={
     try {
       val waveFolder = sys.env.getOrElse("WAVES_DIR",".")
-      backendConfig(SpinalConfig(mode = VHDL)).generate(createToplevel)
+      backendConfig(SpinalConfig(mode = VHDL, targetDirectory="./cocotbWorkspace")).generate(createToplevel)
       genHdlSuccess = true
     } catch {
       case e: Throwable => {
@@ -39,7 +39,7 @@ abstract class SpinalTesterCocotbBase extends AnyFunSuite /* with BeforeAndAfter
   def genVerilog: Unit ={
     try {
 
-      backendConfig(SpinalConfig(mode = Verilog,dumpWave = if(withWaveform) DumpWaveConfig(depth = waveDepth,vcdPath = waveFolder + "/" + getName + "_verilog.vcd") else null)).generate(createToplevel)
+      backendConfig(SpinalConfig(mode = Verilog, targetDirectory="./cocotbWorkspace",dumpWave = if(withWaveform) DumpWaveConfig(depth = waveDepth,vcdPath = waveFolder + "/" + getName + "_verilog.vcd") else null)).generate(createToplevel)
       genHdlSuccess = true
     } catch {
       case e: Throwable => {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
@@ -17,13 +17,14 @@ abstract class SpinalTesterCocotbBase extends AnyFunSuite /* with BeforeAndAfter
   var cocotbMustPass = true
   var genHdlSuccess = false
   var waveDepth = 99
+  var cocotbWorkspace = "./cocotbWorkspace"
   def noVhdl = false
   def noVerilog = false
 
   def genVhdl: Unit ={
     try {
       val waveFolder = sys.env.getOrElse("WAVES_DIR",".")
-      backendConfig(SpinalConfig(mode = VHDL, targetDirectory="./cocotbWorkspace")).generate(createToplevel)
+      backendConfig(SpinalConfig(mode = VHDL, targetDirectory=cocotbWorkspace)).generate(createToplevel)
       genHdlSuccess = true
     } catch {
       case e: Throwable => {
@@ -39,7 +40,7 @@ abstract class SpinalTesterCocotbBase extends AnyFunSuite /* with BeforeAndAfter
   def genVerilog: Unit ={
     try {
 
-      backendConfig(SpinalConfig(mode = Verilog, targetDirectory="./cocotbWorkspace",dumpWave = if(withWaveform) DumpWaveConfig(depth = waveDepth,vcdPath = waveFolder + "/" + getName + "_verilog.vcd") else null)).generate(createToplevel)
+      backendConfig(SpinalConfig(mode = Verilog, targetDirectory=cocotbWorkspace, dumpWave = if(withWaveform) DumpWaveConfig(depth = waveDepth,vcdPath = waveFolder + "/" + getName + "_verilog.vcd") else null)).generate(createToplevel)
       genHdlSuccess = true
     } catch {
       case e: Throwable => {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
@@ -5,7 +5,7 @@ import spinal.core._
 
 import scala.sys.process._
 
-abstract class SpinalTesterGhdlBase extends AnyFunSuite  {
+abstract class SpinalTesterGhdlBase extends SpinalAnyFunSuite  {
 
   var withWaveform = false
   var elaborateMustFail = false

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
@@ -28,7 +28,7 @@ abstract class SpinalTesterGhdlBase extends AnyFunSuite  {
 
   def getLibraryName = "lib_" + getName
   def elaborate: Unit = {
-    SpinalVhdl(backendConfig(SpinalConfig()))(createToplevel)
+    backendConfig(SpinalConfig()).generateVhdl(createToplevel)
   }
 
   def backendConfig(config: SpinalConfig) : SpinalConfig = {
@@ -46,12 +46,12 @@ abstract class SpinalTesterGhdlBase extends AnyFunSuite  {
 
 
   def checkHDL(mustSuccess: Boolean): Unit = {
-    val comp = s"ghdl -a --ieee=synopsys --work=$getLibraryName $getName.vhd tester/src/test/resources/${getName}_tb.vhd"
+    val comp = s"ghdl -a --ieee=synopsys --work=$getLibraryName --workdir=$simWorkspacePath $simWorkspacePath/$getName.vhd tester/src/test/resources/${getName}_tb.vhd"
     println("GHDL compilation " + comp)
     assert(((comp !) == 0) == mustSuccess, if (mustSuccess) "compilation fail" else "Compilation has not fail :(")
 
 
-    val elab = s"ghdl -e --ieee=synopsys --work=$getLibraryName ${getName}_tb"
+    val elab = s"ghdl -e --ieee=synopsys --work=$getLibraryName --workdir=$simWorkspacePath ${getName}_tb"
     println("GHDL elaborate " + elab)
     assert(((elab !) == 0) == mustSuccess, if (mustSuccess) "compilation fail" else "Compilation has not fail :(")
   }
@@ -64,7 +64,7 @@ abstract class SpinalTesterGhdlBase extends AnyFunSuite  {
   def simulateHDLWithFail : Unit= simulateHDL(false)
 
   def simulateHDL(mustSuccess : Boolean): Unit = {
-    val run = s"ghdl -r --ieee=synopsys --work=$getLibraryName ${getName}_tb --ieee-asserts=disable ${if (!withWaveform) "" else s" --vcd=$getName.vcd"}"
+    val run = s"ghdl -r --ieee=synopsys --work=$getLibraryName --workdir=$simWorkspacePath ${getName}_tb --ieee-asserts=disable ${if (!withWaveform) "" else s" --vcd=$getName.vcd"}"
     println("GHDL run " + run)
     val ret = (run !)
     assert(!mustSuccess || ret == 0,"Simulation fail")

--- a/tester/src/test/scala/spinal/tester/scalatest/UsbDeviceCtrlTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/UsbDeviceCtrlTester.scala
@@ -47,7 +47,7 @@ case class UsbDeviceCtrlTesterTop() extends Component {
   ctrl.regs.address.enable.simPublic()
 }
 
-class UsbDeviceCtrlTester extends AnyFunSuite{
+class UsbDeviceCtrlTester extends SpinalAnyFunSuite{
   for(i <- 43 to 44) test("miaou" + i){
     SimConfig.compile(UsbDeviceCtrlTesterTop()).doSim(seed = i){ dut =>
       dut.ctrlCd.forkStimulus(1e12/dut.ctrlCd.frequency.getValue.toDouble toLong)

--- a/tester/src/test/scala/spinal/tester/scalatest/VerilatorCacheTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/VerilatorCacheTester.scala
@@ -74,7 +74,7 @@ object VerilatorCacheTester {
   }
 }
 
-class VerilatorCacheTester extends AnyFunSuite {
+class VerilatorCacheTester extends SpinalAnyFunSuite {
   import VerilatorCacheTester._
 
   val cacheDir = new File(SimConfig._workspacePath + "/.cache_cachetest")

--- a/tester/src/test/scala/spinal/tester/scalatest/ZeroWidthTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/ZeroWidthTester.scala
@@ -157,13 +157,13 @@ class ZeroWidthTesterCocotbBoot extends SpinalTesterCocotbBase {
 
   override def postTest: () => Unit = () => {
     if(!noVerilog){
-      val iterator = Source.fromFile("ZeroWidthTester.v").getLines()
+      val iterator = Source.fromFile(s"$cocotbWorkspace/ZeroWidthTester.v").getLines()
       for (line <- iterator) {
         assert(!line.contains("-1"))
       }
     }
     if(!noVhdl) {
-      val iterator = Source.fromFile("ZeroWidthTester.vhd").getLines()
+      val iterator = Source.fromFile(s"$cocotbWorkspace/ZeroWidthTester.vhd").getLines()
       var wait = true
       for (line <- iterator) {
         if(wait){

--- a/tester/src/test/scala/spinal/tester/scalatest/ZeroWidthTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/ZeroWidthTester.scala
@@ -157,13 +157,13 @@ class ZeroWidthTesterCocotbBoot extends SpinalTesterCocotbBase {
 
   override def postTest: () => Unit = () => {
     if(!noVerilog){
-      val iterator = Source.fromFile(s"$cocotbWorkspace/ZeroWidthTester.v").getLines()
+      val iterator = Source.fromFile(s"$workspaceRoot/ZeroWidthTester.v").getLines()
       for (line <- iterator) {
         assert(!line.contains("-1"))
       }
     }
     if(!noVhdl) {
-      val iterator = Source.fromFile(s"$cocotbWorkspace/ZeroWidthTester.vhd").getLines()
+      val iterator = Source.fromFile(s"$workspaceRoot/ZeroWidthTester.vhd").getLines()
       var wait = true
       for (line <- iterator) {
         if(wait){

--- a/tester/src/test/scala/spinal/tester/scalatest/package.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/package.scala
@@ -3,8 +3,25 @@ package spinal.tester
 import spinal.core._
 
 package object scalatest {
-  import spinal.tester.SpinalConfig
   val simWorkspacePath = spinal.tester.simWorkspacePath
+  
+  def SpinalConfig(
+      mode: SpinalMode = null,
+      dumpWave: DumpWaveConfig = null,
+      defaultConfigForClockDomains: ClockDomainConfig = ClockDomainConfig(),
+      defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency(),
+      allowOutOfRangeLiterals: Boolean = false,
+      verbose: Boolean = false,
+      targetDirectory: String = simWorkspacePath
+  ) = spinal.core.SpinalConfig(
+    mode = mode,
+    dumpWave = dumpWave,
+    targetDirectory = targetDirectory,
+    allowOutOfRangeLiterals = allowOutOfRangeLiterals,
+    verbose = verbose,
+    defaultConfigForClockDomains = defaultConfigForClockDomains,
+    defaultClockDomainFrequency = defaultClockDomainFrequency
+  )
 
   def SpinalVerilog[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)
   def SpinalVhdl[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)

--- a/tester/src/test/scala/spinal/tester/scalatest/package.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/package.scala
@@ -3,12 +3,8 @@ package spinal.tester
 import spinal.core._
 
 package object scalatest {
+  import spinal.tester.SpinalConfig
   val simWorkspacePath = spinal.tester.simWorkspacePath
-  def SpinalConfig() = spinal.core.SpinalConfig(targetDirectory = simWorkspacePath)
-  def SpinalConfig(defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency()) = spinal.core.SpinalConfig(
-    defaultClockDomainFrequency = defaultClockDomainFrequency,
-    targetDirectory = simWorkspacePath
-  )
 
   def SpinalVerilog[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)
   def SpinalVhdl[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)

--- a/tester/src/test/scala/spinal/tester/scalatest/package.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/package.scala
@@ -4,28 +4,5 @@ import spinal.core._
 
 package object scalatest {
   val simWorkspacePath = spinal.tester.simWorkspacePath
-
-  def SpinalConfig(
-      mode: SpinalMode = null,
-      dumpWave: DumpWaveConfig = null,
-      defaultConfigForClockDomains: ClockDomainConfig = ClockDomainConfig(),
-      defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency(),
-      allowOutOfRangeLiterals: Boolean = false,
-      device: Device = Device(),
-      verbose: Boolean = false,
-      targetDirectory: String = simWorkspacePath
-  ) = spinal.core.SpinalConfig(
-    mode = mode,
-    dumpWave = dumpWave,
-    targetDirectory = targetDirectory,
-    allowOutOfRangeLiterals = allowOutOfRangeLiterals,
-    device = device,
-    verbose = verbose,
-    defaultConfigForClockDomains = defaultConfigForClockDomains,
-    defaultClockDomainFrequency = defaultClockDomainFrequency
-  )
-
-  def SpinalVerilog[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)
-  def SpinalVhdl[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)
-  def SpinalSystemVerilog[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)
+  type SpinalAnyFunSuite = spinal.tester.SpinalAnyFunSuite
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/package.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/package.scala
@@ -1,0 +1,16 @@
+package spinal.tester
+
+import spinal.core._
+
+package object scalatest {
+  val simWorkspacePath = spinal.tester.simWorkspacePath
+  def SpinalConfig() = spinal.core.SpinalConfig(targetDirectory = simWorkspacePath)
+  def SpinalConfig(defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency()) = spinal.core.SpinalConfig(
+    defaultClockDomainFrequency = defaultClockDomainFrequency,
+    targetDirectory = simWorkspacePath
+  )
+
+  def SpinalVerilog[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)
+  def SpinalVhdl[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)
+  def SpinalSystemVerilog[T <: Component](gen: => T): SpinalReport[T] = SpinalConfig().generateVerilog(gen)
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/package.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/package.scala
@@ -4,13 +4,14 @@ import spinal.core._
 
 package object scalatest {
   val simWorkspacePath = spinal.tester.simWorkspacePath
-  
+
   def SpinalConfig(
       mode: SpinalMode = null,
       dumpWave: DumpWaveConfig = null,
       defaultConfigForClockDomains: ClockDomainConfig = ClockDomainConfig(),
       defaultClockDomainFrequency: IClockDomainFrequency = UnknownFrequency(),
       allowOutOfRangeLiterals: Boolean = false,
+      device: Device = Device(),
       verbose: Boolean = false,
       targetDirectory: String = simWorkspacePath
   ) = spinal.core.SpinalConfig(
@@ -18,6 +19,7 @@ package object scalatest {
     dumpWave = dumpWave,
     targetDirectory = targetDirectory,
     allowOutOfRangeLiterals = allowOutOfRangeLiterals,
+    device = device,
     verbose = verbose,
     defaultConfigForClockDomains = defaultConfigForClockDomains,
     defaultClockDomainFrequency = defaultClockDomainFrequency


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1029 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

1. Avoid to generate intermediate files in the root directory while running "sbt test".
2. Move temp files for cocotb into individual cocotbWorkspace directory.
3. Create a SpinalAnyFunSuite to wrap all spinal tester specific default settings.
4. Expose SpinalTesterCocotbBase and SpinalTesterGhdlBase to user who can inherit and use it if they want to use cocotb and ghdl correspondingly.

A lot of changes are based on @andreasWallner 's PR #1036. Thanks a lot.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
None

# Checklist

- [ ] ~~Unit tests were added~~
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
