### PR TITLE
VivadoFlow: Fix issues with getFMax() and getArea(), and improve.

### DIFF
--- a/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoFlow.scala
+++ b/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoFlow.scala
@@ -42,7 +42,7 @@ object VivadoFlow {
 s"""${readRtl}
 read_xdc doit.xdc
 
-synth_design -part $device -top ${rtl.getTopModuleName()}
+synth_design -mode out_of_context -part $device -top ${rtl.getTopModuleName()}
 opt_design
 place_design
 route_design

--- a/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoFlow.scala
+++ b/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoFlow.scala
@@ -112,15 +112,20 @@ report_design_analysis -logic_level_distribution
         return 1.0 / (targetPeriod.toDouble - slack * 1e-9)
       }
       override def getArea(): String =  {
-        val intFind = "(\\d+,?)+".r
+        // 0, 30, 0.5, 15,5
+        val intFind = "(\\d+,?\\.?\\d*)".r
         val leArea = try {
           family match {
             case "Artix 7" | "Kintex 7" =>
               intFind.findFirstIn("Slice LUTs[ ]*\\|[ ]*(\\d+,?)+".r.findFirstIn(report).get).get + " LUT " +
               intFind.findFirstIn("Slice Registers[ ]*\\|[ ]*(\\d+,?)+".r.findFirstIn(report).get).get + " FF "
+            // Assume the the resources table is the only one with 5 columns (this is the case in Vivado 2021.2)
+            // (Not very version-proof, we should actually first look at the right table header first...)
             case "Kintex UltraScale" | "Kintex UltraScale+" | "Virtex UltraScale+" =>
-              intFind.findFirstIn("CLB LUTs[ ]*\\|[ ]*(\\d+,?)+".r.findFirstIn(report).get).get + " LUT " +
-              intFind.findFirstIn("CLB Registers[ ]*\\|[ ]*(\\d+,?)+".r.findFirstIn(report).get).get + " FF "
+              intFind.findFirstIn("\\| CLB LUTs[ ]*\\|([ ]*\\S+\\s+\\|){5}".r.findFirstIn(report).get).get + " LUT " +
+              intFind.findFirstIn("\\| CLB Registers[ ]*\\|([ ]*\\S+\\s+\\|){5}".r.findFirstIn(report).get).get + " FF " +
+              intFind.findFirstIn("\\| Block RAM Tile[ ]*\\|([ ]*\\S+\\s+\\|){5}".r.findFirstIn(report).get).get + " BRAM " + 
+              intFind.findFirstIn("\\| URAM[ ]*\\|([ ]*\\S+\\s+\\|){5}".r.findFirstIn(report).get).get + " URAM "
           }
         } catch {
           case e : Exception => "???"


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1153 and #1154.

# Context, Motivation & Description

Make sure pulse timing (for BRAMs, PLLs) is also considered for f.max
Make sure partials are matched with English localization (`0.5 BRAM` vs `0,5 BRAM`) 
URAMs and BRAMs are reported for Ultrascale(+)
`-mode out_of_context` is used during synthesis to prevent the need for I/O pins or XORing outputs.


# Impact on code generation

No impact on code generation.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
