### PR TITLE
Fix signal names with $ for verilator

### DIFF
--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -282,7 +282,7 @@ ${    val signalInits = for((signal, id) <- config.signals.zipWithIndex) yield {
       else if(signal.dataType.width <= 64) "QData"
       else "WData"
       val enforcedCast = if(signal.dataType.width > 64) "(WData*)" else ""
-      val signalReference = s"top->${signal.path.mkString("->")}"
+      val signalReference = s"top->${signal.path.map(_.replace("$", "__024")).mkString("->")}"
       val memPatch = if(signal.dataType.isMem) "[0]" else ""
 
       s"      signalAccess[$id] = new ${typePrefix}SignalAccess($enforcedCast $signalReference$memPatch ${if(signal.dataType.width > 64) s" , ${signal.dataType.width}, ${if(signal.dataType.isInstanceOf[SIntDataType]) "true" else "false"}" else ""});\n"


### PR DESCRIPTION
`$` is a valid character in Verilog signal names, Verilator translates them to `__024`.

# Context, Motivation & Description

While it's not generally useful since I didn't check what other simulators do / VHDL doesn't support special characters, it's still useful in corner cases.
In principle verilog would also support other printable ASCII special chars, but the verilog component emitter does current not support escaped identifiers, so skip those for now.

# Impact on code generation

None
