### PR TITLE
Make SpinalFormalConfig members class parameters

### DIFF
--- a/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
+++ b/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
@@ -62,12 +62,10 @@ case class SpinalFormalConfig(
     var _backend: SpinalFormalBackendSel = SpinalFormalBackendSel.SYMBIYOSYS,
     var _keepDebugInfo: Boolean = false,
     var _skipWireReduce: Boolean = false,
-    var _hasAsync: Boolean = false
+    var _hasAsync: Boolean = false,
+    var _timeout: Option[Int] = None,
+    var _engines: ArrayBuffer[FormalEngin] = ArrayBuffer()
 ) {
-  var _multiClock = false
-  var _timeout: Option[Int] = None;
-  var _engines: ArrayBuffer[FormalEngin] = ArrayBuffer[FormalEngin]()
-
   def withSymbiYosys: this.type = {
     _backend = SpinalFormalBackendSel.SYMBIYOSYS
     this


### PR DESCRIPTION
# Context, Motivation & Description

When the parameters are simple members and not part of the constructor then the scala auto-generated  method will not copy them. This leads to e.g. the engine settings not being in effect when calling `compile` (or any function calling `compile` like `doVerify`) since that will operate on a copy.
This breaks the ability to change e.g. the engine used.

Note: The multi-clock setting did work so far, since `_hasAsync` was used
for that and the removed `_multiClock` was unused.

# Impact on code generation

None

# Checklist

~- [ ] Unit tests were added~
