### PR TITLE
XSim: better Windows support + add xcix IP import

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -453,13 +453,13 @@ object SpinalXSimBackend {
     vconfig.xciSourcesPaths   =  xciSourcesPaths
     vconfig.bdSourcesPaths    = bdSourcesPaths
     vconfig.toplevelName      = rtl.toplevelName
-    vconfig.wavePath          = "test.wdb"
     vconfig.waveFormat        = waveFormat match {
       case WaveFormat.DEFAULT => WaveFormat.WDB
       case _ => waveFormat
     }
     vconfig.workspaceName     = workspaceName
     vconfig.workspacePath     = workspacePath
+    vconfig.wavePath          = s"${workspacePath}/${workspaceName}/${rtl.toplevelName}.wdb"
     vconfig.xilinxDevice      = xilinxDevice
     vconfig.userSimulationScript = simScript
     vconfig.xelabFlags        = simulatorFlags.toArray

--- a/sim/src/main/scala/spinal/sim/XSimBackend.scala
+++ b/sim/src/main/scala/spinal/sim/XSimBackend.scala
@@ -89,48 +89,60 @@ class XSimBackend(config: XSimBackendConfig) extends Backend {
   val compilePath        = s"${simulatePath}/compile.${scriptSuffix}"
   val elaboratePath      = s"${simulatePath}/elaborate.${scriptSuffix}"
 
+  val isMsys = sys.env.get("MSYSTEM").isDefined
+
   val msys2Shell = {
     if (isWindows) {
-      val msys2ShellPath =
-        sys.env.getOrElse("MSYS2_ROOT", "C:\\msys64") + "\\msys2_shell.cmd"
-      if (!new File(msys2ShellPath).exists) {
-        throw new Exception(
-          "MSYS2 Shell not found! Please Setup you MSYS2_ROOT Environment Variable."
-        )
+      if (isMsys) { // SBT Called from Msys
+        "sh"
+      } else { // SBT Called from CMD
+        val msys2ShellPath =
+          sys.env.getOrElse("MSYS2_ROOT", "C:\\msys64") + "\\msys2_shell.cmd"
+        if (!new File(msys2ShellPath).exists) {
+          throw new Exception(
+            "MSYS2 Shell not found! Please Setup you MSYS2_ROOT Environment Variable."
+          )
+        }
+        msys2ShellPath + " -defterm -here -no-start -mingw64"
       }
-      msys2ShellPath
     } else {
       ""
     }
   }
+
   val vivadoHome = sys.env.getOrElse(
     "VIVADO_HOME",
     throw new Exception(
       "VIVADO_HOME not found! Setup your vivado environment first."
     )
   )
+  val vivadoBinPath = new File(s"${vivadoHome}/bin").getAbsolutePath
 
-  def doCmd(command: String, cwd: File, message : String) = {
-    val logger = new Logger()
-    if(Process(command, cwd)! (logger) != 0){
-      println(logger.logs)
-      throw new Exception(message)
-    }
-  }
-  def doCmd(command: String, cwd: File, extraEnv: Seq[(String, String)], message : String) = {
+  def doCmd(command: String, cwd: File, message : String, extraEnv: Seq[(String, String)] = Seq.empty) : Unit = {
     val logger = new Logger()
     if(Process(command, cwd, extraEnv :_*)! (logger) != 0){
       println(logger.logs)
       throw new Exception(message)
     }
   }
-  def doCmdMys2(command: String, cwd: File, message : String) = {
-    val cmd_msys2 = s""" $msys2Shell -defterm -here -no-start -mingw64 -c "$command" """.trim
-    doCmd(cmd_msys2, cwd, message)
+  def doCmdVivado(command: String, cwd: File, message: String, extraEnv: Seq[(String, String)] = Seq.empty) = {
+    val cmdVivado =
+      if (isWindows) {
+        if (isMsys) {
+          // msys turns "/c" to "c:\" because of posix path conversion, needs escape
+          s"cmd //c ${vivadoBinPath}/setEnvAndRunCmd.bat ${command}"
+        } else {
+          s"cmd /c ${vivadoBinPath}/setEnvAndRunCmd.bat ${command}"
+        }
+      } else {
+        s"${vivadoBinPath}/setEnvAndRunCmd.sh ${command}"
+      }
+
+    doCmd(cmdVivado, cwd, message, extraEnv)
   }
-  def doCmdMys2(command: String, cwd: File, extraEnv: Seq[(String, String)], message : String) = {
-    val cmd_msys2 = s""" $msys2Shell -defterm -here -no-start -mingw64 -c "$command" """.trim
-    doCmd(cmd_msys2, cwd, extraEnv, message)
+  def doCmdMys2(command: String, cwd: File, message: String, extraEnv: Seq[(String, String)] = Seq.empty) : Unit = {
+    val cmdMsys2 = s""" $msys2Shell -c "$command" """.trim
+    doCmd(cmdMsys2, cwd, message, extraEnv)
   }
 
 
@@ -229,32 +241,25 @@ class XSimBackend(config: XSimBackendConfig) extends Backend {
     outFile.close()
 
     val vivadoScriptPath = scriptPath.replace("\\", "/")
-    val command = {
-      val baseCommand = s""" vivado -mode batch -source "$vivadoScriptPath" """.trim
-      if (isWindows) {
-        s"cmd /c $baseCommand"
-      } else {
-        baseCommand
-      }
-    };
-    doCmd(command,
+    val command =  s""" vivado -mode batch -source "$vivadoScriptPath" """.trim
+    doCmdVivado(command,
       new File(workPath),
       "Generation of vivado script failed")
   }
 
   def getScriptCommand(cmd: String) = {
     if (isWindows) {
-      s"cmd /c ${cmd}.bat"
+      s"${cmd}.bat"
     } else {
-      s"bash ${cmd}.sh"
+      s"${cmd}.sh"
     }
   }
 
   def runScript() = {
-    doCmd(getScriptCommand("compile"),
+    doCmdVivado(getScriptCommand("compile"),
       new File(simulatePath),
       "run compile failed")
-    doCmd(getScriptCommand("elaborate"),
+    doCmdVivado(getScriptCommand("elaborate"),
       new File(simulatePath),
       "run elaborate failed")
       val simDesignDir = s"${simulatePath}/xsim.dir"

--- a/sim/src/main/scala/spinal/sim/XSimBackend.scala
+++ b/sim/src/main/scala/spinal/sim/XSimBackend.scala
@@ -178,7 +178,7 @@ class XSimBackend(config: XSimBackendConfig) extends Backend {
       s"import_files -force $p"
     }
     val importXsi = xciAbsoluteSourcesPaths map { p =>
-      s"import_files -force -quiet [findFiles $p *.xci]"
+      s"import_files -force -quiet [findFiles $p *.{xci,xcix}]"
     }
     val importBd = bdAbsoluteSourcesPaths map { p =>
       s"import_files -force -quiet [findFiles $p *.bd]"


### PR DESCRIPTION
Follow-up to #1234

# Context, Motivation & Description
- Context : from https://github.com/SpinalHDL/SpinalHDL/issues/1234#issuecomment-1812168567
- Description : 
  - calls to Vivado generated scripts are called from `cmd` native shell
  - msys2 still needed but only to build `spinal_xsim.dll` 
  - wdb file moved to xsim subfolder to avoid Vivado cluttering Project root folder when opening wdb viewer
  - added `xcix` import along `xci` IP
# Impact on code generation

None

# Checklist

~~- [ ] Unit tests were added~~
- [ ] XSim Simulation behavior changes started to be documented:
  - on RTD : https://github.com/SpinalHDL/SpinalDoc-RTD/pull/230
