### PR TITLE
scala 2.12 is now the default

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,5 +1,5 @@
 object SpinalVersion {
-  val compilers = List("2.11.12", "2.12.18", "2.13.12")
+  val compilers = List("2.12.18", "2.11.12", "2.13.12")
   val compilerIsRC = false
 
   val isDev = true


### PR DESCRIPTION
This make Scala 2.12.18 the SpinalHDL default scala version (when included as a sbt submodule)

As some tools are droping scala 2.11, i guess its time XD