### PR TITLE
spinal.lib.Stream fix isFree

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -289,7 +289,7 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
 
 /** Return True when the bus is ready, but no data is present
   */
-  def isFree: Bool = signalCache(this ->"isFree")((!valid || ready).setCompositeName(this, "isFree", true))
+  def isFree: Bool = signalCache(this ->"isFree")((!valid && ready).setCompositeName(this, "isFree", true))
   
   def connectFrom(that: Stream[T]): Stream[T] = {
     this.valid := that.valid


### PR DESCRIPTION
# Context, Motivation & Description

Based on the comments, the `isFree` property within `spinal.lib.Stream` is intended for use in scenarios where:  
 - The `valid` signal is low and the `ready` signal is high, indicating that the receiver is ready but the sender has not transmitted data.  
Under these conditions, `isFree` should be high.  

If my understanding is correct, there appears to be a logical error with `isFree`, 
where an accidental use of `||` (logical OR) instead of `&&` (logical AND) has led to its improper functioning.  

This pull request addresses and corrects this issue.  

# Impact on code generation

`!io.valid || io.ready` => `!io.valid && io.ready`

# Checklist

- Unit tests were added -> Not applicable
- API changes are or will be documented -> Not applicable
