### PR TITLE
fix check for wide signals

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -1441,7 +1441,7 @@ class PhaseInferWidth(pc: PhaseContext) extends PhaseMisc{
             if (e.getWidth < 0) {
               errors += s"Negative width on $e at ${e.getScalaLocationLong}"
             }
-            if (e.getWidth > 4096) {
+            if (e.getWidth > pc.config.bitVectorWidthMax) {
               errors += s"Way too big signal $e at ${e.getScalaLocationLong}"
             }
           case _ =>


### PR DESCRIPTION
Fixes a bug introduced in the commit e352b88bcc9ebbb04e0a80a24597d2fd7814f76e. The check was only updated at one of two locations.

See also #870 