### PR TITLE
Commenting (and scaladocing) idslXXX

### DIFF
--- a/idslpayload/src/main/scala/spinal/idslplugin/Annotation.scala
+++ b/idslpayload/src/main/scala/spinal/idslplugin/Annotation.scala
@@ -1,9 +1,43 @@
 package spinal.idslplugin
 
+
+/**
+ * A trait representing a callback mechanism for post-initialization operations.
+ * 
+ * This trait is used to define an action that should be taken after an object has been initialized.
+ * Classes or traits implementing `PostInitCallback` can define custom behavior that is executed
+ * after the initial construction and setup of the instance.
+ */
 trait PostInitCallback {
+  /**
+   * The method to be called after the initialization of the object.
+   *
+   * Implementing classes should override this method to define custom post-initialization behavior.
+   * This method is expected to return the current instance (`this`) of the class.
+   *
+   * @return the current instance of the class implementing this trait.
+   */
   def postInitCallback(): this.type
 }
 
+/**
+ * A trait for callback handling during value assignments.
+ * 
+ * This trait provides a mechanism to define custom behavior whenever a value is assigned to a variable.
+ * It is particularly useful in scenarios where additional actions need to be taken or side-effects need
+ * to be considered during value assignments.
+ */
 trait ValCallback {
+  /**
+   * A method to be called during the assignment of a value.
+   * 
+   * Implementors can override this method to define custom behavior that occurs when a value is assigned.
+   * This method can be used to perform additional checks, logging, or other side-effects.
+   *
+   * @param ref The value being assigned.
+   * @param name The name of the variable to which the value is being assigned.
+   * @tparam T The type of the value being assigned.
+   * @return The value after potential modifications or checks.
+   */
   def valCallback[T](ref: T, name: String): T
 }

--- a/idslpayload/src/main/scala/spinal/idslplugin/Macro.scala
+++ b/idslpayload/src/main/scala/spinal/idslplugin/Macro.scala
@@ -3,23 +3,47 @@ package spinal.idslplugin
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
-
-
-class Location(val file : String, val line: Int, val col : Int)
+/**
+ * Represents a source code location.
+ *
+ * This class is used to capture and represent the location of a piece of code in the source files.
+ * It includes information about the file name, line number, and column number.
+ *
+ * @param file The name of the source file.
+ * @param line The line number in the source file.
+ * @param col  The column number in the source file.
+ */
+class Location(val file: String, val line: Int, val col: Int)
 
 object Location {
+  /**
+   * Captures the current source code location.
+   *
+   * This method uses a Scala macro to capture the location in the source code where it is called.
+   * It is useful for debugging, logging, or providing more informative error messages.
+   *
+   * @return A Location instance representing the current position in the source code.
+   */
   implicit def capture: Location = macro locationMacro
 
+  /**
+   * Macro implementation to capture the source code location.
+   *
+   * @param x The macro context used by the Scala compiler.
+   * @return An expression that evaluates to a Location instance.
+   */
   def locationMacro(x: Context): x.Expr[Location] = {
     import x.universe._
 
-//    val className = Option(x.enclosingClass).map(_.symbol.toString).getOrElse("")
-//    val methodName = Option(x.enclosingMethod).map(_.symbol.toString).getOrElse("")
-    val pos  = x.enclosingPosition
-    val line =  pos.line
-    val col  =  pos.column
-    val file =  pos.source.toString().replace(".scala", "")
-//    val where = s"${line}"
+    // Capture the position in the source code where the macro is called.
+    val pos = x.enclosingPosition
+    val line = pos.line
+    val col = pos.column
+
+    // Extract the source file name, removing the ".scala" extension.
+    val file = pos.source.toString().replace(".scala", "")
+
+    // Create and return an expression that evaluates to a new Location instance.
     reify(new Location(x.literal(file).splice, x.literal(line).splice, x.literal(col).splice))
   }
 }

--- a/idslplugin/src/main/scala/spinal/idslplugin/components/MainTransformer.scala
+++ b/idslplugin/src/main/scala/spinal/idslplugin/components/MainTransformer.scala
@@ -6,108 +6,180 @@ import scala.tools.nsc.Global
 import scala.tools.nsc.plugins.PluginComponent
 import scala.tools.nsc.transform.Transform
 
+/**
+ * MainTransformer is a plugin component for the Scala compiler.
+ * It extends the Transform trait to provide custom AST transformations.
+ * 
+ * @param global Provides access to the abstract syntax trees (ASTs) and other compiler internals.
+ */
 class MainTransformer(val global: Global) extends PluginComponent with Transform {
 
+  // The name of this phase in the compiler pipeline.
   override val phaseName: String = "idsl-plugin"
 
+  // Specifies the compiler phases after which this plugin should run.
   override val runsAfter: List[String] = List("uncurry")
   override val runsRightAfter: Option[String] = Some("uncurry")
 
+  // Method to create a new transformer for each compilation unit.
   override protected def newTransformer(unit: global.CompilationUnit): global.Transformer = ToStringMaskerTransformer
 
   import global._
 
-
+  /**
+   * Transformer object to modify the AST.
+   * This object defines custom transformations to be applied to the AST during the compilation.
+   */
   object ToStringMaskerTransformer extends Transformer {
 
+    /**
+    * Helper method to check if a symbol has a specific annotation.
+    */
     def symbolHasAnnotation(s: Symbol, name: String): Boolean = {
       if (s.annotations.exists(_.symbol.name.toString() == name)) return true
       s.parentSymbols.exists(symbolHasAnnotation(_, name))
     }
 
+    /**
+    * Helper method to check if a symbol extends a trait with a specific name.
+    */
     def symbolHasTrait(s: Symbol, name: String): Boolean = {
       s.parentSymbols.exists { p =>
         (p.fullName == name) || symbolHasTrait(p, name)
       }
     }
 
+    /**
+    * Helper method to check if a type extends a trait with a specific name.
+    */
     def typeHasTrait(s: Type, name: String): Boolean = {
       s.parents.exists { p =>
         p.toString().toString == name  || typeHasTrait(p, name)
       }
     }
 
-
+    /**
+     * Overrides the transform method to apply custom transformations to the AST.
+     * 
+     * @param tree The AST node to transform.
+     * @return The transformed AST node.
+     */
     override def transform(tree: global.Tree): global.Tree = {
       val transformedTree = super.transform(tree)
-      //      println(transformedTree.getClass.toString + " => \n" + transformedTree.toString)
+      
       transformedTree match {
-        case cd: ClassDef => {
+        case cd: ClassDef => { // Perform checks and transformations specific to ClassDef nodes.
           var ret: Tree = cd
 
-          //No io bundle without component trait compilation time check
+          //1. Check that we have no io bundle without component trait (compilation time check)
+
+          // True if body of this class define a value "io" assigned with a non-null Bundle .
           val withIoBundle = cd.impl.body.exists{
             case vd : ValDef if vd.name.toString == "io " && vd.rhs != null && typeHasTrait(vd.rhs.tpe, "spinal.core.Bundle") => true
             case _ => false
           }
+
+          // Issue error if we have a io bundle, but we are NOT a Component, an Area, a Data nor with implement the AllowIOBundle trait.
           if(withIoBundle && !symbolHasTrait(cd.symbol, "spinal.core.Component") && !symbolHasTrait(cd.symbol, "spinal.core.Area" ) && !symbolHasTrait(cd.symbol, "spinal.core.Data" ) && !symbolHasTrait(cd.symbol, "spinal.core.AllowIoBundle" )){
             global.globalError(cd.symbol.pos, s"MISSING EXTENDS COMPONENT\nclass with 'val io = new Bundle{...}' should extends spinal.core.Component")
           }
 
 
-          //ValCallback management
+          //2. ValCallback management
+          // ValCallback is a special trait that allow to define a callback that is called for each value
+          // It allows Bundle to "know" its values for example (Bundle.elements is the list of Data value defined inside the Bundle)
           if (symbolHasTrait(cd.symbol, "spinal.idslplugin.ValCallback")) {
+             // Get the class or trait that owns the current class definition.
             val clazz = cd.impl.symbol.owner
+
+            // Find the 'valCallback' method within the members of the class or trait.
             val func = clazz.tpe.members.find(_.name.toString == "valCallback").get
+
+            // Modify the body of the class definition.
             val body = cd.impl.body.map {
+              // Process each ValDef (variable definition) that is not a parameter accessor,
+              // doesn't have the 'DontName' annotation, and has a non-empty right-hand side.
               case vd: ValDef if !vd.mods.isParamAccessor  && !vd.symbol.annotations.exists(_.symbol.name.toString == "DontName") && vd.rhs.nonEmpty =>
+                // Get the name of the variable.
                 val nameStr = vd.getterName.toString
+                // Create a constant with the variable's name.
                 val const = Constant(nameStr)
+                // Create a literal from the constant.
                 val lit = Literal(const)
+                // Create a 'This' reference to the current class or trait.
                 val thiz = This(clazz)
+                // Select the 'valCallback' method from the current context.
                 val sel = Select(thiz, func)
+                // Apply the 'valCallback' method with the original right-hand side and the variable's name.
                 val appl = Apply(sel, List(vd.rhs, lit))
 
+                // Set types for new nodes to maintain the AST's integrity.
                 thiz.tpe = clazz.tpe
                 sel.tpe = func.tpe
                 appl.tpe = definitions.UnitTpe
                 lit.setType(definitions.StringTpe)
+
+                // Return a modified ValDef with the new application replacing the original right-hand side.
                 treeCopy.ValDef(vd, vd.mods, vd.name, vd.tpt, appl)
+              // For other elements in the body, keep them as is.
               case e => e
             }
+            // Create a new template (class body) with the modified body.
             val impl = treeCopy.Template(cd.impl, cd.impl.parents, cd.impl.self, body)
-            val cdNew = treeCopy.ClassDef(cd, cd.mods, cd.name, cd.tparams, impl) //)mods0, name0, tparams0, impl0
-
+            // Create a new ClassDef with the modified template.
+            val cdNew = treeCopy.ClassDef(cd, cd.mods, cd.name, cd.tparams, impl)
+            // Set the modified ClassDef as the return value.
             ret = cdNew
           }
 
           ret
         }
-        case a: Apply => {
+        case a: Apply => { // Perform checks and transformations specific to Apply nodes.
+
           var ret: Tree = a
 
+          // Check if the function call (Apply node) is a constructor.
           if (a.fun.symbol.isConstructor) {
+            // Get the class symbol of the constructor.
             val sym = a.fun.symbol.enclClass
+            // Get the type of the class.
             val tpe = sym.typeOfThis
+
+            // Check if the class has the 'PostInitCallback' trait.
+            // Allow to insert a callback after the constructor
             if (symbolHasTrait(sym, "spinal.idslplugin.PostInitCallback")) {
+              // Determine if the constructor call should be avoided for transformation.
+              // Avoid transformation for constructor calls within super and this references.
               val avoidIt = a match {
                 case Apply(Select(Super(_, _), _), _) => true
                 case Apply(Select(This(_), _), _) => true
                 case _ => false
               }
+
+              // If the constructor call is not to be avoided.
               if (!avoidIt) {
+                // Find the 'postInitCallback' method in the class members.
                 val func = tpe.members.find(_.name.toString == "postInitCallback").get
+                // Select the 'postInitCallback' method from the current Apply node.
                 val sel = Select(a, func.name)
+                // Apply the 'postInitCallback' method without any arguments.
                 val appl = Apply(sel, Nil)
+
+                // Set the type information for the new nodes.
                 sel.tpe = MethodType(Nil, a.tpe)
                 appl.tpe = a.tpe
+
+                // Set the new Apply node as the return value.
                 ret = appl
               }
             }
           }
+
+          // Return the transformed or original Apply node.
           ret
         }
         case oth => {
+          // For all other kinds of nodes, return the transformed tree as is.
           transformedTree
         }
       }


### PR DESCRIPTION
# Context, Motivation & Description

To understand the sources better, I documented idslplugin and idslpayload with comments and scaladoc.
Added a bit of cleanup, removing old commented code.

Comments are semi-automatic with GPT-4 and a manual refinement phase.

# Impact on code generation

No code has been modified, this should not cause any issue.

# Checklist

- Unit tests were added -> Not applicable
- API changes are or will be documented -> Not applicable
