### PR TITLE
Fix hierarchy violation error for toplevel

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2041,7 +2041,8 @@ class PhaseCheckHiearchy extends PhaseCheck{
             val bt = s.finalTarget
 
             if (!(bt.isDirectionLess && bt.component == c) && !(bt.isOutputOrInOut && bt.component == c) && !(bt.isInputOrInOut && bt.component.parent == c)) {
-              PendingError(s"HIERARCHY VIOLATION : $bt is driven by ${s.source}, but isn't accessible in the $c component.\n${s.getScalaLocationLong}")
+              val identifier = if(c == null) "toplevel" else s"$c component"
+              PendingError(s"HIERARCHY VIOLATION : $bt is driven by ${s.source}, but isn't accessible in the $identifier.\n${s.getScalaLocationLong}")
               error = true
             }
 


### PR DESCRIPTION
Improves the error message for signals on the toplevel (don't just say "null" as component ;-))
