### PR TITLE
add setOutputAsReg

### DIFF
--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -347,6 +347,11 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
 
   /** Set baseType to reg */
   def setAsReg(): this.type
+  /** Recursively set baseType to reg only for output */
+  def setOutputAsReg(): this.type = {
+    flatten.filter(_.dir == out).foreach(_.setAsReg())
+    this
+  }
   /** Set baseType to Combinatorial */
   def setAsComb(): this.type
 


### PR DESCRIPTION
Similar to `Data.setAsReg`, but aware of the port direction that it only sets output ports as register.  This allows a better shorthand like the following:

```scala
val io = new Bundle {
  val masterStream = master(Stream(Bits(4 bits))) setOutputAsReg()
}
```

Using `setAsReg` here would lead to the complaint of `REGISTER DEFINED AS COMPONENT INPUT`.

@Dolu1990 before merging, could you check if `MultiData` is the right place to put this function?  Alternatively, should this be the default behaviour (if direction present, set as register only when is output) for `setAsReg`?