### PR TITLE
Set the correct reset signal type (polarity) in QSys IP file

### DIFF
--- a/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
+++ b/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
@@ -125,6 +125,7 @@ class ClockDomainEmitter extends QSysifyInterfaceEmiter {
           true
         }
         case tag : ResetTag => {
+          val resetType = if (tag.clockDomain.config.resetActiveLevel == HIGH) "reset" else "reset_n"
           builder ++=
             s"""
               |#
@@ -138,7 +139,7 @@ class ClockDomainEmitter extends QSysifyInterfaceEmiter {
               |set_interface_property $interfaceName PORT_NAME_MAP ""
               |set_interface_property $interfaceName SVD_ADDRESS_GROUP ""
               |
-              |add_interface_port $interfaceName $name reset Input 1
+              |add_interface_port $interfaceName $name $resetType Input 1
              """.stripMargin
           true
         }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description
The current QSysify only identifies the reset signal in the HW IP as an active high reset, even if the reset is active low.
This will cause Quartus Platform Designer to erroneously insert reset inverters if the top level reset signal is an active low reset.

This change selects the correct reset signal type based on the clock domain config.

# Impact on code generation
Emits the correct reset signal type in the HW IP tcl file.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
