### PR TITLE
Have Spinal emit a constraints on VHDL blackbox component declaration…

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -1200,7 +1200,8 @@ class ComponentEmitterVhdl(
     component.getOrdredNodeIo.foreach {
       case baseType: BaseType =>
         if (baseType.isIo && !baseType.isSuffix) {
-          declarations ++= s"      ${baseType.getName()} : ${emitDirection(baseType)} ${blackBoxReplaceTypeRegardingTag(component, emitDataType(baseType, false))};\n"
+          val isGeneric = baseType.hasTag(classOf[GenericValue])
+          declarations ++= s"      ${baseType.getName()} : ${emitDirection(baseType)} ${blackBoxReplaceTypeRegardingTag(component, emitDataType(baseType, !isGeneric))};\n"
         }
       case _ =>
     }


### PR DESCRIPTION
In my investigation of #1104 I came across #358 which disabled constraining the widths of signals in a component declaration because emitting constraints containing generics would be quite difficult. While I agree this would be quite difficult, constraining the signals that don't have a generic is pretty straightforward and fixes my issue. 

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1104 


# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
Adds width constraints to io signals in a VHDL blackbox component declaration when generating VHDL

before:

```VHDL
  component Example is
    port( 
      io_data_in_0 : in std_logic_vector;
      io_data_in_1 : in std_logic_vector;
      io_data_in_2 : in std_logic_vector;
      io_data_in_3 : in std_logic_vector;
      io_data_out : out std_logic_vector
 );
```

After
```VHDL
  component Example is
    port( 
      io_data_in_0 : in std_logic_vector(15 downto 0);
      io_data_in_1 : in std_logic_vector(15 downto 0);
      io_data_in_2 : in std_logic_vector(15 downto 0);
      io_data_in_3 : in std_logic_vector(15 downto 0);
      io_data_out : out std_logic_vector(15 downto 0)
 );
```

