### PR TITLE
fix #1133. use max width of all BMB ports as mux width to avoid misma…

### DIFF
--- a/lib/src/main/scala/spinal/lib/memory/sdram/xdr/Tasker.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/xdr/Tasker.scala
@@ -161,7 +161,12 @@ case class Tasker(cpa : CoreParameterAggregate) extends Component{
 
     output.valid := (selOH & inputsValids).orR
     Vec(inputs.map(_.ready)) := Vec(selOH.asBools.map(_ && output.ready))
-    val selPayload = MuxOH(selOH, inputs.map(_.payload.resized))
+
+    val selPayload = cloneOf(inputs.map(_.payload).maxBy(_.getBitsWidth))
+    val selInputs = Vec(cloneOf(selPayload), inputs.size)
+    selInputs := Vec(inputs.map(_.payload.resized))
+    selPayload := MuxOH(selOH, selInputs)
+
     output.write := selPayload.write
     output.address := selPayload.address
     output.context := selPayload.context


### PR DESCRIPTION
…tch.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1133 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

The inputs of mux with different width will lead the MuxOH width mismatch.
Which would take the responsibility to do the width check? does MuxOH should check them?
The temperary solution is added. However, a more unified method is preferred. :)

# Impact on code generation

No.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

~- [ ] Unit tests were added~
~- [ ] API changes are or will be documented:~
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
