### PR TITLE
Add setAll() and clearAll() for Data

### DIFF
--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -486,9 +486,9 @@ abstract class BitVector extends BaseType with Widthable {
   }
 
   /** Set all bits */
-  def setAll(): this.type
+  override def setAll(): this.type
   /** Clear all bits */
-  def clearAll(): this.type = {
+  override def clearAll(): this.type = {
     this := this.getZeroUnconstrained
     this
   }

--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -89,6 +89,24 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
   /** this is assigned to False */
   def clear(): Unit = this := False
 
+  /** Set to True.
+    *
+    * Direct call to `set()` to reduce the number of nodes in the netlist.
+    */
+  override def setAll(): this.type = {
+    this.set()
+    this
+  }
+
+  /** Set to False.
+    *
+    * Direct call to `clear()` to reduce the number of nodes in the netlist.
+    */
+  override def clearAll(): this.type = {
+    this.clear()
+    this
+  }
+
   /**
     * this is assigned to True when cond is True
     * @example{{{ myBool.setWhen(cond) }}}

--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -422,6 +422,15 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
   def assignFromBits(bits: Bits, hi: Int, low: Int): Unit
   def assignFromBits(bits: Bits, offset: Int, bitCount: BitCount): Unit = this.assignFromBits(bits, offset + bitCount.value - 1, offset)
 
+  def clearAll(): this.type = {
+    assignFromBits(Bits(asBits.getBitsWidth bits).clearAll())
+    this
+  }
+  def setAll(): this.type = {
+    assignFromBits(Bits(asBits.getBitsWidth bits).setAll())
+    this
+  }
+
   def as[T <: Data](dataType: HardType[T]) : T = {
     val ret = dataType()
     ret.assignFromBits(this.asBits)
@@ -755,4 +764,3 @@ trait DataWrapper extends Data{
   override def freeze(): DataWrapper.this.type = ???
   override def unfreeze(): DataWrapper.this.type = ???
 }
-

--- a/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/RegInst.scala
@@ -128,7 +128,7 @@ case class RegInst(name: String, addr: BigInt, doc: String, busif: BusIf) extend
     val reg = acc match{
       case AccessType.NA => {
         val reg = hardType()
-        reg.assignFromBits(B(0, reg.getBitsWidth bit))
+        reg.clearAll()
         reg
       }
       case AccessType.ROV => {
@@ -496,7 +496,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf) {
 
   protected def _RC[T <: BaseType](reg: T, section: Range): T = {
     when(hitDoRead){
-      reg.assignFromBits(Bits(reg.getBitsWidth bit).clearAll()) //busif.wdata(reg, section, "clear")
+      reg.clearAll() //busif.wdata(reg, section, "clear")
     }
     reg
   }
@@ -511,7 +511,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf) {
 
   protected def _RS[T <: BaseType](reg: T, section: Range): T = {
     when(hitDoRead){
-      reg.assignFromBits( Bits(reg.getBitsWidth bit).setAll())//busif.wdata(reg, section, "set")
+      reg.setAll() //busif.wdata(reg, section, "set")
     }
     reg
   }
@@ -528,7 +528,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf) {
     when(hitDoWrite){
       reg.assignFromBits(busif.wdata(reg, section)  )//busif.writeData(section))
     }.elsewhen(hitDoRead){
-      reg.assignFromBits(Bits(reg.getBitsWidth bit).clearAll())//busif.wdata(reg, section, "clear")
+      reg.clearAll() //busif.wdata(reg, section, "clear")
     }
     reg
   }
@@ -547,7 +547,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf) {
     when(hitDoWrite){
       reg.assignFromBits(busif.wdata(reg, section)  )//busif.writeData(section))
     }.elsewhen(hitDoRead){
-      reg.assignFromBits(Bits(reg.getBitsWidth bit).setAll()) //busif.wdata(reg, section, "set")
+      reg.setAll() //busif.wdata(reg, section, "set")
     }
     reg
   }
@@ -596,7 +596,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf) {
     when(hitDoWrite){
       reg.assignFromBits(busif.wdata(reg, section, "set")  )//Bits(reg.getBitsWidth bit).setAll())
     }.elsewhen(hitDoRead){
-      reg.assignFromBits(Bits(reg.getBitsWidth bit).clearAll()) //busif.wdata(reg, section, "clear")
+      reg.clearAll() //busif.wdata(reg, section, "clear")
     }
     reg
   }
@@ -615,7 +615,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf) {
     when(hitDoWrite){
       reg.assignFromBits(busif.wdata(reg, section, "clear"))//Bits(reg.getBitsWidth bit).clearAll())
     }.elsewhen(hitDoRead){
-      reg.assignFromBits(Bits(reg.getBitsWidth bit).setAll()) //busif.wdata(reg, section, "set")
+      reg.setAll() //busif.wdata(reg, section, "set")
     }
     reg
   }

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
@@ -106,7 +106,7 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
     * wishbone3.clearAll()
     * }}}
     */
-  def clearAll() : Unit = {
+  override def clearAll() : this.type = {
     /////////////////////
     // MINIMAl SIGLALS //
     /////////////////////
@@ -136,6 +136,8 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
     if(this.config.useBTE &&  isMasterInterface) this.BTE.clearAll()
     if(this.config.useTGD && !isMasterInterface) this.TGD_MISO.clearAll()
     if(this.config.useTGD &&  isMasterInterface) this.TGD_MOSI.clearAll()
+
+    this
   }
 
   /** Connect common Wishbone signals


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

Sometimes I need to zero out an entire bundle, but assigning each bundle signal is tedious, especially for multi-level Bundles. I ended up using the method in the PR as it's simple and uses some of the most basic methods available (even for Data), so I figured that it could be added directly to `Data`. Let me know if that's the place for this sort of general method, or should it be higher up in the hard type hierarchy?

Also, I noticed that this pattern is often used in RegIf, so I changed it as well to use the new construct from Data.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

None, convenience function for `Data`, which is already implemented for `BitVector` and some of its children.

# Checklist

- [ ] Unit tests were added – should there be any for such a small change?
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
