### PR TITLE
Add timeScale support to simulators

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -46,6 +46,7 @@ case class SpinalVerilatorBackendConfig[T <: Component](
                                                          optimisationLevel : Int = 2,
                                                          simulatorFlags    : ArrayBuffer[String] = ArrayBuffer[String](),
                                                          withCoverage      : Boolean,
+                                                         timeScale         : TimeNumber = null,
                                                          timePrecision     : TimeNumber = null
 )
 
@@ -172,6 +173,7 @@ class SpinalVpiBackendConfig[T <: Component](val rtl               : SpinalRepor
                                              val usePluginsCache  : Boolean,
                                              val pluginsCachePath : String,
                                              val enableLogging    : Boolean,
+                                             val timeScale        : TimeNumber,
                                              val timePrecision    : TimeNumber)
 
 
@@ -188,6 +190,7 @@ case class SpinalIVerilogBackendConfig[T <: Component](override val rtl : Spinal
                                                    override val usePluginsCache   : Boolean = true,
                                                    override val pluginsCachePath  : String = "./simWorkspace/.pluginsCachePath",
                                                    override val enableLogging     : Boolean = false,
+                                                   override val timeScale         : TimeNumber = null,
                                                    override val timePrecision     : TimeNumber = null) extends
                                               SpinalVpiBackendConfig[T](rtl,
                                                                         waveFormat,
@@ -202,6 +205,7 @@ case class SpinalIVerilogBackendConfig[T <: Component](override val rtl : Spinal
                                                                         usePluginsCache,
                                                                         pluginsCachePath,
                                                                         enableLogging,
+                                                                        timeScale,
                                                                         timePrecision)
 
 
@@ -218,6 +222,7 @@ case class SpinalVCSBackendConfig[T <: Component](override val rtl : SpinalRepor
                                                   override val usePluginsCache   : Boolean = true,
                                                   override val pluginsCachePath  : String = "./simWorkspace/.pluginsCachePath",
                                                   override val enableLogging     : Boolean = false,
+                                                  override val timeScale         : TimeNumber = null,
                                                   override val timePrecision     : TimeNumber = null,
                                                   val simSetupFile               : String = null,
                                                   val envSetup                   : () => Unit = null,
@@ -239,6 +244,7 @@ case class SpinalVCSBackendConfig[T <: Component](override val rtl : SpinalRepor
     usePluginsCache,
     pluginsCachePath,
     enableLogging,
+    timeScale,
     timePrecision)
 
 case class SpinalGhdlBackendConfig[T <: Component](override val rtl : SpinalReport[T],
@@ -254,6 +260,7 @@ case class SpinalGhdlBackendConfig[T <: Component](override val rtl : SpinalRepo
                                                    override val usePluginsCache   : Boolean = true,
                                                    override val pluginsCachePath  : String = "./simWorkspace/.pluginsCachePath",
                                                    override val enableLogging     : Boolean = false,
+                                                   override val timeScale         : TimeNumber = null,
                                                    override val timePrecision     : TimeNumber = null) extends
                                               SpinalVpiBackendConfig[T](rtl,
                                                                         waveFormat,
@@ -268,6 +275,7 @@ case class SpinalGhdlBackendConfig[T <: Component](override val rtl : SpinalRepo
                                                                         usePluginsCache,
                                                                         pluginsCachePath,
                                                                         enableLogging,
+                                                                        timeScale,
                                                                         timePrecision)
 
 
@@ -440,6 +448,7 @@ case class SpinalXSimBackendConfig[T <: Component](val rtl               : Spina
                                                val xilinxDevice     : String,
                                                val simScript        : String,
                                                val simulatorFlags   : ArrayBuffer[String] = ArrayBuffer[String](),
+                                               val timeScale        : TimeNumber = null,
                                                val timePrecision    : TimeNumber = null)
 
 object SpinalXSimBackend {
@@ -463,6 +472,7 @@ object SpinalXSimBackend {
     vconfig.xilinxDevice      = xilinxDevice
     vconfig.userSimulationScript = simScript
     vconfig.xelabFlags        = simulatorFlags.toArray
+    vconfig.timeScale         = if (timeScale != null) timeScale.decomposeString else null
     vconfig.timePrecision     = if (timePrecision != null) timePrecision.decomposeString else null
 
     var signalId = 0
@@ -996,6 +1006,7 @@ case class SpinalSimConfig(
           optimisationLevel = _optimisationLevel,
           simulatorFlags = _simulatorFlags,
           withCoverage = _withCoverage,
+          timeScale = _timeScale,
           timePrecision = _timePrecision
         )
         val backend = SpinalVerilatorBackend(vConfig)
@@ -1025,6 +1036,7 @@ case class SpinalSimConfig(
           runFlags = _runFlags,
           enableLogging = _withLogging,
           usePluginsCache = !_disableCache,
+          timeScale = _timeScale,
           timePrecision = _timePrecision
         )
         val backend = SpinalGhdlBackend(vConfig)
@@ -1053,6 +1065,7 @@ case class SpinalSimConfig(
           simulatorFlags = _simulatorFlags,
           enableLogging = _withLogging,
           usePluginsCache = !_disableCache,
+          timeScale = _timeScale,
           timePrecision = _timePrecision
         )
         val backend = SpinalIVerilogBackend(vConfig)
@@ -1084,6 +1097,7 @@ case class SpinalSimConfig(
           vcsFlags = _vcsUserFlags,
           simSetupFile = _vcsSimSetupFile,
           envSetup = _vcsEnvSetup,
+          timeScale = _timeScale,
           timePrecision = _timePrecision
         )
         val backend = SpinalVCSBackend(vConfig)
@@ -1108,6 +1122,7 @@ case class SpinalSimConfig(
           xilinxDevice = _xilinxDevice,
           simScript = _simScript,
           simulatorFlags = _simulatorFlags,
+          timeScale = _timeScale,
           timePrecision = _timePrecision
         )
         val backend = SpinalXSimBackend(vConfig)

--- a/sim/src/main/scala/spinal/sim/IVerilogBackend.scala
+++ b/sim/src/main/scala/spinal/sim/IVerilogBackend.scala
@@ -60,10 +60,17 @@ class IVerilogBackend(config: IVerilogBackendConfig) extends VpiBackend(config) 
   val IVERILOGLDFLAGS = Process(Seq(iverilogVpiPath, "--ldflags")).!!
   val IVERILOGLDLIBS = Process(Seq(iverilogVpiPath, "--ldlibs")).!!
 
-  val timeScale = config.timePrecision match {
-    case null => "1ns/1ns"
-    case t => "1ns/" + t.replace(" ", "")
+  val timeScaleStr = config.timeScale match {
+    case null => "1ns"
+    case t => t.replace(" ", "")
   }
+
+  val timePrecisionStr = config.timePrecision match {
+    case null => "1ns"
+    case t => t.replace(" ", "")
+  }
+
+  val timeScale = timeScaleStr + "/" + timePrecisionStr
 
   def compileVPI() = {
     val vpiModulePath = pluginsPath + "/" + vpiModuleName

--- a/sim/src/main/scala/spinal/sim/VCSBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VCSBackend.scala
@@ -157,10 +157,17 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
     }
   }
 
-  val timeScale = config.timePrecision match {
-    case null => "1ns/1ns"
-    case t => "1ns/" + t.replace(" ", "")
+  val timeScaleStr = config.timeScale match {
+    case null => "1ns"
+    case t => t.replace(" ", "")
   }
+
+  val timePrecisionStr = config.timePrecision match {
+    case null => "1ns"
+    case t => t.replace(" ", "")
+  }
+
+  val timeScale = timeScaleStr + "/" + timePrecisionStr
 
 
   def compileVPI(): Unit = {

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -30,6 +30,7 @@ case class VpiBackendConfig(
   var LDFLAGS: String        = "-lpthread ", 
   var useCache: Boolean      = false,
   var logSimProcess: Boolean = false,
+  var timeScale: String      = null,
   var timePrecision: String  = null
 )
 

--- a/sim/src/main/scala/spinal/sim/XSimBackend.scala
+++ b/sim/src/main/scala/spinal/sim/XSimBackend.scala
@@ -29,6 +29,7 @@ case class XSimBackendConfig(
                              var waveFormat: WaveFormat = WaveFormat.NONE,
                              var userSimulationScript: String = null,
                              var xelabFlags: Array[String] = null,
+                             var timeScale: String = null,
                              var timePrecision: String = null
                            )
 
@@ -168,9 +169,10 @@ class XSimBackend(config: XSimBackendConfig) extends Backend {
       moreOptions ++= config.xelabFlags
     }
     if (config.timePrecision != null) {
+      val timeScale = config.timeScale.replace(" ", "")
       val timePrecision = config.timePrecision.replace(" ","")
       moreOptions += "-override_timeprecision"
-      moreOptions += "-timescale " + timePrecision + "/" + timePrecision
+      moreOptions += "-timescale " + timeScale + "/" + timePrecision
       moreOptions += "-timeprecision_vhdl " + timePrecision
     }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1138 

# Context, Motivation & Description

Finishes adding time scale support. This wasn't properly finished with the original set of time precision changes.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
