### PR TITLE
Fix PackedBundle unpack element bounds filter

### DIFF
--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -105,7 +105,7 @@ class PackedBundle extends Bundle {
       // Check if the assignment range falls within the current data's range
       // This happens when the data range's high or low falls within the assignment's hi and lo
       // ...or whenever lo isn't past the data range's high and hi isn't below the data range's low
-      if (!(lo >= elRange.high || hi < elRange.low)) {
+      if ((elRange.low >= lo && elRange.low < hi) || (elRange.high >= lo && elRange.high < hi)) {
         if (elRange.step > 0) {
           // "Little endian" -- ascending range
           val subBits = bits(elRange).resize(el.getBitsWidth)


### PR DESCRIPTION
Fixes an issue where 1-width boolean values fail to unpack.  This change checks that the upper or lower bounds of an element are within the bit range requested.

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
