### PR TITLE
Deprecate `genIf`

### DIFF
--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -693,6 +693,7 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
   }
 
   /** Generate this if condition is true */
+  @deprecated("does not work with <>, use 'someBool generate Type()' or 'if(condition) Type() else null' instead")
   def genIf(cond: Boolean): this.type = if(cond) this else null
 
   private [core] def formalPast(delay : Int) : this.type = {

--- a/lib/src/main/scala/spinal/lib/blackbox/lattice/ice40/Blackbox.scala
+++ b/lib/src/main/scala/spinal/lib/blackbox/lattice/ice40/Blackbox.scala
@@ -338,10 +338,10 @@ object SB_PLL40_CONFIG {
 abstract class ICE40_PLL(p: AbstractPllConfig) extends BlackBox {
   val RESETB = in port Bool() default True
   val BYPASS = in port Bool() default False
-  val EXTFEEDBACK = in port Bool().genIf(p.withExtFeedback)
-  val DYNAMICDELAY = in port Bits(8 bit).genIf(p.withDynamicDelay)
-  val LATCHINPUTVALUE = in port Bool().genIf(p.withLatchInputValue)
-  val LOCK = out port Bool().genIf(p.withLock)
+  val EXTFEEDBACK = p.withExtFeedback generate(in port Bool())
+  val DYNAMICDELAY = p.withDynamicDelay generate(in port Bits(8 bit))
+  val LATCHINPUTVALUE = p.withLatchInputValue generate(in port Bool())
+  val LOCK = p.withLock generate(out port Bool())
   val PLLOUTGLOBAL = out port Bool()
   val PLLOUTCORE = out port Bool()
 


### PR DESCRIPTION
As noted in #1116 `genIf` does not work with <>, both SpinalHDL and VecRiscV codebases have moved over to using `condition generate ...` or `if(condition) ... else null`
Therefore deprecate `genIf` to point users to the alternatives.

# Impact on code generation

None