### PR TITLE
Rework PackedBundle packing to avoid width confusion

### DIFF
--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedBundleTester.scala
@@ -26,10 +26,10 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
           val e = in(Bits(3 bit))
           val f = in(Bits(6 bit))
           val g = in(Bits(6 bit))
-          val packed = out(packedBundle.asBits.clone)
+          val packed = out(packedBundle.packed.clone)
         }
 
-        io.packed := RegNext(packedBundle.asBits)
+        io.packed := RegNext(packedBundle.packed)
         packedBundle.a := io.a
         packedBundle.b := io.b
         packedBundle.c := io.c
@@ -101,10 +101,10 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
           val e = out(Bits(3 bit))
           val f = out(Bits(6 bit))
           val g = out(Bits(6 bit))
-          val packed = in(packedBundle.asBits.clone)
+          val packed = in(packedBundle.packed.clone)
         }
 
-        packedBundle.assignFromBits(RegNext(io.packed))
+        packedBundle.unpack(RegNext(io.packed))
         io.a := packedBundle.a
         io.b := packedBundle.b
         io.c := packedBundle.c
@@ -174,10 +174,10 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
           val e = in(Bits(3 bit))
           val f = in(Bits(6 bit))
           val g = in(Bits(6 bit))
-          val packed = out(packedBundle.asBits.clone)
+          val packed = out(packedBundle.packed.clone)
         }
 
-        io.packed := RegNext(packedBundle.asBits)
+        io.packed := RegNext(packedBundle.packed)
         packedBundle.a := io.a
         packedBundle.b := io.b
         packedBundle.c := io.c
@@ -249,10 +249,10 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
           val e = out(Bits(3 bit))
           val f = out(Bits(6 bit))
           val g = out(Bits(6 bit))
-          val packed = in(packedBundle.asBits.clone)
+          val packed = in(packedBundle.packed.clone)
         }
 
-        packedBundle.assignFromBits(RegNext(io.packed))
+        packedBundle.unpack(RegNext(io.packed))
         io.a := packedBundle.a
         io.b := packedBundle.b
         io.c := packedBundle.c

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedWordBundleTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimPackedWordBundleTester.scala
@@ -21,10 +21,10 @@ class SpinalSimPackedWordBundleTester extends AnyFunSuite {
           val b = in(Bits(8 bit))
           val c = in(Bits(16 bit))
           val d = in(Bits(3 bit))
-          val packed = out(packedBundle.asBits.clone)
+          val packed = out(packedBundle.packed.clone)
         }
 
-        io.packed := RegNext(packedBundle.asBits)
+        io.packed := RegNext(packedBundle.packed)
         packedBundle.a := io.a
         packedBundle.b := io.b
         packedBundle.c := io.c
@@ -73,10 +73,10 @@ class SpinalSimPackedWordBundleTester extends AnyFunSuite {
           val b = out(Bits(8 bit))
           val c = out(Bits(16 bit))
           val d = out(Bits(3 bit))
-          val packed = in(packedBundle.asBits.clone)
+          val packed = in(packedBundle.packed.clone)
         }
 
-        packedBundle.assignFromBits(RegNext(io.packed))
+        packedBundle.unpack(RegNext(io.packed))
         io.a := packedBundle.a
         io.b := packedBundle.b
         io.c := packedBundle.c


### PR DESCRIPTION
Original method of translating to and from a packed bitvector results in errors in FIFO, Streams, etc. These classes analyze the bundle type and detect width mismatches.
New change doesn't override asBits or getBitsWidth to avoid problems.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
