### PR TITLE
Use simProxy for driving clock

### DIFF
--- a/core/src/main/scala/spinal/core/sim/ClockDomain.scala
+++ b/core/src/main/scala/spinal/core/sim/ClockDomain.scala
@@ -50,26 +50,20 @@ object DoReset {
   * Generate a clock
   */
 object DoClock {
-
   def apply(clk: Bool, period: Long): Unit = {
     assert(period >= 2)
 
     var value = clk.toBoolean
+    val clkProxy = clk.simProxy()
 
-    def t : Unit = {
+    def t: Unit = {
       value = !value
-      clk  #= value
+      clkProxy #= value
       delayed(period >> 1)(t)
     }
+
     t
-
-//    while(true){
-//      value = !value
-//      clk  #= value
-//      sleep(period >> 1)
-//    }
   }
-
 }
 
 /**


### PR DESCRIPTION
As mentioned in #1165, a small change so that a sim clock is driven using a proxy instead of direct access.
On my machine that gave ~10% performance improvement on clock-heavy tests. For more "normal" tests far less of an impact is to be expected.

# Context, Motivation & Description

Go fast ;-)

# Impact on code generation

None

# Checklist

No functionality change ~-  Unit tests were added~
No API change ~-  API changes are or will be documented:~
