### PR TITLE
Include blackbox sources in formal verification output

### DIFF
--- a/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
+++ b/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
@@ -198,7 +198,8 @@ case class SpinalFormalConfig(
 
     val rtlFiles = new ArrayBuffer[String]()
 //    val rtlPath = rtlDir.getAbsolutePath
-    report.generatedSourcesPaths.foreach { srcPath =>
+    val rtlSources = (report.generatedSourcesPaths ++ report.blackboxesSourcesPaths)
+    rtlSources.foreach { srcPath =>
       val src = new File(srcPath)
       val lines = Source.fromFile(src).getLines.toArray
       val w = new PrintWriter(src)

--- a/tester/src/test/resources/FormalBlackboxTest.v
+++ b/tester/src/test/resources/FormalBlackboxTest.v
@@ -1,0 +1,21 @@
+module FormalBlackboxTest(/*AUTOARG*/
+   // Outputs
+   o,
+   // Inputs
+   clk, a, b
+   );
+   input clk;
+
+   input wire [7:0] a;
+   input wire [7:0] b;
+   output wire [7:0] o;
+
+   reg [7:0]         output_reg = 0;
+
+   assign o = output_reg;
+
+   always @(posedge clk)
+     output_reg <= a + b;
+
+
+endmodule // FormalBlackboxTest

--- a/tester/src/test/scala/spinal/tester/code/FormalBlackbox.scala
+++ b/tester/src/test/scala/spinal/tester/code/FormalBlackbox.scala
@@ -1,0 +1,42 @@
+package spinal.tester.code
+
+import spinal.core._
+import spinal.core.formal._
+import spinal.tester.SpinalAnyFunSuite
+/*
+ * This test is for Issue #1256, to verify that SpinalHDL copies any
+ * external rtl specified in blackboxes or added by
+ * FormalConfig.addRtl() to the formal verification directory and .sbt.
+ * The blackboxed rtl is Verilog because spinal defaults to generating
+ * verilog when it exports for formal verification
+ */
+
+class FormalBlackboxTest extends BlackBox {
+  val io = new Bundle {
+    val clk = in Bool()
+    val a = in UInt(8 bits)
+    val b = in UInt(8 bits)
+    val o = out UInt(8 bits)
+
+  }
+  noIoPrefix()
+  addTag(noNumericType)
+  mapCurrentClockDomain(io.clk)
+  addRTLPath("tester/src/test/resources/FormalBlackboxTest.v")
+}
+
+class FormalBlackboxAsserts extends Component {
+  val dut = FormalDut(new FormalBlackboxTest())
+  anyseq(dut.io.a)
+  anyseq(dut.io.b)
+  when(!initstate()){
+    assert(dut.io.o === (past(dut.io.a) + past(dut.io.b)))
+  }
+}
+
+
+class FormalBlackbox extends SpinalAnyFunSuite {
+  test("formal"){
+    FormalConfig.withBMC(4).doVerify(new FormalBlackboxAsserts)
+  }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1256 

# Context, Motivation & Description

Issue: When running formal verification on a design containing a Verilog blackbox, Spinal does not include the blackbox source in the formal verification rtl directory or .sby file.

This PR adds blackbox sources to those included in the formal verification source exports

# Impact on code generation

None


