### PR TITLE
AxiMemorySim Random object as parameter

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/AxiMemorySim.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/sim/AxiMemorySim.scala
@@ -288,7 +288,7 @@ case class AxiMemorySim(
   axi : Axi4,
   clockDomain : ClockDomain,
   config : AxiMemorySimConfig,
-  random : Random = Random,
+  random : Random = Random
 ) {
   val memory = SparseMemory()
   val pending_reads = new mutable.Queue[AxiJob]


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

Optionally pass a `scala.util.Random` object into `AxiMemorySim`, so tests can be reproducible.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
