### PR TITLE
Bug fix for #1190: VCS run flag not pass to simv

### DIFF
--- a/sim/src/main/scala/spinal/sim/VCSBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VCSBackend.scala
@@ -357,7 +357,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       val iface = sharedMemIface
       val logger = new LoggerPrintWithTerminationFilter()
       def run(): Unit = {
-        val runCommand = Seq(s"./$toplevelName", config.runFlags).mkString(" ")
+        val runCommand = Seq(s"./$toplevelName", config.flags.runFlags.mkString(" ")).mkString(" ")
         println(s"[SIMV] $runCommand")
         val retCode = Process(runCommand, new File(workspacePath)).!(logger)
         if (retCode != 0 && !logger.terminationOfSimulation) {

--- a/sim/src/main/scala/spinal/sim/VCSBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VCSBackend.scala
@@ -357,7 +357,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
       val iface = sharedMemIface
       val logger = new LoggerPrintWithTerminationFilter()
       def run(): Unit = {
-        val runCommand = Seq(s"./$toplevelName", config.flags.runFlags.mkString(" ")).mkString(" ")
+        val runCommand = Seq(s"./$toplevelName", config.flags.getRunFlags).mkString(" ")
         println(s"[SIMV] $runCommand")
         val retCode = Process(runCommand, new File(workspacePath)).!(logger)
         if (retCode != 0 && !logger.terminationOfSimulation) {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1190 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

As title.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
No impact.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
