### PR TITLE
Fix cocotb test cases

### DIFF
--- a/tester/src/test/python/spinal/AnalogConnectionTester/AnalogConnectionTester.py
+++ b/tester/src/test/python/spinal/AnalogConnectionTester/AnalogConnectionTester.py
@@ -1,21 +1,15 @@
 import random
 import cocotb
 from cocotb.triggers import Timer
-from cocotb.types import Logic
-from cocotb.handle import Release, Deposit
-from cocotb.utils import get_sim_time
-
-from cocotblib.misc import assertEquals, Bundle
 
 @cocotb.coroutine
 async def try_tri(pad, write, writeEnable, read):
     val = random.getrandbits(1) == 1
     we = random.getrandbits(1) == 1
-    pad.value = Release()
     writeEnable.value = we
     write.value = val
     await Timer(10)
-    print(get_sim_time(), pad.value, write.value, writeEnable.value, read.value, pad.name)
+    #print(get_sim_time(), pad.value, write.value, writeEnable.value, read.value, pad.name)
     if not we:
         assert(str(pad.value).lower()[-1] == 'z')
     elif val:
@@ -32,32 +26,7 @@ async def test_tri_side(dut):
         (dut.blackbox_pad, dut.blackbox_tri_write, dut.blackbox_tri_writeEnable, dut.blackbox_tri_read),
         (dut.sliced_bus_pad, dut.sliced_bus_tri_write, dut.sliced_bus_tri_writeEnable, dut.sliced_bus_tri_read),
     ]
+    # don't deposit to PAD signals - which messes up at least VHDL simulation
     for i in range(1000):
         pad, write, writeEnable, read = random.choice(bundles)
         await try_tri(pad, write, writeEnable, read)
-
-
-@cocotb.coroutine
-async def try_pad(pad, write, writeEnable, read):
-    val = random.getrandbits(1) == 1
-    writeEnable.value = False
-    pad.value = val
-    await Timer(10)
-    print(get_sim_time(), pad.value, write.value, writeEnable.value, read.value, pad.name)
-    if val:
-        assert(str(read.value).lower()[-1] == '1')
-    else:
-        assert(str(read.value).lower()[-1] == '0')
-
-
-#@cocotb.test()
-#async def test_pad_side(dut):
-#    bundles = [
-#        (dut.simple_driver_pad, dut.simple_driver_tri_write, dut.simple_driver_tri_writeEnable, dut.simple_driver_tri_read),
-#        (dut.analog_bus_pad, dut.analog_bus_tri_write, dut.analog_bus_tri_writeEnable, dut.analog_bus_tri_read),
-#        (dut.blackbox_pad, dut.blackbox_tri_write, dut.blackbox_tri_writeEnable, dut.blackbox_tri_read),
-#        (dut.sliced_bus_pad, dut.sliced_bus_tri_write, dut.sliced_bus_tri_writeEnable, dut.sliced_bus_tri_read),
-#    ]
-#    for i in range(1000):
-#        pad, write, writeEnable, read = random.choice(bundles)
-#        await try_pad(pad, write, writeEnable, read)

--- a/tester/src/test/scala/spinal/tester/scalatest/AnalogConnectionTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/AnalogConnectionTester.scala
@@ -65,8 +65,6 @@ class AnalogConnectionCocotbBoot extends SpinalTesterCocotbBase {
   override def getName = "AnalogConnection"
   override def pythonTestLocation = "tester/src/test/python/spinal/AnalogConnectionTester"
   override def createToplevel = new AnalogConnectionTester
-  withWaveform=true
-  override def noVhdl = true
 }
 
 class AnalogConnectionTest extends AnyFunSuite {


### PR DESCRIPTION
Any deposit to a pad signal breaks the analog tests since these act as forces on the signal. Therefore driving 'z' fixes the pad level to 'z'. `Release` also does not improve the situation - so simply never touch those signals.

