### PR TITLE
Compile for all supported versions during CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/sbt
+    - run: sbt ++compile
     - run: sbt Test/compile
     - uses: actions/cache/save@v3
       with:


### PR DESCRIPTION
# Context, Motivation & Description

In our version file we list a few versions that the package claims to be compatible with, we should build for all of them in the CI to prevent possible surprises during a release.

# Impact on code generation

none
