### PR TITLE
Make type of register value in CHeaderGenerator configurable

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/CHeaderGenerator.scala
@@ -67,7 +67,7 @@ final case class CHeaderGenerator(
                    |  * @brief       ${reg.getDoc().replace("\n","\\n")}
                    |  */
                    |typedef union {
-                   |    u32 val;
+                   |    ${regType} val;
                    |    struct {
                    |        ${fdUnion(" " * 8)}
                    |    } reg;


### PR DESCRIPTION
When generating a header file using the CHeaderGenerator, if you try to specify an alternative regType (such as `uint32_t`), the header it generated would include the following:
```
/**
  * @union       ap_config_reg_t
  * @address     0x0100
  * @brief       Configuration Register
  */
typedef union {
    u32 val;
    struct {
        uint32_t func_en   :  1; //RW, reset: 0x1, Function enable
        uint32_t reserved_0 : 31; //NA, Reserved
    } reg;
} ap_config_reg_t;
```

The members of the union would have their type set correctly, but the non-union member of the struct would not. 

This PR changes it to generate the following:
```
/**
  * @union       ap_config_reg_t
  * @address     0x0100
  * @brief       Configuration Register
  */
typedef union {
    uint32_t val;
    struct {
        uint32_t func_en   :  1; //RW, reset: 0x1, Function enable
        uint32_t reserved_0 : 31; //NA, Reserved
    } reg;
} ap_config_reg_t;
```


