### PR TITLE
Reset AxiLite4Driver on instantiation

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axilite/sim/AxiLite4Driver.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axilite/sim/AxiLite4Driver.scala
@@ -9,7 +9,6 @@ import spinal.lib.sim.{StreamDriver, StreamMonitor, StreamReadyRandomizer}
 import scala.collection.mutable
 
 case class AxiLite4Driver(axi : AxiLite4, clockDomain : ClockDomain) {
-
   def reset() : Unit = {
     axi.aw.valid #= false
     axi.w.valid #= false
@@ -17,6 +16,8 @@ case class AxiLite4Driver(axi : AxiLite4, clockDomain : ClockDomain) {
     axi.r.ready #= true
     axi.b.ready #= true
   }
+
+  reset()
 
   def read(address : BigInt) : BigInt = {
     axi.ar.payload.prot.assignBigInt(6)


### PR DESCRIPTION
Closes #1125

# Context, Motivation & Description

The AxiLite4Driver's behavior differs from most other drivers that it needed a call to `.reset()` to drive some static, necessary levels. Call reset on instatiation to remove this confusion, keep reset to not break old code. Remove unnecessary `reset()` calls in tests so that they are not bad examples.

# Impact on code generation

none