### PR TITLE
core: RFC object SmtBmcSolver extends Enumeration: TYPOs ?

### DIFF
--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -29,10 +29,10 @@ sealed trait SbyEngine extends FormalEngin {
 object SmtBmcSolver extends Enumeration {
   type SmtBmcSolver = Value
 
-  val Yices = Value("yices")      // Yices2 ?
-  val Boolector = Value("booleactor")   // TYPO: boolector
+  val Yices = Value("yices")
+  val Boolector = Value("boolector")
   val Z3 = Value("z3")
-  val mathsat = Value("mathsat")
+  // val mathsat = Value("mathsat")
   val cvc4 = Value("cvc4")
 }
 

--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -29,8 +29,8 @@ sealed trait SbyEngine extends FormalEngin {
 object SmtBmcSolver extends Enumeration {
   type SmtBmcSolver = Value
 
-  val Yices = Value("yices")
-  val Boolector = Value("booleactor")
+  val Yices = Value("yices")      // Yices2 ?
+  val Boolector = Value("booleactor")   // TYPO: boolector
   val Z3 = Value("z3")
   val mathsat = Value("mathsat")
   val cvc4 = Value("cvc4")

--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -30,10 +30,20 @@ object SmtBmcSolver extends Enumeration {
   type SmtBmcSolver = Value
 
   val Yices = Value("yices")
+  /** bitwuzla: is untested
+   */
+  val bitwuzla = Value("bitwuzla")
+  /** Boolector: is untested
+   */
   val Boolector = Value("boolector")
   val Z3 = Value("z3")
-  // val mathsat = Value("mathsat")
+  /** mathsat: is untested
+   */
+  val mathsat = Value("mathsat")
   val cvc4 = Value("cvc4")
+  /**cvc5: is untested
+   */
+  val cvc5 = Value("cvc5")
 }
 
 case class SmtBmc(

--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -41,7 +41,7 @@ object SmtBmcSolver extends Enumeration {
    */
   val mathsat = Value("mathsat")
   val cvc4 = Value("cvc4")
-  /**cvc5: is untested
+  /** cvc5: is untested
    */
   val cvc5 = Value("cvc5")
 }


### PR DESCRIPTION
Request For Comments:
    
  Boolector definitely looks incorrect spelling to me, has this been tested ?
    
  Just a check Yices is called 'yices' in the configuration for sby and not yices2.

@Readon PING  you can open a commit if any change needed separately, then close this without merge.  Thanks