### PR TITLE
fix bugs that cause engines missing while copy.

### DIFF
--- a/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
+++ b/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
@@ -64,7 +64,7 @@ case class SpinalFormalConfig(
     var _skipWireReduce: Boolean = false,
     var _hasAsync: Boolean = false,
     var _timeout: Option[Int] = None,
-    var _engines: ArrayBuffer[FormalEngin] = ArrayBuffer()
+    var _engines: ArrayBuffer[FormalEngin] = ArrayBuffer[FormalEngin]()
 ) {
   def withSymbiYosys: this.type = {
     _backend = SpinalFormalBackendSel.SYMBIYOSYS


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->



# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

While do formal verification with different engine like z3.
The existing engines might not be copied for the object who calls compiledCloned method, in compile function of SpinalFormalConfig class.
So the default yices engine are always used, which act differently with the original design.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
~~- [ ] API changes are or will be documented:~~
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
