### PR TITLE
PhysicalUnit formatting

### DIFF
--- a/core/src/main/scala/spinal/core/Units.scala
+++ b/core/src/main/scala/spinal/core/Units.scala
@@ -93,6 +93,12 @@ abstract class PhysicalNumber[T <: PhysicalNumber[_]](protected val value: BigDe
   def toLong       = value.toLong
   def toDouble     = value.toDouble
   def toBigDecimal = value
+
+  def decompose: (BigDecimal, String)
+  def decomposeString: String = {
+    val (number, unit) = this.decompose
+    f"${number.toLong} $unit"
+  }
 }
 
 
@@ -111,7 +117,7 @@ case class TimeNumber(private val v: BigDecimal) extends PhysicalNumber[TimeNumb
 
   def toHertz = HertzNumber(1 / this.value)
 
-  def decompose: (BigDecimal, String) = this.value match {
+  override def decompose: (BigDecimal, String) = this.value match {
     case d if value >= 3600.0  => (d / 3600.0,  "hr")
     case d if value >= 60.0    => (d / 60.0,    "min")
     case d if value >= 1.0     => (d / 1.0,     "sec")
@@ -122,11 +128,6 @@ case class TimeNumber(private val v: BigDecimal) extends PhysicalNumber[TimeNumb
     case d if value >= 1.0e-15 => (d / 1.0e-15, "fs")
     case d: BigDecimal        => (d,           "unknown")
     case _                    => (0.0,         "error")
-  }
-
-  def decomposeString: String = {
-    val (deci, unit) = this.decompose
-    f"${deci.toLong} ${unit}"
   }
 }
 
@@ -146,7 +147,7 @@ case class HertzNumber(private val v: BigDecimal) extends PhysicalNumber[HertzNu
 
   def toTime = TimeNumber(1 / this.value)
 
-  def decompose: (BigDecimal, String) = this.value match {
+  override def decompose: (BigDecimal, String) = this.value match {
     case d if d > 1.0e18 => (d / 1.0e18, "EHz")
     case d if d > 1.0e15 => (d / 1.0e15, "PHz")
     case d if d > 1.0e12 => (d / 1.0e12, "THz")

--- a/core/src/test/scala/spinal/core/PhysicalNumbers.scala
+++ b/core/src/test/scala/spinal/core/PhysicalNumbers.scala
@@ -13,7 +13,6 @@ class PhysicalNumbers extends AnyFunSuite {
     assert(hz100 == hz100_2)
     assert(hz100_2 == hz100)
     assert(hz100 != hz200)
-    assert(hz200 != ms2)
     assert(hz100 != null)
 
     assert(hz100 < hz200)

--- a/core/src/test/scala/spinal/core/PhysicalNumbers.scala
+++ b/core/src/test/scala/spinal/core/PhysicalNumbers.scala
@@ -34,4 +34,14 @@ class PhysicalNumbers extends AnyFunSuite {
 
     assert(hz100.hashCode() == hz100_2.hashCode())
   }
+
+  test("formatting") {
+    assert(f"${HertzNumber(5123000)}" == "5.123 MHz")
+    assert(f"${HertzNumber(5123000)}%s" == "5.123 MHz")
+    assert(f"${HertzNumber(5123000)}%S" == "5.123MHz")
+    assert(f"${HertzNumber(5123000)}%#s" == "5.123")
+    assert(f"${HertzNumber(5123000)}%.5s" == "5.12300 MHz")
+    assert(f"${HertzNumber(5123000)}%15.5s" == "    5.12300 MHz")
+    assert(f"${HertzNumber(5123000)}%-15.5s" == "5.12300 MHz    ")
+  }
 }


### PR DESCRIPTION
Make both HertzNumber and TimeNumber consistent that both have `decompose` / `decomposeString` (missing on HertzNumber before). Also make both formattable via f-interpolation, `String.format`, etc.

# Context, Motivation & Description

Simpler use when printing/reporting/building error messages.

# Impact on code generation

No impact on code generation, but code that printed the classes w/o any formatting will now generate different output. This should not be an issue though because the format was unspecific and not well specified before.

# Checklist

- [x] Unit tests were added
