### PR TITLE
[feature] FuseSocGeneratorBuilder provide a easy way to use fusesoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,16 @@ lazy val lib = (project in file("lib"))
     defaultSettingsWithPlugin,
     name := "SpinalHDL-lib",
     libraryDependencies += "commons-io" % "commons-io" % "2.11.0",
+    libraryDependencies ++= Seq(
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.16.0-rc1",
+      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.16.0-rc1",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.16.0-rc1",
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.16.0-rc1",
+      "com.fasterxml.jackson.module" % "jackson-module-scala_2.12" % "2.16.0-rc1"
+    ),
+
     version := SpinalVersion.lib,
+
   )
   .dependsOn (sim, core)
 

--- a/lib/src/main/scala/spinal/lib/eda/fusesoc/FuseSocGeneratorBuilder.scala
+++ b/lib/src/main/scala/spinal/lib/eda/fusesoc/FuseSocGeneratorBuilder.scala
@@ -1,0 +1,68 @@
+package spinal.lib.eda.fusesoc
+
+import spinal.core._
+import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator}
+import com.fasterxml.jackson.module.scala._
+
+abstract class FuseSocGeneratorBuilder[P, C<:Component](componentName: String, defaultPram: P) {
+  private val yamlMapper = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER))
+  yamlMapper.registerModule(DefaultScalaModule)
+  private val jsonMapper = new ObjectMapper(new JsonFactory().configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true).configure(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION, true))
+  jsonMapper.registerModule(DefaultScalaModule)
+
+
+  private case class P2SParam(spinal_parameter: P,
+                              output: Object = Map("files"->List(Map(componentName+".v"->new Object{val file_type: String = "verilogSource"}))),
+                              target_directory: String = "./generate",
+                              entry_function: String = "",
+                              copy_core: Boolean=false,
+                              spinal_project_path: String = ".")
+
+
+  private val CoreFile = new Object {
+    val name: String = s"::$componentName:0.0.0"
+    val filesets: Object = new Object{
+      val base: Map[String, List[String]] = Map("depend"->List("chenbosoft:utils:generators:0.0.0"))
+    }
+    val generate: Map[String, Object] = Map(componentName+"_gen"->new Object{
+      val generator = "spinalhdl"
+      val parameters: P2SParam = P2SParam(defaultPram)
+    })
+  }
+
+  def buildScript: String = {
+    "CAPI=2:\n\n"+yamlMapper.writeValueAsString(CoreFile)+
+      s"""
+         |targets:
+         |  lint:
+         |    default_tool : verilator
+         |    generate: [${componentName+"_gen"}]
+         |    filesets: [base]
+         |    tools:
+         |      verilator:
+         |        mode : lint-only
+         |    toplevel : $componentName
+         |
+         |""".stripMargin
+  }
+
+  def buildComponent(parameter: P): C
+
+  def run(args: Array[String]): Unit = {
+    val p = getParameter(args)
+    val config = SpinalConfig(targetDirectory = p.target_directory)
+    SpinalVerilog(config)(buildComponent(p.spinal_parameter))
+  }
+
+  private def getParameter(args: Array[String]): P2SParam = {
+    val builder = scopt.OParser.builder[P2SParam]
+    val parser = scopt.OParser.sequence(
+      builder.opt[String]("spinal_parameter").required().action((x,c)=>c.copy(spinal_parameter=jsonMapper.readValue(x, defaultPram.getClass))),
+      builder.opt[String]("target_directory").required().action((x,c)=>c.copy(target_directory = x))
+    )
+    scopt.OParser.parse(parser, args, P2SParam(defaultPram)).getOrElse(throw new Exception(""))
+  }
+}
+


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

# Context, Motivation & Description
fusesoc is a manager tool, which provide 2 main functions:
1. It can be used as a pkg manager tool, module which from many sources(github, local etc.) can be used in a easy way
2. edalize, user can easily ignore some eda script, and use some main function of this eda. 

This PR provide a easy way to take spinalhdl component into fusesoc. It provide 2 main functions:
1. parametrization in fusesoc
2. generate fusesoc .core file template.

note: it depends a python script out of spinal repository

Text below describes usage:
1. in workdir, type `fusesoc library add spinal_generator https://github.com/chenbo-again/spinalhdl_fusesoc_
generator` to get python script
2. create FuseSocGeneratorBuilder
4. use buildScript method generate .core file template
5. create and modify .core file based on template
6. create a entry function and execute FuseSocGeneratorBuilder#run

It is already tested locally
<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
No
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ x] Unit tests were added
- [ x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
