### PR TITLE
add explicit unsupported feature error of axi4 downsizer.

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Downsizer.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Downsizer.scala
@@ -34,6 +34,9 @@ class Axi4DownsizerSubTransactionGenerator[T <: Axi4Ax](
         val last    = out Bool ()
         val done    = out Bool ()
     }
+    checkConfig(inputConfig)
+    checkConfig(outputConfig)
+
     val sizeMaxOut = log2Up(outputConfig.bytePerWord)
     val sizeMaxIn  = log2Up(inputConfig.bytePerWord)
 
@@ -89,6 +92,11 @@ class Axi4DownsizerSubTransactionGenerator[T <: Axi4Ax](
     io.done := cmdExtender.io.done
     io.start := startAddress
     io.output << cmdStream
+
+    def checkConfig(config: Axi4Config) = {
+        assert(!config.useBurst, "Current implementation does not support variable burst type.")
+        assert(!config.useId, "Current implementation does not support interleavable transfer.")
+    }
 
     def formalAsserts() = new Composite(this, "asserts") {
         def ratio2size(x: UInt): UInt = {

--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4AdapterTester.scala
@@ -318,26 +318,46 @@ class Axi4DownsizerTester extends SpinalAnyFunSuite {
         println("done")
     }
 
-    test("readOnly_32_64") {
-        SimConfig
-            .compile(Axi4ReadOnlyDownsizer(Axi4Config(20, 64, 4), Axi4Config(20, 32, 4)))
-            .doSim("test", 42)((dut: Axi4ReadOnlyDownsizer) => readTester(dut))
-    }
-    test("readOnly_16_64") {
-        SimConfig
-            .compile(Axi4ReadOnlyDownsizer(Axi4Config(20, 64, 4), Axi4Config(20, 16, 4)))
-            .doSim("test", 42)((dut: Axi4ReadOnlyDownsizer) => readTester(dut))
-    }
-    test("readOnly_32_128") {
-        SimConfig
-            .compile(Axi4ReadOnlyDownsizer(Axi4Config(20, 128, 4), Axi4Config(20, 32, 4)))
-            .doSim("test", 42)((dut: Axi4ReadOnlyDownsizer) => readTester(dut))
-    }
-    test("readOnly_32_128_pipelined") {
-        SimConfig
-            .compile(Axi4ReadOnlyDownsizer(Axi4Config(20, 128, 4), Axi4Config(20, 32, 4)))
-            .doSim("test", 42)((dut: Axi4ReadOnlyDownsizer) => readTester(dut, true))
-    }
+  test("readOnly_32_64") {
+    SimConfig
+      .compile(
+        Axi4ReadOnlyDownsizer(
+          Axi4Config(20, 64, 4, useBurst = false, useId = false),
+          Axi4Config(20, 32, 4, useBurst = false, useId = false)
+        )
+      )
+      .doSim("test", 42)((dut: Axi4ReadOnlyDownsizer) => readTester(dut))
+  }
+  test("readOnly_16_64") {
+    SimConfig
+      .compile(
+        Axi4ReadOnlyDownsizer(
+          Axi4Config(20, 64, 4, useBurst = false, useId = false),
+          Axi4Config(20, 16, 4, useBurst = false, useId = false)
+        )
+      )
+      .doSim("test", 42)((dut: Axi4ReadOnlyDownsizer) => readTester(dut))
+  }
+  test("readOnly_32_128") {
+    SimConfig
+      .compile(
+        Axi4ReadOnlyDownsizer(
+          Axi4Config(20, 128, 4, useBurst = false, useId = false),
+          Axi4Config(20, 32, 4, useBurst = false, useId = false)
+        )
+      )
+      .doSim("test", 42)((dut: Axi4ReadOnlyDownsizer) => readTester(dut))
+  }
+  test("readOnly_32_128_pipelined") {
+    SimConfig
+      .compile(
+        Axi4ReadOnlyDownsizer(
+          Axi4Config(20, 128, 4, useBurst = false, useId = false),
+          Axi4Config(20, 32, 4, useBurst = false, useId = false)
+        )
+      )
+      .doSim("test", 42)((dut: Axi4ReadOnlyDownsizer) => readTester(dut, true))
+  }
 }
 
 class Axi4IdRemoverTester extends SpinalAnyFunSuite {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Partially Closes #1100 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
~~- [ ] API changes are or will be documented:~~
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
