### PR TITLE
Update built Scala minor version to latest

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,5 +1,5 @@
 object SpinalVersion {
-  val compilers = List("2.11.12", "2.12.13", "2.13.6")
+  val compilers = List("2.11.12", "2.12.18", "2.13.12")
   val compilerIsRC = false
 
   val isDev = true


### PR DESCRIPTION
# Context, Motivation & Description

Continue to build with the supported minor version.
For now I still kept 2.11 as the first in the list, and therefore the one with which all tests are executed, we might want to revisit this in the future.

# Impact on code generation

Checked unittests locally with all Scala versions, no major issues.
I only encountered one issue running the test with 2.13.x, which is that the test for physical number formatting fails - I'll investigate that separately since it also occurs with the current 2.13.6.
