### PR TITLE
Add init parameter to Timeout

### DIFF
--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -600,15 +600,17 @@ class Counter(val start: BigInt,val end: BigInt) extends ImplicitArea[UInt] {
 }
 
 object Timeout {
-  def apply(cycles: BigInt) : Timeout = new Timeout(cycles)
-  def apply(time: TimeNumber) : Timeout = new Timeout((time*ClockDomain.current.frequency.getValue).toBigInt)
-  def apply(frequency: HertzNumber) : Timeout = Timeout(frequency.toTime)
+  def apply(cycles: BigInt): Timeout = new Timeout(cycles)
+
+  def apply(time: TimeNumber): Timeout = new Timeout((time * ClockDomain.current.frequency.getValue).toBigInt)
+
+  def apply(frequency: HertzNumber): Timeout = Timeout(frequency.toTime)
 }
 
-class Timeout(val limit: BigInt) extends ImplicitArea[Bool] {
+class Timeout(val limit: BigInt, init: Bool = False) extends ImplicitArea[Bool] {
   assert(limit > 1)
 
-  val state = RegInit(False)
+  val state = RegInit(init)
   val stateRise = False
 
   val counter = CounterFreeRun(limit)
@@ -628,6 +630,11 @@ class Timeout(val limit: BigInt) extends ImplicitArea[Bool] {
     this
   }
 
+  def init(value: Bool): this.type = {
+    state.removeInitAssignments()
+    state.init(value)
+    this
+  }
 
   override def implicitValue: Bool = state
 }


### PR DESCRIPTION
Resurrection of an older PR...

# Context, Motivation & Description

Currently `Timeout` is initialized to be `False`.
This can for sure be changed with `init` like this:
```scala
val t = Timeout(5)
t.init(True)
```
(which will produce slightly ugly verilog with two reset statements, but work)

But it feels different from other things, i.e. this doesn't do what one might initially assume: `val t = Timeout(5) init True` (changes type of t).

This change adds a parameter, making it feel more like other library components or functions like e.g. `rise`

RTD change tbd.

# Impact on code generation

None
