### PR TITLE
Fix HDL names of memory ports

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -177,12 +177,12 @@ class ComponentEmitterVerilog(
     component.dslBody.walkStatements{ s =>
       s.walkDrivingExpressions{ e =>
         if(!e.isInstanceOf[DeclarationStatement] && expressionToWrap.contains(e)){
-          var sName = s match {
+          val sName = s match {
             case s : AssignmentStatement => "_" + s.dlcParent.getName()
             case s : WhenStatement => "_when"
             case s : SwitchContext => "_switch"
-            case s : Nameable => "_" + s.getName()
             case s : MemPortStatement => "_" + s.dlcParent.getName() + "_port"
+            case s : Nameable => "_" + s.getName()
             case _ => ""
           }
           val name = component.localNamingScope.allocateName(anonymSignalPrefix + sName)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -174,15 +174,15 @@ class ComponentEmitterVerilog(
     cutLongExpressions()
     expressionToWrap --= wrappedExpressionToName.keysIterator
 
-    component.dslBody.walkStatements{ s =>
-      s.walkDrivingExpressions{ e =>
-        if(!e.isInstanceOf[DeclarationStatement] && expressionToWrap.contains(e)){
+    component.dslBody.walkStatements { s =>
+      s.walkDrivingExpressions { e =>
+        if (!e.isInstanceOf[DeclarationStatement] && expressionToWrap.contains(e)) {
           val sName = s match {
-            case s : AssignmentStatement => "_" + s.dlcParent.getName()
-            case s : WhenStatement => "_when"
-            case s : SwitchContext => "_switch"
-            case s : MemPortStatement => "_" + s.dlcParent.getName() + "_port"
-            case s : Nameable => "_" + s.getName()
+            case s: AssignmentStatement => "_" + s.dlcParent.getName()
+            case _: WhenStatement => "_when"
+            case _: SwitchContext => "_switch"
+            case s: MemPortStatement => "_" + s.dlcParent.getName() + "_port"
+            case s: Nameable => "_" + s.getName()
             case _ => ""
           }
           val name = component.localNamingScope.allocateName(anonymSignalPrefix + sName)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -201,12 +201,12 @@ class ComponentEmitterVhdl(
     component.dslBody.walkStatements{ s =>
       s.walkExpression{ e =>
         if(!e.isInstanceOf[DeclarationStatement] && expressionToWrap.contains(e)){
-          var sName = s match {
+          val sName = s match {
             case s : AssignmentStatement => "_" + s.dlcParent.getName()
             case s : WhenStatement => "_when"
             case s : SwitchContext => "_switch"
-            case s : Nameable => "_" + s.getName()
             case s : MemPortStatement =>  "_" + s.dlcParent.getName() + "_port"
+            case s : Nameable => "_" + s.getName()
             case _ => ""
           }
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -198,15 +198,15 @@ class ComponentEmitterVhdl(
     //Wrap expression which need it
     cutLongExpressions()
     expressionToWrap --= wrappedExpressionToName.keysIterator
-    component.dslBody.walkStatements{ s =>
-      s.walkExpression{ e =>
-        if(!e.isInstanceOf[DeclarationStatement] && expressionToWrap.contains(e)){
+    component.dslBody.walkStatements { s =>
+      s.walkExpression { e =>
+        if (!e.isInstanceOf[DeclarationStatement] && expressionToWrap.contains(e)) {
           val sName = s match {
-            case s : AssignmentStatement => "_" + s.dlcParent.getName()
-            case s : WhenStatement => "_when"
-            case s : SwitchContext => "_switch"
-            case s : MemPortStatement =>  "_" + s.dlcParent.getName() + "_port"
-            case s : Nameable => "_" + s.getName()
+            case s: AssignmentStatement => "_" + s.dlcParent.getName()
+            case _: WhenStatement => "_when"
+            case _: SwitchContext => "_switch"
+            case s: MemPortStatement => "_" + s.dlcParent.getName() + "_port"
+            case s: Nameable => "_" + s.getName()
             case _ => ""
           }
 


### PR DESCRIPTION
We have code to name memory access ports with the postfix "_port", but it is not working/used.

A MemPortStatement is a Nameable, the match would never choose the MemPortStatement case.
