### PR TITLE
add IConnectable trait

### DIFF
--- a/core/src/main/scala/spinal/core/Bundle.scala
+++ b/core/src/main/scala/spinal/core/Bundle.scala
@@ -190,3 +190,12 @@ class Bundle extends MultiData with Nameable with ValCallbackRec {
 class BundleCase extends Bundle {
   private[core] override def rejectOlder = false
 }
+
+trait BundleWithAssign[T <: BundleWithAssign[T]] {
+  def connectFrom(that: T): T
+  def <<(that: T): T = connectFrom(that)
+  def >>(into: T): T = {
+    into << this.asInstanceOf[T]
+    into
+  }
+}

--- a/core/src/main/scala/spinal/core/Bundle.scala
+++ b/core/src/main/scala/spinal/core/Bundle.scala
@@ -191,7 +191,7 @@ class BundleCase extends Bundle {
   private[core] override def rejectOlder = false
 }
 
-trait BundleWithAssign[T <: BundleWithAssign[T]] {
+trait IConnectable[T <: IConnectable[T]] {
   def connectFrom(that: T): T
   def <<(that: T): T = connectFrom(that)
   def >>(into: T): T = {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

Add IConnectable trait to connect bus

Example:
```scala
object BundleWithAssignTraitTest extends App {
  case class TestBundle()
      extends Bundle
      with IMasterSlave
      with IConnectable[TestBundle] {
    val valid = Bool
    val ready = Bool

    def asMaster(): Unit = {
      inWithNull(ready)
      outWithNull(valid)
    }

    def connectFrom(that: TestBundle): TestBundle = {
      that.ready := this.ready
      this.valid := that.valid
      that
    }
  }

  case class TestModule() extends Component {
    val io = new Bundle {
      val s = slave(TestBundle())
      val m = master(TestBundle())
    }

    val save = Reg(TestBundle())
    io.s >> save
    io.m << save
  }

  SpinalConfig().generateVerilog(TestModule())
}
```
Generated Verilog code:
```Verilog
// Generator : SpinalHDL v1.7.2    git head : 08fc866bebdc40c471ebe327bface63e34406489
// Component : TestModule
// Git hash  : ff0242cd879a6e8623afd4a1817f525fb45aada3

`timescale 1ns/1ps

module TestModule (
  input               io_s_valid,
  output              io_s_ready,
  output              io_m_valid,
  input               io_m_ready,
  input               clk,
  input               reset
);

  reg                 save_valid;
  reg                 save_ready;

  assign io_s_ready = save_ready;
  assign io_m_valid = save_valid;
  always @(posedge clk) begin
    save_valid <= io_s_valid;
    save_ready <= io_m_ready;
  end


endmodule
```
This PR designs a trait to connect bus using `>>` and `<<`. 
Users do not need to implement these functions for custom bundles

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

It is a feature and it would not impact the code without IConnectable trait.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
