### PR TITLE
Propagate tags from Tristates when using InOutWrapper

### DIFF
--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -763,6 +763,7 @@ trait SpinalTag {
   def driverShouldNotChange = false
   def canSymplifyHost       = false
   def allowMultipleInstance = true // Allow multiple instances of the tag on the same object
+  def ioTag                 = false // Propagate tag to IO
 
   def apply[T <: SpinalTagReady](that : T) : T = {
     that.addTag(this)

--- a/lib/src/main/scala/spinal/lib/io/InOutWrapper.scala
+++ b/lib/src/main/scala/spinal/lib/io/InOutWrapper.scala
@@ -32,6 +32,7 @@ object InOutWrapper {
               when(bundle.writeEnable) {
                 newIo := bundle.write
               }
+              newIo.addTags(bundle.getTags())
             }
             case bundle: TriStateOutput[_] if bundle.isOutput || bundle.isMasterInterface => {
               val newIo = inout(Analog(bundle.dataType)).setWeakName(bundle.getName())
@@ -39,6 +40,7 @@ object InOutWrapper {
               when(bundle.writeEnable) {
                 newIo := bundle.write
               }
+              newIo.addTags(bundle.getTags())
             }
             case bundle: ReadableOpenDrain[_] if bundle.write.isOutput && bundle.read.isInput => {
               val newIo = inout(Analog(bundle.dataType)).setWeakName(bundle.getName())
@@ -49,6 +51,7 @@ object InOutWrapper {
                   newIo.assignFromBits(B"0", id, 1 bits)
                 }
               }
+              newIo.addTags(bundle.getTags())
               //            for(bt <- bundle.write.flatten){
               //              for((value, id) <- bt.asBits.asBools.zipWithIndex) {
               //                when(!value){
@@ -66,6 +69,7 @@ object InOutWrapper {
                   newIo(i) := bundle.write(i)
                 }
               }
+              newIo.addTags(bundle.getTags())
             }
             case _ =>
           }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1086

This is a simple change which copies tags on the tristate signal to the wrapper analog pin.

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
