### PR TITLE
Update C++ version for verilator (to C++14)

### DIFF
--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -519,6 +519,10 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
 
     val verilatorBinFilename = if(isWindows) "verilator_bin.exe" else "verilator"
 
+    // allow a user to overwrite/add verilator flags, e.g. C++ version
+    // if the default is too old (see e.g. #278)
+    val envFlags = sys.env.getOrElse("SPINAL_VERILATOR_FLAGS", "")
+
     // when changing the verilator script, the hash generation (below) must also be updated
     val verilatorScript = s""" set -e ;
        | ${verilatorBinFilename}
@@ -527,8 +531,6 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
        | -CFLAGS -I"$jdkIncludes" -CFLAGS -I"$jdkIncludes/${if(isWindows)"win32" else (if(isMac) "darwin" else (if(isFreeBsd) "freebsd" else "linux"))}"
        | -CFLAGS -fvisibility=hidden
        | -LDFLAGS -fvisibility=hidden
-       | -CFLAGS -std=c++11
-       | -LDFLAGS -std=c++11
        | -CFLAGS -DVL_USER_FINISH=1
        | --autoflush  
        | --output-split 5000
@@ -553,6 +555,7 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
                                      .map('"' + _.replace("\\","/") + '"')
                                      .mkString(" ")}
        | --exe $workspaceName/$wrapperCppName
+       | $envFlags
        | ${config.simulatorFlags.mkString(" ")}""".stripMargin.replace("\n", "")
 
 


### PR DESCRIPTION
Closes #1209

# Context, Motivation & Description

With the jump to verilator 5, verilator started using newer C++ syntax. For now it seems that compiling against C++14 is sufficient (when not using the recent timing support that required C++20).

It seems we pinned the C++ version to C++11 to support older compilers (see #278).
This PR removes the pinned version and goes back to using the compiler default that should work in most cases, possibly being faster then if set to C++11. It provides an additional environment variable to add arbitrary setting during compilation, therefore also e.g. allowing for setting the linker on a per-machine basis.

C++11 or larger has been the default for recent compiler for a while (introduced in 2020, default in 2021) - if a user wants to use latest verilator they have to have a matching gcc version (min C++14, available since gcc 6.1, though not as a default).

# Impact on code generation

No impact on code generation.
When updating existing simulation caches may be broken because of C++ version mismatches.