### PR TITLE
[feature] add BusSlaveFactory onWriteBits

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -167,6 +167,20 @@ trait BusSlaveFactory extends Area{
 
 
   /**
+    * Call doThat(with write data) when a write transaction occurs on address
+    */
+  def onWriteBits(address: BigInt, documentation: String = null)(doThat: Bits => Unit): Unit = {
+    val writeBits = Bits(this.busDataWidth bits)
+    nonStopWrite(writeBits, 0)
+    onWritePrimitive(
+      address       = SingleMapping(address),
+      haltSensitive = true,
+      documentation = documentation
+    )(doThat(writeBits))
+  }
+
+  
+  /**
     * Call doThat when a read transaction occurs on address
     */
   def onRead(address: BigInt, documentation: String = null)(doThat: => Unit): Unit = {

--- a/tester/src/test/python/spinal/BusSlaveFactoryonWriteBitsTester/BusSlaveFactoryonWriteBitsTester.py
+++ b/tester/src/test/python/spinal/BusSlaveFactoryonWriteBitsTester/BusSlaveFactoryonWriteBitsTester.py
@@ -1,0 +1,48 @@
+import random
+from queue import Queue
+
+import cocotb
+from cocotb.triggers import RisingEdge, Timer
+
+from cocotblib.misc import assertEquals, ClockDomainAsyncReset
+from cocotblib.Apb3 import Apb3
+
+class UutModel:
+    def __init__(self,dut):
+        self.dut = dut
+
+        cocotb.fork(self.loop())
+
+    @cocotb.coroutine
+    def loop(self):
+        dut = self.dut
+        ok1_en, ok2_en = False, False
+        while True:
+            yield RisingEdge(dut.clk)
+            if ok1_en:
+                assertEquals(dut.io_ok1, 1,"io_ok1")
+            if ok2_en:
+                assertEquals(dut.io_ok2, 1,"io_ok2")
+            ok1_en, ok2_en = False, False
+
+            if int(dut.io_bus_PWRITE) & int(dut.io_bus_PENABLE) == 1 :
+                if dut.io_bus_PADDR == 0x0 and int(dut.io_bus_PWDATA) & 1 == 1:
+                    ok1_en = True
+                if dut.io_bus_PADDR == 0x0040 and int(dut.io_bus_PWDATA) & 2 == 2:
+                    ok2_en = True
+
+
+@cocotb.test()
+def test1(dut):
+    yield Timer(1)
+    dut.log.info("Cocotb test boot")
+    random.seed(0)
+    cocotb.fork(ClockDomainAsyncReset(dut.clk, dut.reset))
+    apb3 = Apb3(dut, "io_bus", dut.clk)
+    apb3.write(random.randint(0, 0x100), random.randint(0, 0xffffffff))
+    uutModel = UutModel(dut)
+    for i in range(0,5000):
+        yield apb3.write(random.randint(0, 0x100), random.randint(0, 0xffffffff))
+
+    dut.log.info("Cocotb test done")
+

--- a/tester/src/test/python/spinal/BusSlaveFactoryonWriteBitsTester/Makefile
+++ b/tester/src/test/python/spinal/BusSlaveFactoryonWriteBitsTester/Makefile
@@ -1,0 +1,13 @@
+include ../common/Makefile.def
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+	VERILOG_SOURCES += $(SPINALROOT)/BusSlaveFactoryonWriteBitsTester.v
+	TOPLEVEL=BusSlaveFactoryonWriteBitsTester
+endif
+# ifeq ($(TOPLEVEL_LANG),vhdl)
+# 	VHDL_SOURCES += $(SPINALROOT)/BusSlaveFactoryonWriteBitsTester.vhd
+# 	TOPLEVEL=BusSlaveFactoryonWriteBitsTester
+# endif
+MODULE=BusSlaveFactoryonWriteBitsTester
+
+include ../common/Makefile.sim

--- a/tester/src/test/python/spinal/BusSlaveFactoryonWriteBitsTester/__init__.py
+++ b/tester/src/test/python/spinal/BusSlaveFactoryonWriteBitsTester/__init__.py
@@ -1,0 +1,1 @@
+#!/bin/env python

--- a/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryonWriteBits.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/BusSlaveFactoryonWriteBits.scala
@@ -1,0 +1,40 @@
+package spinal.tester.scalatest
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{Assertions}
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb._
+
+object BusSlaveFactoryonWriteBitsTester {
+  class BusSlaveFactoryonWriteBitsTester extends Component {
+    val io = new Bundle {
+      val bus = slave(Apb3(Apb3Config(32, 32)))
+      val ok1 = out(Bool)
+      val ok2 = out(Bool)
+    }
+    val (ok1, ok2) = (RegNext(False), RegNext(False))
+    io.ok1 := ok1
+    io.ok2 := ok2
+    val factory = Apb3SlaveFactory(io.bus)
+    factory.onWriteBits(0x0) { bits =>
+      when(bits(0) === True) {
+        ok1 := True
+      }
+    }
+    factory.onWriteBits(0x0040) { bits =>
+      when(bits(1) === True) {
+        ok2 := True
+      }
+    }
+  }
+}
+
+class BusSlaveFactoryonWriteBitsTesterCocotbBoot extends SpinalTesterCocotbBase {
+  override def getName: String = "BusSlaveFactoryonWriteBitsTester"
+  override def pythonTestLocation: String = "tester/src/test/python/spinal/BusSlaveFactoryonWriteBitsTester"
+  override def createToplevel: Component = new BusSlaveFactoryonWriteBitsTester.BusSlaveFactoryonWriteBitsTester
+
+  withWaveform = true
+  override def noVhdl = true
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->
Closes #1068 

# Context, Motivation & Description
when we talk about bussalvefactory. It's useful for providing a interface to do a callback with a writedata parameter when a write transaction occour.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
no old api was changed.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
I do a unit test on my own, I write a simple case like this
```
  factory.onWriteBits(address = 0x100)(bits=>{
    when(bits(0) === True) {
      Pending := True
    }
  })
```
the generated code is like this

```
  assign when_Box_l42 = (bus_HWDATA[0] == 1'b1);
.....

....
always @(posedge clk or posedge reset) begin
        32'h00000100 : begin
          if(when_BusSlaveFactory_l978_regNext) begin
            if(when_Box_l42) begin
              Pending <= 1'b1;
            end
          end
        end
end
```

- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
