### PR TITLE
Add option for IO instantitation to InOutWrapper

### DIFF
--- a/lib/src/main/scala/spinal/lib/io/InOutWrapper.scala
+++ b/lib/src/main/scala/spinal/lib/io/InOutWrapper.scala
@@ -2,15 +2,42 @@ package spinal.lib.io
 
 import spinal.core._
 import spinal.core.fiber.Engine
-import spinal.lib.master
+import spinal.lib.io._
 
+import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.language.postfixOps
 
 object InOutWrapper {
-  def apply[T <: Component](c : T) : T = {
+  def InferredDriver(i: Bool, o: Bool, io: Bool, we: Bool, name: String): Unit = {
+    when(we) {
+      io := i
+    }
+    o := io
+  }
+  def XilinxSeries7IOBuf(i: Bool, o: Bool, io: Bool, we: Bool, name: String): Unit = {
+    import spinal.lib.blackbox.xilinx.s7.IOBUF
+    val buffer = IOBUF()
+    buffer.T := !we
+    buffer.I := i
+    o := buffer.O
+    io := buffer.IO
+    buffer.setName("IOBUF_" + name)
+  }
+  def LatticeIce40SB_IO(i: Bool, o: Bool, io: Bool, we: Bool, name: String): Unit = {
+    import spinal.lib.blackbox.lattice.ice40.SB_IO
+    val buffer = SB_IO("101001")
+    buffer.OUTPUT_ENABLE := we
+    buffer.D_OUT_0 := i
+    o := buffer.D_IN_0
+    io := buffer.PACKAGE_PIN
+    buffer.setName("SB_IO_" + name)
+  }
+
+  def apply[T <: Component](c: T, makeDriver: (Bool, Bool, Bool, Bool, String) => Unit = InferredDriver): T = {
     Engine.get.onCompletion += (() => {
       val dataParents = mutable.LinkedHashMap[Data, Int]()
-
+      @tailrec
       def add(that: Data): Unit = {
         if (that.parent != null) {
           dataParents(that.parent) = dataParents.getOrElseUpdate(that.parent, 0) + 1
@@ -26,55 +53,63 @@ object InOutWrapper {
         add(io)
       }
 
+      def flattenedName(bundle: Data, signal: Data, marker: String) =
+        bundle.getName() + signal
+          .getName()
+          .substring(bundle.getName().length + marker.length)
+
+      def makeBuffers(width: Int, name: String) = {
+        val we = Bits(width bit)
+        val i = Bits(width bit)
+        val o = Bits(width bit)
+        val io = inout(Analog(Bits(width bit))).setWeakName(name)
+        (0 until width) foreach { idx => makeDriver(i(idx), o(idx), io(idx), we(idx), name + "_" + idx) }
+        (i, o, we, io)
+      }
+
       c.rework {
         for ((dataParent, count) <- dataParents) {
           dataParent match {
-            case bundle: TriState[_] if bundle.writeEnable.isOutput => {
-              val newIo = inout(Analog(bundle.dataType)).setWeakName(bundle.getName())
-              bundle.setAsDirectionLess.unsetName().allowDirectionLessIo
-              bundle.read.assignFrom(newIo)
-              when(bundle.writeEnable) {
-                newIo := bundle.write
+            case bundle: TriState[_] if bundle.writeEnable.isOutput =>
+              (bundle.write.flatten zip bundle.read.flatten).foreach {
+                case (dw: Data, dr: Data) =>
+                  val name = flattenedName(bundle, dw, "_write")
+                  val (i, o, we, newIo) = makeBuffers(widthOf(dw), name)
+                  we.setAllTo(bundle.writeEnable)
+                  i := dw.asBits
+                  dr.assignFromBits(o)
+                  propagateTags(bundle, newIo)
               }
-              propagateTags(bundle, newIo)
-            }
-            case bundle: TriStateOutput[_] if bundle.isOutput || bundle.isMasterInterface => {
-              val newIo = inout(Analog(bundle.dataType)).setWeakName(bundle.getName())
-              bundle.setAsDirectionLess.unsetName().allowDirectionLessIo
-              when(bundle.writeEnable) {
-                newIo := bundle.write
+              bundle.setAsDirectionLess().unsetName().allowDirectionLessIo()
+            case bundle: TriStateOutput[_] if bundle.isOutput =>
+              bundle.write.flatten.foreach {
+                dw: Data =>
+                  val name = flattenedName(bundle, dw, "_write")
+                  val (i, _, we, newIo) = makeBuffers(widthOf(dw), name)
+                  we.setAllTo(bundle.writeEnable)
+                  i := dw.asBits
+                  propagateTags(bundle, newIo)
               }
-              propagateTags(bundle, newIo)
-            }
-            case bundle: ReadableOpenDrain[_] if bundle.write.isOutput && bundle.read.isInput => {
-              val newIo = inout(Analog(bundle.dataType)).setWeakName(bundle.getName())
-              bundle.setAsDirectionLess.unsetName().allowDirectionLessIo
-              bundle.read.assignFrom(newIo)
-              for ((value, id) <- bundle.write.asBits.asBools.zipWithIndex) {
-                when(!value) {
-                  newIo.assignFromBits(B"0", id, 1 bits)
-                }
+              bundle.setAsDirectionLess().unsetName().allowDirectionLessIo()
+            case bundle: ReadableOpenDrain[_] if bundle.isMasterInterface =>
+              (bundle.write.flatten zip bundle.read.flatten).foreach {
+                case (dw: Data, dr: Data) =>
+                  val name = flattenedName(bundle, dw, "_write")
+                  val (i, o, we, newIo) = makeBuffers(widthOf(dw), name)
+                  we := ~dw.asBits
+                  i.clearAll()
+                  dr.assignFromBits(o)
+                  propagateTags(bundle, newIo)
               }
+              bundle.setAsDirectionLess().unsetName().allowDirectionLessIo()
+            case bundle: TriStateArray if bundle.writeEnable.isOutput =>
+              val name = bundle.getName()
+              val (i, o, we, newIo) = makeBuffers(bundle.width, name)
+              we := bundle.writeEnable
+              i := bundle.write
+              bundle.read := o
+              bundle.setAsDirectionLess().unsetName().allowDirectionLessIo()
               propagateTags(bundle, newIo)
-              //            for(bt <- bundle.write.flatten){
-              //              for((value, id) <- bt.asBits.asBools.zipWithIndex) {
-              //                when(!value){
-              //                  bt.assignFromBits("0", id, 1 bits)
-              //                }
-              //              }
-              //            }
-            }
-            case bundle: TriStateArray if bundle.writeEnable.isOutput => {
-              val newIo = inout(Analog(bundle.write)).setWeakName(bundle.getName())
-              bundle.setAsDirectionLess.unsetName().allowDirectionLessIo
-              bundle.read.assignFrom(newIo)
-              for (i <- 0 until bundle.width) {
-                when(bundle.writeEnable(i)) {
-                  newIo(i) := bundle.write(i)
-                }
-              }
-              propagateTags(bundle, newIo)
-            }
             case _ =>
           }
         }
@@ -82,26 +117,30 @@ object InOutWrapper {
     })
     c
   }
+}
 
-  def main(args: Array[String]): Unit = {
-    case class MyTriStateTag() extends SpinalTag {
-      override def ioTag = true
-    }
-    case class D() extends Bundle{
-      val x = UInt(2 bits)
-      val y = Bool()
-    }
-    val report = SpinalVhdl(InOutWrapper(new Component{
-      def t = D()
-      val driver = in(t)
-      val sink = out(t)
-      val openDrain = master(ReadableOpenDrain(t))
-      openDrain.addTag(MyTriStateTag())
-      openDrain.write := driver
-      sink := openDrain.read
-    }))
-    report.toplevel.getAllIo.foreach(io => println(s"${io.getName()} => ${io.getTags()}"))
+object InOutWrapperPlayground extends App {
+  import spinal.lib._
+
+  case class MyTriStateTag() extends SpinalTag {
+    override def ioTag = true
   }
+
+  case class D() extends Bundle{
+    val x = UInt(2 bits)
+    val y = Bool()
+  }
+
+  val report = SpinalVhdl(InOutWrapper(new Component{
+    def t = D()
+    val driver = in(t)
+    val sink = out(t)
+    val openDrain = master(ReadableOpenDrain(t))
+    openDrain.addTag(MyTriStateTag())
+    openDrain.write := driver
+    sink := openDrain.read
+  }))
+  report.toplevel.getAllIo.foreach(io => println(s"${io.getName()} => ${io.getTags()}"))
 }
 
 


### PR DESCRIPTION
# Context, Motivation & Description

I encountered issues inferring drivers on at least Xilinx (infers only on top level, not for components in a block diagram) and ICE40 w/ yosys (warns on inferred drivers and produced invalid result for me in a case that I just debugged).
To work around those issues, give the InOutWrapper an additional parameter with a callback for generating instantiations of hardmacros.

# Impact on code generation

none

# Checklist

- API changes are or will be documented: RTD tbd
