### PR TITLE
Disable `setAffinity` on Windows platform

### DIFF
--- a/sim/src/main/scala/spinal/affinity/Affinity.scala
+++ b/sim/src/main/scala/spinal/affinity/Affinity.scala
@@ -1,7 +1,7 @@
 package spinal.affinity
 
 object Affinity {
-  var warningFired = false
+  var warningFired = System.getProperty("os.name").contains("Win")
   def apply(cpuId : Int) {
     try {
       if(!warningFired) net.openhft.affinity.Affinity.setAffinity(cpuId)


### PR DESCRIPTION
Closes #1092

# Context, Motivation & Description

Disable the `setAffinity` function on Windows platform to avoid warnings.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
