### PR TITLE
Fix StreamFifoCC from leaking metastable io.pop.payload when empty

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1524,23 +1524,30 @@ class StreamFifoCC[T <: Data](val dataType: HardType[T],
   val finalPopCd = popClock.withOptionalBufferedResetFrom(withPopBufferedReset)(pushClock)
   val popCC = new ClockingArea(finalPopCd) {
     val popPtr      = Reg(UInt(log2Up(2*depth) bits)) init(0)
-    val popPtrPlus  = popPtr + 1
-    val popPtrGray  = RegNextWhen(toGray(popPtrPlus), io.pop.fire) init(0)
+    val popPtrPlus  = KeepAttribute(popPtr + 1)
+    val popPtrGray  = toGray(popPtr)
     val pushPtrGray = BufferCC(pushToPopGray, B(0, ptrWidth bit))
-    val empty       = isEmpty(popPtrGray, pushPtrGray)
+    val addressGen = Stream(UInt(log2Up(depth) bits))
+    val empty = isEmpty(popPtrGray, pushPtrGray)
+    addressGen.valid := !empty
+    addressGen.payload := popPtr.resized
 
-    io.pop.valid   := !empty
-    io.pop.payload := ram.readSync((io.pop.fire ? popPtrPlus | popPtr).resized, clockCrossing = true)
-
-    when(io.pop.fire) {
+    when(addressGen.fire){
       popPtr := popPtrPlus
     }
 
-    io.popOccupancy := (fromGray(pushPtrGray) - popPtr).resized
+    val readArbitation = addressGen.m2sPipe()
+    val readPort = ram.readSyncPort
+    readPort.cmd := addressGen.toFlowFire
+    io.pop << readArbitation.translateWith(readPort.rsp)
+
+    val ptrToPush = RegNextWhen(popPtrGray, readArbitation.fire) init(0)
+    val ptrToOccupancy = RegNextWhen(popPtr, readArbitation.fire) init(0)
+    io.popOccupancy := (fromGray(pushPtrGray) - ptrToOccupancy).resized
   }
 
   pushToPopGray := pushCC.pushPtrGray
-  popToPushGray := popCC.popPtrGray
+  popToPushGray := popCC.ptrToPush
 
   def formalAsserts(gclk: ClockDomain) = new Composite(this, "asserts") {
     import spinal.core.formal._

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1566,6 +1566,7 @@ class StreamFifoCC[T <: Data](val dataType: HardType[T],
       }
       assert(popCC.popPtrGray === toGray(popCC.popPtr))
       assert(fromGray(popCC.pushPtrGray) - popCC.popPtr <= depth)
+      assert(popCC.popPtr === fromGray(popCC.ptrToPush) + io.pop.valid.asUInt)
     }
 
     val globalArea = new ClockingArea(gclk) {

--- a/lib/src/main/scala/spinal/lib/cpu/riscv/debug/DebugTransportModuleJtag.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/debug/DebugTransportModuleJtag.scala
@@ -87,7 +87,7 @@ class DebugTransportModuleJtag(p : DebugTransportModuleParameter,
       pushClock = jtagCd,
       popClock = debugCd,
       withOutputM2sPipe = false
-    ).toStream.m2sPipe(crossClockData = true)
+    ).toStream.m2sPipe(crossClockData = true, holdPayload = true)
 
     bus.cmd << cmd
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamFifoCCTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimStreamFifoCCTester.scala
@@ -18,30 +18,34 @@ class SpinalSimStreamFifoCCTester extends SpinalSimFunSuite {
     val queueModel = mutable.Queue[Long]()
 
     //Push data randomly and fill the queueModel with pushed transactions
-    val pushThread = fork{
-      while(true){
-        dut.io.push.valid.randomize()
-        dut.io.push.payload.randomize()
-        dut.pushClock.waitSampling()
-        if(dut.io.push.valid.toBoolean && dut.io.push.ready.toBoolean){
-          queueModel.enqueue(dut.io.push.payload.toLong)
-        }
+
+    var pushRate, popRate = 0.5f
+    dut.io.push.valid #= false
+    dut.pushClock.onSamplings{
+      if(dut.io.push.valid.toBoolean && dut.io.push.ready.toBoolean){
+        queueModel.enqueue(dut.io.push.payload.toLong)
       }
+      dut.io.push.valid #= pushRate > Random.nextFloat()
+      dut.io.push.payload.randomize()
     }
 
     //Pop data randomly and check that it match with the queueModel
-    val popThread = fork{
-      dut.io.pop.ready #= false
-      dut.pushClock.waitSampling()
-      dut.popClock.waitSampling()
-      for(repeat <- 0 until 10000){
-        dut.io.pop.ready.randomize()
-        dut.popClock.waitSampling()
-        if(dut.io.pop.valid.toBoolean && dut.io.pop.ready.toBoolean){
-          assert(dut.io.pop.payload.toLong == queueModel.dequeue())
+    dut.io.pop.ready #= false
+    dut.pushClock.waitSampling()
+    dut.popClock.waitSampling()
+    var repeat = 0
+    val repeatTarget = 1000
+    dut.popClock.onSamplings{
+      if(dut.io.pop.valid.toBoolean && dut.io.pop.ready.toBoolean){
+        assert(dut.io.pop.payload.toLong == queueModel.dequeue())
+        if(repeat % (repeatTarget/10) == 0){
+          pushRate = Random.nextFloat()
+          popRate = Random.nextFloat()
         }
+        repeat += 1
       }
-      simSuccess()
+      dut.io.pop.ready #= popRate > Random.nextFloat()
+      if(repeat == repeatTarget) simSuccess()
     }
   }
 
@@ -95,7 +99,7 @@ class SpinalSimStreamFifoCCTester extends SpinalSimFunSuite {
 
     test("testSyncReset_" + postfix) {
       //Compile the simulator
-      val compiled = SimConfig.withConfig(SpinalConfig(defaultConfigForClockDomains = ClockDomainConfig(resetKind = SYNC))).allOptimisation.compile(
+      val compiled = SimConfig.withFstWave.withConfig(SpinalConfig(defaultConfigForClockDomains = ClockDomainConfig(resetKind = SYNC))).allOptimisation.compile(
         rtl = new StreamFifoCC(
           dataType = Bits(32 bits),
           depth = 32,


### PR DESCRIPTION
So, figured out that StreamFifoCC is reading the memory on every cycle, including when the fifo is empty, potentialy leaking a metastable value on the io.pop.payload.

This PR rework the pop side of the fifo a bit like what was done for the non-CC version.

the PR also fix a similar metastable leak on the RISC-V debug module