### PR TITLE
Regif Chead union struct name add prefix

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
@@ -62,7 +62,7 @@ final case class CHeaderGenerator(
 
             def union: String = {
                 s"""/**
-                   |  * @union       ${reg.getName().toLowerCase()}_t
+                   |  * @union       ${prefix.toLowerCase()}_${reg.getName().toLowerCase()}_t
                    |  * @address     0x${reg.getAddr().hexString(16)}
                    |  * @brief       ${reg.getDoc().replace("\n","\\n")}
                    |  */
@@ -71,7 +71,7 @@ final case class CHeaderGenerator(
                    |    struct {
                    |        ${fdUnion(" " * 8)}
                    |    } reg;
-                   |} ${reg.getName().toLowerCase()}_t;""".stripMargin
+                   |}${prefix.toLowerCase()}_${reg.getName().toLowerCase()}_t;""".stripMargin
             }
 
             def fdNameLens = math.max("reserved_0".size, reg.getFieldDescrs().map(_.getName.size).max)


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
Regif Chead union struct name will conflict in different regfile with same field name . So we add prefix in Regif Chead union struct name
<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
