### PR TITLE
feature: add Jtag VPI support for sim

### DIFF
--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagDriver.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagDriver.scala
@@ -1,0 +1,86 @@
+package spinal.lib.com.jtag.sim
+
+import spinal.core.sim._
+import spinal.lib.com.jtag.Jtag
+
+/*
+    * Jtag Driver tool
+    * Author: Alexis Marquet
+*/
+case class JtagDriver(jtag: Jtag, clockPeriod: Long) {
+  object JtagStates extends Enumeration {
+    val RESET, IDLE,
+    IR_SELECT, IR_CAPTURE, IR_SHIFT, IR_EXIT1, IR_PAUSE, IR_EXIT2, IR_UPDATE,
+    DR_SELECT, DR_CAPTURE, DR_SHIFT, DR_EXIT1, DR_PAUSE, DR_EXIT2, DR_UPDATE, UNKNOWN = Value
+  }
+  var tapState = JtagStates.UNKNOWN
+  def tapStep(tms: Boolean): Unit = {
+    val oldState = tapState
+    tapState = tapState match {
+      case JtagStates.RESET => if (tms) JtagStates.RESET else JtagStates.IDLE
+      case JtagStates.IDLE => if (tms) JtagStates.DR_SELECT else JtagStates.IDLE
+      case JtagStates.DR_SELECT => if (tms) JtagStates.IR_SELECT else JtagStates.DR_CAPTURE
+      case JtagStates.DR_CAPTURE => if (tms) JtagStates.IR_SELECT else JtagStates.DR_SHIFT
+      case JtagStates.DR_SHIFT => if (tms) JtagStates.DR_EXIT1 else JtagStates.DR_SHIFT
+      case JtagStates.DR_EXIT1 => if (tms) JtagStates.DR_UPDATE else JtagStates.DR_PAUSE
+      case JtagStates.DR_PAUSE => if (tms) JtagStates.DR_EXIT2 else JtagStates.DR_PAUSE
+      case JtagStates.DR_EXIT2 => if (tms) JtagStates.DR_UPDATE else JtagStates.DR_SHIFT
+      case JtagStates.DR_UPDATE => if (tms) JtagStates.DR_SELECT else JtagStates.IDLE
+      case JtagStates.IR_SELECT => if (tms) JtagStates.RESET else JtagStates.IR_CAPTURE
+      case JtagStates.IR_CAPTURE => if (tms) JtagStates.RESET else JtagStates.IR_SHIFT
+      case JtagStates.IR_SHIFT => if (tms) JtagStates.IR_EXIT1 else JtagStates.IR_SHIFT
+      case JtagStates.IR_EXIT1 => if (tms) JtagStates.IR_UPDATE else JtagStates.IR_PAUSE
+      case JtagStates.IR_PAUSE => if (tms) JtagStates.IR_EXIT2 else JtagStates.IR_PAUSE
+      case JtagStates.IR_EXIT2 => if (tms) JtagStates.IR_UPDATE else JtagStates.IR_SHIFT
+      case JtagStates.IR_UPDATE => if (tms) JtagStates.DR_SELECT else JtagStates.IDLE
+      case JtagStates.UNKNOWN => JtagStates.UNKNOWN
+    }
+  }
+
+  /*
+    * Reset the JTAG tap into Test-Logic-Reset state
+   */
+  def doResetTap(): Unit = {
+    doTmsSeq(Seq(true, true, true, true, true))
+    tapState = JtagStates.RESET
+  }
+
+  /*
+    * Send a sequence of TMS bits to move the JTAG tap into a specific state
+   */
+  def doTmsSeq(tmsSeq: Seq[Boolean]): Unit = {
+    for (tms <- tmsSeq) {
+      jtag.tms #= tms
+      doClockCycle(1)
+    }
+  }
+
+  /*
+    * Send a clock cycle to the JTAG tap
+   */
+  def doClockCycle(n: Long): Unit = {
+    for (_ <- 0 until n.toInt) {
+      jtag.tck #= true
+      tapStep(jtag.tms.toBoolean)
+      sleep(clockPeriod / 2)
+      jtag.tck #= false
+      sleep(clockPeriod / 2)
+    }
+  }
+
+  /*
+    * Send a sequence of TDI bits to the JTAG tap and return the TDO sequence
+    * param: flipTms is used to flip the last TMS bit to 1 when the scan chain is finished
+    * This allows to write longer sequences of bits from multiple calls to this function
+   */
+  def doScanChain(tdiSeq: Seq[Boolean], flipTms: Boolean): Seq[Boolean] = {
+    var tdoSeq = Seq.fill(tdiSeq.length)(false)
+    for (i <- 0 until tdiSeq.length) {
+      jtag.tdi #= tdiSeq(i)
+      jtag.tms #= (i == tdiSeq.length - 1 && flipTms)
+      tdoSeq = tdoSeq.updated(i, jtag.tdo.toBoolean)
+      doClockCycle(1)
+    }
+    tdoSeq
+  }
+}

--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagDriver.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagDriver.scala
@@ -1,44 +1,19 @@
 package spinal.lib.com.jtag.sim
 
+import scala.collection.mutable
+import spinal.core.TimeNumber
 import spinal.core.sim._
 import spinal.lib.com.jtag.Jtag
 
 /*
-    * Jtag Driver tool
-    * Author: Alexis Marquet
-*/
-case class JtagDriver(jtag: Jtag, clockPeriod: Long) {
-  object JtagStates extends Enumeration {
-    val RESET, IDLE,
-    IR_SELECT, IR_CAPTURE, IR_SHIFT, IR_EXIT1, IR_PAUSE, IR_EXIT2, IR_UPDATE,
-    DR_SELECT, DR_CAPTURE, DR_SHIFT, DR_EXIT1, DR_PAUSE, DR_EXIT2, DR_UPDATE, UNKNOWN = Value
-  }
-  var tapState = JtagStates.UNKNOWN
-  def tapStep(tms: Boolean): Unit = {
-    val oldState = tapState
-    tapState = tapState match {
-      case JtagStates.RESET => if (tms) JtagStates.RESET else JtagStates.IDLE
-      case JtagStates.IDLE => if (tms) JtagStates.DR_SELECT else JtagStates.IDLE
-      case JtagStates.DR_SELECT => if (tms) JtagStates.IR_SELECT else JtagStates.DR_CAPTURE
-      case JtagStates.DR_CAPTURE => if (tms) JtagStates.IR_SELECT else JtagStates.DR_SHIFT
-      case JtagStates.DR_SHIFT => if (tms) JtagStates.DR_EXIT1 else JtagStates.DR_SHIFT
-      case JtagStates.DR_EXIT1 => if (tms) JtagStates.DR_UPDATE else JtagStates.DR_PAUSE
-      case JtagStates.DR_PAUSE => if (tms) JtagStates.DR_EXIT2 else JtagStates.DR_PAUSE
-      case JtagStates.DR_EXIT2 => if (tms) JtagStates.DR_UPDATE else JtagStates.DR_SHIFT
-      case JtagStates.DR_UPDATE => if (tms) JtagStates.DR_SELECT else JtagStates.IDLE
-      case JtagStates.IR_SELECT => if (tms) JtagStates.RESET else JtagStates.IR_CAPTURE
-      case JtagStates.IR_CAPTURE => if (tms) JtagStates.RESET else JtagStates.IR_SHIFT
-      case JtagStates.IR_SHIFT => if (tms) JtagStates.IR_EXIT1 else JtagStates.IR_SHIFT
-      case JtagStates.IR_EXIT1 => if (tms) JtagStates.IR_UPDATE else JtagStates.IR_PAUSE
-      case JtagStates.IR_PAUSE => if (tms) JtagStates.IR_EXIT2 else JtagStates.IR_PAUSE
-      case JtagStates.IR_EXIT2 => if (tms) JtagStates.IR_UPDATE else JtagStates.IR_SHIFT
-      case JtagStates.IR_UPDATE => if (tms) JtagStates.DR_SELECT else JtagStates.IDLE
-      case JtagStates.UNKNOWN => JtagStates.UNKNOWN
-    }
-  }
+ * Jtag Driver tool
+ * Author: Alexis Marquet
+ */
+case class JtagDriver(jtag: Jtag, clockPeriod: TimeNumber) {
+  var tapState: JtagStates.Value = JtagStates.UNKNOWN
 
   /*
-    * Reset the JTAG tap into Test-Logic-Reset state
+   * Reset the JTAG tap into Test-Logic-Reset state
    */
   def doResetTap(): Unit = {
     doTmsSeq(Seq(true, true, true, true, true))
@@ -46,41 +21,69 @@ case class JtagDriver(jtag: Jtag, clockPeriod: Long) {
   }
 
   /*
-    * Send a sequence of TMS bits to move the JTAG tap into a specific state
+   * Send a sequence of TMS bits to move the JTAG tap into a specific state
    */
   def doTmsSeq(tmsSeq: Seq[Boolean]): Unit = {
     for (tms <- tmsSeq) {
       jtag.tms #= tms
-      doClockCycle(1)
+      doClockCycles(1)
     }
   }
 
   /*
-    * Send a clock cycle to the JTAG tap
+   * Send n clock cycle to the JTAG tap
    */
-  def doClockCycle(n: Long): Unit = {
+  def doClockCycles(n: Long): Unit = {
     for (_ <- 0 until n.toInt) {
       jtag.tck #= true
       tapStep(jtag.tms.toBoolean)
-      sleep(clockPeriod / 2)
+      sleep(timeToLong(clockPeriod / 2))
       jtag.tck #= false
-      sleep(clockPeriod / 2)
+      sleep(timeToLong(clockPeriod / 2))
+    }
+  }
+
+  def tapStep(tms: Boolean): Unit = {
+    tapState = tapState match {
+      case JtagStates.RESET      => if (tms) JtagStates.RESET else JtagStates.IDLE
+      case JtagStates.IDLE       => if (tms) JtagStates.DR_SELECT else JtagStates.IDLE
+      case JtagStates.DR_SELECT  => if (tms) JtagStates.IR_SELECT else JtagStates.DR_CAPTURE
+      case JtagStates.DR_CAPTURE => if (tms) JtagStates.IR_SELECT else JtagStates.DR_SHIFT
+      case JtagStates.DR_SHIFT   => if (tms) JtagStates.DR_EXIT1 else JtagStates.DR_SHIFT
+      case JtagStates.DR_EXIT1   => if (tms) JtagStates.DR_UPDATE else JtagStates.DR_PAUSE
+      case JtagStates.DR_PAUSE   => if (tms) JtagStates.DR_EXIT2 else JtagStates.DR_PAUSE
+      case JtagStates.DR_EXIT2   => if (tms) JtagStates.DR_UPDATE else JtagStates.DR_SHIFT
+      case JtagStates.DR_UPDATE  => if (tms) JtagStates.DR_SELECT else JtagStates.IDLE
+      case JtagStates.IR_SELECT  => if (tms) JtagStates.RESET else JtagStates.IR_CAPTURE
+      case JtagStates.IR_CAPTURE => if (tms) JtagStates.RESET else JtagStates.IR_SHIFT
+      case JtagStates.IR_SHIFT   => if (tms) JtagStates.IR_EXIT1 else JtagStates.IR_SHIFT
+      case JtagStates.IR_EXIT1   => if (tms) JtagStates.IR_UPDATE else JtagStates.IR_PAUSE
+      case JtagStates.IR_PAUSE   => if (tms) JtagStates.IR_EXIT2 else JtagStates.IR_PAUSE
+      case JtagStates.IR_EXIT2   => if (tms) JtagStates.IR_UPDATE else JtagStates.IR_SHIFT
+      case JtagStates.IR_UPDATE  => if (tms) JtagStates.DR_SELECT else JtagStates.IDLE
+      case JtagStates.UNKNOWN    => JtagStates.UNKNOWN
     }
   }
 
   /*
-    * Send a sequence of TDI bits to the JTAG tap and return the TDO sequence
-    * param: flipTms is used to flip the last TMS bit to 1 when the scan chain is finished
-    * This allows to write longer sequences of bits from multiple calls to this function
+   * Send a sequence of TDI bits to the JTAG tap and return the TDO sequence
+   * param: flipTms is used to flip the last TMS bit to 1 when the scan chain is finished
+   * This allows to write longer sequences of bits from multiple calls to this function
    */
   def doScanChain(tdiSeq: Seq[Boolean], flipTms: Boolean): Seq[Boolean] = {
-    var tdoSeq = Seq.fill(tdiSeq.length)(false)
-    for (i <- 0 until tdiSeq.length) {
+    // use mutable seq
+    val tdoSeq = mutable.Seq.fill(tdiSeq.length)(false)
+    for (i <- tdiSeq.indices) {
       jtag.tdi #= tdiSeq(i)
       jtag.tms #= (i == tdiSeq.length - 1 && flipTms)
-      tdoSeq = tdoSeq.updated(i, jtag.tdo.toBoolean)
-      doClockCycle(1)
+      tdoSeq(i) = jtag.tdo.toBoolean
+      doClockCycles(1)
     }
     tdoSeq
+  }
+
+  object JtagStates extends Enumeration {
+    val RESET, IDLE, IR_SELECT, IR_CAPTURE, IR_SHIFT, IR_EXIT1, IR_PAUSE, IR_EXIT2, IR_UPDATE, DR_SELECT, DR_CAPTURE,
+        DR_SHIFT, DR_EXIT1, DR_PAUSE, DR_EXIT2, DR_UPDATE, UNKNOWN = Value
   }
 }

--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagDriver.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagDriver.scala
@@ -54,6 +54,6 @@ case class JtagDriver(jtag: Jtag, clockPeriod: TimeNumber) {
       tdoSeq(i) = jtag.tdo.toBoolean
       doClockCycles(1)
     }
-    tdoSeq
+    tdoSeq.to[collection.immutable.Seq]
   }
 }

--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagDriver.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagDriver.scala
@@ -1,6 +1,6 @@
 package spinal.lib.com.jtag.sim
 
-import scala.collection.{immutable, mutable}
+import scala.collection.mutable
 import spinal.core.TimeNumber
 import spinal.core.sim._
 import spinal.lib.com.jtag.Jtag
@@ -33,7 +33,7 @@ case class JtagDriver(jtag: Jtag, clockPeriod: TimeNumber) {
    * param: flipTms is used to flip the last TMS bit to 1 when the scan chain is finished
    * This allows to write longer sequences of bits from multiple calls to this function
    */
-  def doScanChain(tdiSeq: Seq[Boolean], flipTms: Boolean): immutable.Seq[Boolean] = {
+  def doScanChain(tdiSeq: Seq[Boolean], flipTms: Boolean): Seq[Boolean] = {
     // use mutable seq
     val tdoSeq = mutable.Seq.fill(tdiSeq.length)(false)
     for (i <- tdiSeq.indices) {
@@ -42,7 +42,7 @@ case class JtagDriver(jtag: Jtag, clockPeriod: TimeNumber) {
       tdoSeq(i) = jtag.tdo.toBoolean
       doClockCycles(1)
     }
-    tdoSeq.to _
+    tdoSeq.toSeq
   }
 
   /*

--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
@@ -1,0 +1,149 @@
+package solsoc
+
+import spinal.core.sim._
+import spinal.lib.com.jtag.Jtag
+
+import java.nio.{ByteBuffer, ByteOrder}
+import spinal.core.sim._
+
+import java.io.{DataInputStream, DataOutputStream}
+import java.net.ServerSocket
+
+/*
+    * This is a JTAG VPI interface for openocd
+    * It is used to connect openocd to a JTAG interface over TCP
+    * the reference interface implementation is in https://github.com/openocd-org/openocd/blob/master/src/jtag/drivers/jtag_vpi.c
+ */
+
+object JtagVpi {
+  def apply(jtag: Jtag, port: Int = 5555, jtagClkPeriod: Long) = fork {
+    val driver = JtagDriver(jtag, jtagClkPeriod)
+    var inputStream: DataInputStream = null
+    var outputStream: DataOutputStream = null
+    class SocketThread extends Thread {
+      val socket = new ServerSocket(port)
+
+      override def run(): Unit = {
+        println("VPI Server started, waiting for connection...")
+        while (true) {
+          val connection = try {
+            socket.accept()
+          } catch {
+            case e: Exception => return
+          }
+          //connection.setTcpNoDelay(true)
+          outputStream = new DataOutputStream(connection.getOutputStream())
+          inputStream = new DataInputStream(connection.getInputStream())
+          println("VPI Client connected")
+        }
+      }
+    }
+    val server = new SocketThread
+    onSimEnd(server.socket.close())
+    server.start()
+
+    // read the first message from the client and print it
+    val buffer = new Array[Byte](MaxSizeOfVpiCmd)
+    while (true) {
+      if(inputStream == null)
+      {
+        sleep(jtagClkPeriod)
+      }
+      else {
+        inputStream.readFully(buffer)
+
+        val vpiCmd = deserializeVpiCmd(buffer)
+
+        vpiCmd match {
+          case VpiCmd(Cmds.RESET, _, _, _, _) => {
+            driver.doResetTap()
+          }
+          case VpiCmd(Cmds.TMS_SEQ, bufferOut, _, _, nbBits) => {
+            val tmsSeq = bufferOut.map(x => (0 until 8).map(i => (x & (1 << i)) != 0)).flatten.take(nbBits)
+            driver.doTmsSeq(tmsSeq)
+          }
+          case VpiCmd(Cmds.SCAN_CHAIN, bufferOut, bufferIn, length, nbBits) => {
+            // bufferOut is a byte array, we need to convert it to a boolean array
+            // bufferIn is a byte array, we need to convert it to a boolean array
+            // each byte of bufferOut is a sequence of 8 bits (which is why nbBits exists)
+            // convert bufferOut to a boolean array
+            val tdiSeq = bufferOut.map(x => (0 until 8).map(i => (x & (1 << i)) != 0)).flatten.take(nbBits)
+            val tdoSeq = driver.doScanChain(tdiSeq, false)
+            // convert tdoSeq to a byte array grouped by 8 bits
+            val tdoSeqBytes = tdoSeq.grouped(8).map(_.foldLeft(0)((acc, b) => (acc << 1) | (if (b) 1 else 0))).toArray
+            // copy the result to bufferIn
+            for (i <- 0 until length) {
+              bufferIn(i) = tdoSeqBytes(i).toByte
+            }
+            // create packet to send to the client, exactly the same as the received packet but with the tdoSeq
+            val vpiCmd = VpiCmd(Cmds.SCAN_CHAIN, bufferOut, bufferIn, length, nbBits)
+            serialize(buffer, vpiCmd)
+            outputStream.write(buffer)
+          }
+          case VpiCmd(Cmds.SCAN_CHAIN_FLIP_TMS, bufferOut, bufferIn, length, nbBits) => {
+            // same as SCAN_CHAIN but with the last TMS set to 1
+            val tdiSeq = bufferOut.map(x => (0 until 8).map(i => (x & (1 << i)) != 0)).flatten.take(nbBits)
+            val tdoSeq = driver.doScanChain(tdiSeq, true)
+            val tdoSeqBytes =
+              tdoSeq.grouped(8).map(_.reverse.foldLeft(0)((acc, b) => (acc << 1) | (if (b) 1 else 0))).toArray
+            for (i <- 0 until length) {
+              bufferIn(i) = tdoSeqBytes(i).toByte
+            }
+            val vpiCmd = VpiCmd(Cmds.SCAN_CHAIN_FLIP_TMS, bufferOut, bufferIn, length, nbBits)
+            serialize(buffer, vpiCmd)
+            outputStream.write(buffer)
+          }
+          case VpiCmd(Cmds.STOP_SIMU, _, _, _, _) => {
+            println("Stop simulation")
+            simSuccess()
+          }
+        }
+      }
+    }
+  }
+
+  def deserializeVpiCmd(buffer: Array[Byte]): VpiCmd = {
+    val byteBuffer = ByteBuffer.wrap(buffer)
+    byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
+    val cmd = byteBuffer.getInt match {
+      case 0 => Cmds.RESET
+      case 1 => Cmds.TMS_SEQ
+      case 2 => Cmds.SCAN_CHAIN
+      case 3 => Cmds.SCAN_CHAIN_FLIP_TMS
+      case 4 => Cmds.STOP_SIMU
+    }
+    val bufferOut = new Array[Byte](XFERT_MAX_SIZE)
+    byteBuffer.get(bufferOut)
+    val bufferIn = new Array[Byte](XFERT_MAX_SIZE)
+    byteBuffer.get(bufferIn)
+    val length = byteBuffer.getInt
+    val nbBits = byteBuffer.getInt
+    VpiCmd(cmd, bufferOut, bufferIn, length, nbBits)
+  }
+
+  def XFERT_MAX_SIZE = 512
+
+  def serialize(buffer: Array[Byte], vpiCmd: VpiCmd) = {
+    val byteBuffer = ByteBuffer.wrap(buffer)
+    byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
+    vpiCmd.cmd match {
+      case Cmds.RESET               => byteBuffer.putInt(0)
+      case Cmds.TMS_SEQ             => byteBuffer.putInt(1)
+      case Cmds.SCAN_CHAIN          => byteBuffer.putInt(2)
+      case Cmds.SCAN_CHAIN_FLIP_TMS => byteBuffer.putInt(3)
+      case Cmds.STOP_SIMU           => byteBuffer.putInt(4)
+    }
+    byteBuffer.put(vpiCmd.bufferOut)
+    byteBuffer.put(vpiCmd.bufferIn)
+    byteBuffer.putInt(vpiCmd.length)
+    byteBuffer.putInt(vpiCmd.nbBits)
+  }
+
+  def MaxSizeOfVpiCmd = 4 + 2 * XFERT_MAX_SIZE + 4 + 4
+
+  case class VpiCmd(cmd: Cmds.Cmd, bufferOut: Array[Byte], bufferIn: Array[Byte], length: Int, nbBits: Int)
+  object Cmds extends Enumeration {
+    type Cmd = Value
+    val RESET, TMS_SEQ, SCAN_CHAIN, SCAN_CHAIN_FLIP_TMS, STOP_SIMU = Value
+  }
+}

--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
@@ -13,6 +13,15 @@ import java.net.ServerSocket
     * This is a JTAG VPI interface for openocd
     * It is used to connect openocd to a JTAG interface over TCP
     * the reference interface implementation is in https://github.com/openocd-org/openocd/blob/master/src/jtag/drivers/jtag_vpi.c
+    * Example openocd config:
+
+source [find interface/jtag_vpi.cfg]
+debug_level 1
+set _CHIPNAME SOC
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10002fff
+# init the CPU
+target create $_CHIPNAME.cpu riscv -chain-position $_CHIPNAME.cpu
+init
  */
 
 object JtagVpi {

--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
@@ -1,11 +1,10 @@
-package solsoc
+package spinal.lib.com.jtag.sim
 
 import spinal.core.TimeNumber
 import spinal.core.sim._
 import spinal.lib.com.jtag.Jtag
 
 import java.nio.{ByteBuffer, ByteOrder}
-import spinal.lib.com.jtag.sim.JtagDriver
 import spinal.sim.SimThread
 
 import java.io.{DataInputStream, DataOutputStream}
@@ -52,7 +51,7 @@ object JtagVpi {
             this.synchronized(JtagVpi.connection = connection)
             println("VPI Client connected")
           }
-          socket.close
+          socket.close()
           // wait for the client to disconnect (in a thread safe manner
           while (this.synchronized(JtagVpi.connection) != null) {
             Thread.sleep(100)
@@ -120,6 +119,7 @@ object JtagVpi {
             case VpiCmd(Cmds.STOP_SIMU, _, _, _, _) =>
               println("Stop simulation")
               simSuccess()
+            case _ => println(s"ERROR: received unknown VPI command: $vpiCmd")
           }
         } catch {
           case _: Exception =>
@@ -127,7 +127,7 @@ object JtagVpi {
             outputStream = null
             this.synchronized {
               this.synchronized(JtagVpi.connection = null)
-              println("VPI Client connected")
+              println("VPI Client disconnected")
             }
         }
       }
@@ -153,6 +153,8 @@ object JtagVpi {
     VpiCmd(cmd, bufferOut, bufferIn, length, nbBits)
   }
 
+  private def XFERT_MAX_SIZE = 512
+
   private def serialize(buffer: Array[Byte], vpiCmd: VpiCmd) = {
     val byteBuffer = ByteBuffer.wrap(buffer)
     byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
@@ -170,8 +172,6 @@ object JtagVpi {
   }
 
   private def MaxSizeOfVpiCmd = 4 + 2 * XFERT_MAX_SIZE + 4 + 4
-
-  private def XFERT_MAX_SIZE = 512
 
   private case class VpiCmd(cmd: Cmds.Cmd, bufferOut: Array[Byte], bufferIn: Array[Byte], length: Int, nbBits: Int)
 

--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
@@ -1,19 +1,21 @@
 package solsoc
 
+import spinal.core.TimeNumber
 import spinal.core.sim._
 import spinal.lib.com.jtag.Jtag
 
 import java.nio.{ByteBuffer, ByteOrder}
 import spinal.lib.com.jtag.sim.JtagDriver
+import spinal.sim.SimThread
 
 import java.io.{DataInputStream, DataOutputStream}
 import java.net.ServerSocket
 
 /*
-    * This is a JTAG VPI interface for openocd
-    * It is used to connect openocd to a JTAG interface over TCP
-    * the reference interface implementation is in https://github.com/openocd-org/openocd/blob/master/src/jtag/drivers/jtag_vpi.c
-    * Example openocd config:
+ * This is a JTAG VPI interface for openocd
+ * It is used to connect openocd to a JTAG interface over TCP
+ * the reference interface implementation is in https://github.com/openocd-org/openocd/blob/master/src/jtag/drivers/jtag_vpi.c
+ * Example openocd config:
 
 source [find interface/jtag_vpi.cfg]
 debug_level 1
@@ -25,7 +27,7 @@ init
  */
 
 object JtagVpi {
-  def apply(jtag: Jtag, port: Int = 5555, jtagClkPeriod: Long) = fork {
+  def apply(jtag: Jtag, port: Int = 5555, jtagClkPeriod: TimeNumber): SimThread = fork {
     val driver = JtagDriver(jtag, jtagClkPeriod)
     var inputStream: DataInputStream = null
     var outputStream: DataOutputStream = null
@@ -35,14 +37,14 @@ object JtagVpi {
       override def run(): Unit = {
         println("VPI Server started, waiting for connection...")
         while (true) {
-          val connection = try {
-            socket.accept()
-          } catch {
-            case e: Exception => return
-          }
-          //connection.setTcpNoDelay(true)
-          outputStream = new DataOutputStream(connection.getOutputStream())
-          inputStream = new DataInputStream(connection.getInputStream())
+          val connection =
+            try {
+              socket.accept()
+            } catch {
+              case _: Exception => return
+            }
+          outputStream = new DataOutputStream(connection.getOutputStream)
+          inputStream = new DataInputStream(connection.getInputStream)
           println("VPI Client connected")
         }
       }
@@ -54,30 +56,25 @@ object JtagVpi {
     // read the first message from the client and print it
     val buffer = new Array[Byte](MaxSizeOfVpiCmd)
     while (true) {
-      if(inputStream == null)
-      {
-        sleep(jtagClkPeriod)
-      }
-      else {
+      if (inputStream == null) {
+        sleep(timeToLong(jtagClkPeriod))
+      } else {
         inputStream.readFully(buffer)
 
         val vpiCmd = deserializeVpiCmd(buffer)
 
         vpiCmd match {
-          case VpiCmd(Cmds.RESET, _, _, _, _) => {
-            driver.doResetTap()
-          }
-          case VpiCmd(Cmds.TMS_SEQ, bufferOut, _, _, nbBits) => {
-            val tmsSeq = bufferOut.map(x => (0 until 8).map(i => (x & (1 << i)) != 0)).flatten.take(nbBits)
+          case VpiCmd(Cmds.RESET, _, _, _, _) => driver.doResetTap()
+          case VpiCmd(Cmds.TMS_SEQ, bufferOut, _, _, nbBits) =>
+            val tmsSeq = bufferOut.flatMap(x => (0 until 8).map(i => (x & (1 << i)) != 0)).take(nbBits)
             driver.doTmsSeq(tmsSeq)
-          }
-          case VpiCmd(Cmds.SCAN_CHAIN, bufferOut, bufferIn, length, nbBits) => {
+          case VpiCmd(Cmds.SCAN_CHAIN, bufferOut, bufferIn, length, nbBits) =>
             // bufferOut is a byte array, we need to convert it to a boolean array
             // bufferIn is a byte array, we need to convert it to a boolean array
             // each byte of bufferOut is a sequence of 8 bits (which is why nbBits exists)
             // convert bufferOut to a boolean array
-            val tdiSeq = bufferOut.map(x => (0 until 8).map(i => (x & (1 << i)) != 0)).flatten.take(nbBits)
-            val tdoSeq = driver.doScanChain(tdiSeq, false)
+            val tdiSeq = bufferOut.flatMap(x => (0 until 8).map(i => (x & (1 << i)) != 0)).take(nbBits)
+            val tdoSeq = driver.doScanChain(tdiSeq, flipTms = false)
             // convert tdoSeq to a byte array grouped by 8 bits
             val tdoSeqBytes = tdoSeq.grouped(8).map(_.foldLeft(0)((acc, b) => (acc << 1) | (if (b) 1 else 0))).toArray
             // copy the result to bufferIn
@@ -88,11 +85,10 @@ object JtagVpi {
             val vpiCmd = VpiCmd(Cmds.SCAN_CHAIN, bufferOut, bufferIn, length, nbBits)
             serialize(buffer, vpiCmd)
             outputStream.write(buffer)
-          }
-          case VpiCmd(Cmds.SCAN_CHAIN_FLIP_TMS, bufferOut, bufferIn, length, nbBits) => {
+          case VpiCmd(Cmds.SCAN_CHAIN_FLIP_TMS, bufferOut, bufferIn, length, nbBits) =>
             // same as SCAN_CHAIN but with the last TMS set to 1
-            val tdiSeq = bufferOut.map(x => (0 until 8).map(i => (x & (1 << i)) != 0)).flatten.take(nbBits)
-            val tdoSeq = driver.doScanChain(tdiSeq, true)
+            val tdiSeq = bufferOut.flatMap(x => (0 until 8).map(i => (x & (1 << i)) != 0)).take(nbBits)
+            val tdoSeq = driver.doScanChain(tdiSeq, flipTms = true)
             val tdoSeqBytes =
               tdoSeq.grouped(8).map(_.reverse.foldLeft(0)((acc, b) => (acc << 1) | (if (b) 1 else 0))).toArray
             for (i <- 0 until length) {
@@ -101,17 +97,15 @@ object JtagVpi {
             val vpiCmd = VpiCmd(Cmds.SCAN_CHAIN_FLIP_TMS, bufferOut, bufferIn, length, nbBits)
             serialize(buffer, vpiCmd)
             outputStream.write(buffer)
-          }
-          case VpiCmd(Cmds.STOP_SIMU, _, _, _, _) => {
+          case VpiCmd(Cmds.STOP_SIMU, _, _, _, _) =>
             println("Stop simulation")
             simSuccess()
-          }
         }
       }
     }
   }
 
-  def deserializeVpiCmd(buffer: Array[Byte]): VpiCmd = {
+  private def deserializeVpiCmd(buffer: Array[Byte]): VpiCmd = {
     val byteBuffer = ByteBuffer.wrap(buffer)
     byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
     val cmd = byteBuffer.getInt match {
@@ -130,9 +124,7 @@ object JtagVpi {
     VpiCmd(cmd, bufferOut, bufferIn, length, nbBits)
   }
 
-  def XFERT_MAX_SIZE = 512
-
-  def serialize(buffer: Array[Byte], vpiCmd: VpiCmd) = {
+  private def serialize(buffer: Array[Byte], vpiCmd: VpiCmd) = {
     val byteBuffer = ByteBuffer.wrap(buffer)
     byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
     vpiCmd.cmd match {
@@ -148,10 +140,13 @@ object JtagVpi {
     byteBuffer.putInt(vpiCmd.nbBits)
   }
 
-  def MaxSizeOfVpiCmd = 4 + 2 * XFERT_MAX_SIZE + 4 + 4
+  private def MaxSizeOfVpiCmd = 4 + 2 * XFERT_MAX_SIZE + 4 + 4
 
-  case class VpiCmd(cmd: Cmds.Cmd, bufferOut: Array[Byte], bufferIn: Array[Byte], length: Int, nbBits: Int)
-  object Cmds extends Enumeration {
+  private def XFERT_MAX_SIZE = 512
+
+  private case class VpiCmd(cmd: Cmds.Cmd, bufferOut: Array[Byte], bufferIn: Array[Byte], length: Int, nbBits: Int)
+
+  private object Cmds extends Enumeration {
     type Cmd = Value
     val RESET, TMS_SEQ, SCAN_CHAIN, SCAN_CHAIN_FLIP_TMS, STOP_SIMU = Value
   }

--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
@@ -4,7 +4,7 @@ import spinal.core.sim._
 import spinal.lib.com.jtag.Jtag
 
 import java.nio.{ByteBuffer, ByteOrder}
-import spinal.core.sim._
+import spinal.lib.com.jtag.sim.JtagDriver
 
 import java.io.{DataInputStream, DataOutputStream}
 import java.net.ServerSocket


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

This PR brings in some initial support for Jtag VPI, as an alternative to TcpJtag which require a forked openOCD. The VPI does not.

# Impact on code generation
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
none

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - _using Scaladoc comments: `/** */`?_
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
