### PR TITLE
Added explicit net types to verilog ports

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -85,10 +85,10 @@ class ComponentEmitterVerilog(
       val EDAcomment = s"${emitCommentAttributes(baseType.instanceAttributes)}"  //like "/* verilator public */"
 
       if(outputsToBufferize.contains(baseType) || baseType.isInput){
-        portMaps += f"${syntax}${dir}%6s ${""}%3s ${section}%-8s ${name}${EDAcomment}${comma}"
+        portMaps += f"${syntax}${dir}%6s wire ${section}%-8s ${name}${EDAcomment}${comma}"
       } else {
-        val isReg   = if(signalNeedProcess(baseType)) "reg" else ""
-        portMaps += f"${syntax}${dir}%6s ${isReg}%3s ${section}%-8s ${name}${EDAcomment}${comma}"
+        val isReg   = if(signalNeedProcess(baseType)) "reg" else "wire"
+        portMaps += f"${syntax}${dir}%6s ${isReg}%-4s ${section}%-8s ${name}${EDAcomment}${comma}"
       }
     }
   }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1225 

# Context, Motivation & Description

Adds explicit net types to the top level ports of Verilog modules. Specifying the net type will keep some vendor synthesis flows from failing or giving warnings.

Example:
```ERROR: net type must be explicitly specified for 'io_sdClk' when default_nettype is none (VERI-1906)```

In addition to the above since the net type is not specified or is "none" it is susceptible to being changed if the user has set `default_nettype elsewhere in the project.

Notes:
Did not add unit test because the change is small. I did run all existing sbt tests to ensure everything still passes.

# Impact on code generation

Impacts Verilog code generation.

Generated Verilog file WishboneSimpleSlave.v as an example.
Before change:
```
module WishboneSimpleSlave (
  input               io_bus_CYC,
  input               io_bus_STB,
  output              io_bus_ACK,
  input               io_bus_WE,
  input      [7:0]    io_bus_ADR,
  output reg [7:0]    io_bus_DAT_MISO,
  input      [7:0]    io_bus_DAT_MOSI,
  input               clk,
  input               reset
);
```

After change:
```
module WishboneSimpleSlave (
  input  wire          io_bus_CYC,
  input  wire          io_bus_STB,
  output wire          io_bus_ACK,
  input  wire          io_bus_WE,
  input  wire [7:0]    io_bus_ADR,
  output reg  [7:0]    io_bus_DAT_MISO,
  input  wire [7:0]    io_bus_DAT_MOSI,
  input  wire          clk,
  input  wire          reset
);
```

# Checklist

- [ ] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
