### PR TITLE
[Fix] polish AhbLite3Interconnect example in comment which can not co…

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3Interconnect.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3Interconnect.scala
@@ -60,9 +60,9 @@ case class AhbLite3CrossbarSlaveConfig(mapping: SizeMapping, index: Int){
   *                 io.ahbSlaves(3) -> (0x5000,0x1000)
   *              )
   *              .addConnections(
-  *                 io.ahbMasters(0).toAhbLite3() -> List(ahbSlaves(0), ahbSlaves(1)),
-  *                 io.ahbMasters(1).toAhbLite3() -> List(ahbSlaves(1), ahbSlaves(2), ahbSlaves(3)),
-  *                 io.ahbMasters(2).toAhbLite3() -> List(ahbSlaves(0), ahbSlaves(3))
+  *                 io.ahbMasters(0).toAhbLite3() -> List(io.ahbSlaves(0), io.ahbSlaves(1)),
+  *                 io.ahbMasters(1).toAhbLite3() -> List(io.ahbSlaves(1), io.ahbSlaves(2), io.ahbSlaves(3)),
+  *                 io.ahbMasters(2).toAhbLite3() -> List(io.ahbSlaves(0), io.ahbSlaves(3))
   *              )
   *              // ** OPTIONAL **
   *              //.addGlobalDefaultSlave(io.defaultSalve)


### PR DESCRIPTION
# Context, Motivation & Description
there are many examples in comment, I think we should make these example compilable, but in this file, the comment can not compile because the compiler can't find ahbSlaves(0), it can only find io.ahbSlaves(0).

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
nothing
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [-] Unit tests were added
- [-] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
