### PR TITLE
Tilelink mapping rework

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -2304,7 +2304,9 @@ object BitsLiteral {
     val minimalWidth   = Math.max(poisonBitCount,valueBitCount)
     var bitCount       = specifiedBitCount
 
-    if (value < 0) throw new Exception("literal value is negative and cannot be represented")
+    if (value < 0) {
+      throw new Exception("literal value is negative and cannot be represented")
+    }
 
     if (bitCount != -1) {
       if (minimalWidth > bitCount) throw new Exception(s"literal 0x${value.toString(16)} can't fit in Bits($specifiedBitCount bits)")

--- a/lib/src/main/scala/spinal/lib/bus/fabric/MappedConnection.scala
+++ b/lib/src/main/scala/spinal/lib/bus/fabric/MappedConnection.scala
@@ -19,6 +19,7 @@ abstract class MappedConnection[N <: Node](val m : N, val s : N) extends Area {
     val value = Handle[AddressMapping]
   }
 
+  def mEmits : MemoryTransfers
 
   //Document the memory connection in a agnostic way for further usages
   val tag = new MemoryConnection{
@@ -28,6 +29,9 @@ abstract class MappedConnection[N <: Node](val m : N, val s : N) extends Area {
     override def transformers = MappedConnection.this.mapping.automatic match {
       case Some(DefaultMapping) => Nil
       case _ => List(OffsetTransformer(mapping.lowerBound))
+    }
+    override def sToM(downs: MemoryTransfers, args: MappedNode) = {
+      downs.intersect(mEmits)
     }
     populate()
   }

--- a/lib/src/main/scala/spinal/lib/bus/fabric/MappedUpDown.scala
+++ b/lib/src/main/scala/spinal/lib/bus/fabric/MappedUpDown.scala
@@ -56,43 +56,13 @@ trait MappedUpDown[N <: bus.fabric.Node, C <: MappedConnection[N]] extends UpDow
   }
   def at(address : BigInt) = new At(_.mapping.automatic = Some(address))
   def at(address : BigInt, size : BigInt) : At = at(SizeMapping(address, size))
-  def at(mapping : AddressMapping) = new At(_.mapping.value load mapping)
+  def at(mapping : AddressMapping) = new At(_.mapping.automatic = Some(mapping))
   def connectFrom(m : N) : C
 
 
   def generateMapping(cToAddressWidth : C => Int): Unit ={
     if(withDowns) {
-      var dc = ArrayBuffer[C]()
-      downs.foreach{ c =>
-        c.mapping.automatic match {
-          case Some(v : BigInt) => c.mapping.value load SizeMapping(v, BigInt(1) << cToAddressWidth(c))
-          case Some(DefaultMapping) => dc += c
-          case Some(x : AddressMapping) => c.mapping.value load x
-          case None => c.mapping.value.get
-        }
-      }
-      for(c <- dc){
-        val spec = ArrayBuffer[SizeMapping]()
-        val others = downs.filter(e => e.mapping.automatic.isEmpty || e.mapping.automatic.get != DefaultMapping).flatMap(_.mapping.value.get match {
-          case m : SizeMapping => List(m)
-          case m : OrMapping => m.conds.map(_.asInstanceOf[SizeMapping]) //DefaultMapping only supported if all others are sizeMapping
-        })
-        val sorted = others.sortWith(_.base < _.base)
-        var address = BigInt(0)
-        val endAt = BigInt(1) << cToAddressWidth(c)
-        for(other <- sorted){
-          val size = other.base - address
-          if(size != 0) spec += SizeMapping(address, size)
-          address = other.base + other.size
-        }
-        val lastSize = endAt - address
-        if(lastSize != 0) spec += SizeMapping(address, lastSize)
-        c.mapping.value.load(spec.size match {
-          case 0 => ???
-          case 1 => spec.head
-          case _ => OrMapping(spec)
-        })
-      }
+
     }
   }
 }

--- a/lib/src/main/scala/spinal/lib/bus/fabric/MappedUpDown.scala
+++ b/lib/src/main/scala/spinal/lib/bus/fabric/MappedUpDown.scala
@@ -35,9 +35,7 @@ trait UpDown[C] extends Nameable{
 
 trait MappedUpDown[N <: bus.fabric.Node, C <: MappedConnection[N]] extends UpDown[C]{
   def <<(m : N): C = {
-    val c = connectFrom(m)
-    c.mapping.automatic = Some(DefaultMapping)
-    c
+    connectFrom(m)
   }
 
   def <<(m : Seq[N]): Seq[C] = m.map(this << _)
@@ -54,9 +52,9 @@ trait MappedUpDown[N <: bus.fabric.Node, C <: MappedConnection[N]] extends UpDow
       others.foreach(of)
     }
   }
-  def at(address : BigInt) = new At(_.mapping.automatic = Some(address))
+  def at(address : BigInt) = new At(_.userMapping = Some(address))
   def at(address : BigInt, size : BigInt) : At = at(SizeMapping(address, size))
-  def at(mapping : AddressMapping) = new At(_.mapping.automatic = Some(mapping))
+  def at(mapping : AddressMapping) = new At(_.userMapping = Some(mapping))
   def connectFrom(m : N) : C
 
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Decoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Decoder.scala
@@ -3,10 +3,11 @@ package spinal.lib.bus.tilelink
 import spinal.core._
 import spinal.lib._
 import spinal.lib.bus.misc.{AddressMapping, AddressTransformer, DefaultMapping, InterleavedMapping, NeverMapping}
-import spinal.lib.logic.{Masked, Symplify}
+import spinal.lib.logic.{DecodingSpec, DecodingSpecExample, Masked, Symplify}
+import spinal.lib.system.tag.{MappedNode, MappedTransfers}
 
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.Seq
+import scala.collection.{Seq, mutable}
 
 object Decoder{
   def upNodeFrom(downs : Seq[NodeParameters]) : NodeParameters = {
@@ -31,43 +32,29 @@ object Decoder{
   }
 }
 
+case class DecoderDownSpec(mappeds : Seq[MappedTransfers],
+                           transformers : Seq[AddressTransformer],
+                           nodeParam : NodeParameters)
 case class Decoder(upNode : NodeParameters,
-                   downsSupports : Seq[M2sSupport],
-                   downsS2m : Seq[S2mParameters],
-                   mapping : Seq[AddressMapping],
-                   transformers : Seq[Seq[AddressTransformer]]) extends Component{
-  val downsNodes = (downsSupports, downsS2m). zipped.map((support, s2m) => upNode.copy(
-    m = Decoder.downMastersFrom(upNode.m, support),
-    s = s2m
-  ))
-
-  assert(mapping.forall(_ != DefaultMapping))
-  for(self <- mapping.indices;
-      other <- mapping.indices.dropWhile(_ != self).tail){
-    if(!mapping(self).isInstanceOf[InterleavedMapping]) { //workaround for now
-      if (downsSupports(self).transfers.intersect(downsSupports(other).transfers).nonEmpty) {
-        assert(mapping(self).intersect(mapping(other)) == NeverMapping, s"Overlap between $self and $other")
-      }
-    }
-  }
-
+                   downsSpec : Seq[DecoderDownSpec]) extends Component{
+  //TODO it doesn't check for overlapp (elaboration time)
   val io = new Bundle{
     val up = slave(Bus(upNode))
-    val downs = Vec(downsNodes.map(e => master(Bus(e))))
+    val downs = Vec(downsSpec.map(e => master(Bus(e.nodeParam))))
   }
 
-  val sinkOffsetWidth = log2Up(downsNodes.count(_.withBCE))
-  val perNodeSinkWidth = downsNodes.map(_.s.sinkWidth).max
+  val sinkOffsetWidth = log2Up(downsSpec.count(_.nodeParam.withBCE))
+  val perNodeSinkWidth = downsSpec.map(_.nodeParam.s.sinkWidth).max
   var sinkPtr = -1
   val downs = io.downs.map { bus =>
     if(bus.p.withBCE) sinkPtr += 1
     bus.fromSinkOffset(sinkPtr << perNodeSinkWidth, upNode.s.sinkWidth)
   }
 
-  def getTermsA(m : AddressMapping, s : M2sSupport) : Seq[Masked] = {
+  def getTermsA(m : AddressMapping, s : M2sTransfers) : Seq[Masked] = {
     val mappingTerms = AddressMapping.terms(m, io.up.p.addressWidth)
     val opcodeTerms = ArrayBuffer[Masked]()
-    def op(filter : M2sTransfers => Boolean, op : Int) = if(filter(s.transfers)) opcodeTerms += Masked(op << io.up.p.addressWidth, 7 << io.up.p.addressWidth)
+    def op(filter : M2sTransfers => Boolean, op : Int) = if(filter(s)) opcodeTerms += Masked(op << io.up.p.addressWidth, 7 << io.up.p.addressWidth)
     op(_.get.some, 4)
     op(_.putFull.some, 0)
     op(_.putPartial.some, 1)
@@ -80,34 +67,36 @@ case class Decoder(upNode : NodeParameters,
     terms
   }
 
-  def decodeA(id : Int, key : Bits) = {
-    val trueTerms, falseTerms = ArrayBuffer[Masked]()
-    for(eid <- 0 until mapping.size){
-      val terms = getTermsA(mapping(eid), downsSupports(eid))
-      val target = if(eid == id) trueTerms else falseTerms
-      target ++= terms
+  val allTermsA, allTermsC = mutable.LinkedHashMap[MappedTransfers, Seq[Masked]]()
+  for(spec <- downsSpec; mt <- spec.mappeds){
+    allTermsA(mt) = getTermsA(mt.mapping, mt.transfers.asInstanceOf[M2sTransfers])
+    if(mt.transfers.asInstanceOf[M2sTransfers].withBCE){
+      allTermsC(mt) = AddressMapping.terms(mt.mapping, io.up.p.addressWidth)
     }
-    Symplify(key, trueTerms, falseTerms)
   }
 
-  def decodeC(id : Int, key : Bits): Bool = {
-    val trueTerms, falseTerms = ArrayBuffer[Masked]()
-    for(eid <- 0 until mapping.size if downsSupports(eid).transfers.withBCE){
-      val terms = AddressMapping.terms(mapping(eid), io.up.p.addressWidth)
-      val target = if(eid == id) trueTerms else falseTerms
-      target ++= terms
-    }
-    Symplify(key, trueTerms, falseTerms)
+  def decodeA(mts : Seq[MappedTransfers], key : Bits) = {
+    val dc = new DecodingSpec(Bool())
+    dc.setDefault(Masked.zero)
+    for(mt <- mts) dc.addNeeds(allTermsA(mt), Masked.one)
+    dc.build(key, allTermsA.values.flatten)
+  }
+
+  def decodeC(mts : Seq[MappedTransfers], key : Bits): Bool = {
+    val dc = new DecodingSpec(Bool())
+    dc.setDefault(Masked.zero)
+    for (mt <- mts if mt.transfers.asInstanceOf[M2sTransfers].withBCE) dc.addNeeds(allTermsC(mt), Masked.one)
+    dc.build(key, allTermsC.values.flatten)
   }
 
   val a = new Area{
     val readys = ArrayBuffer[Bool]()
     val key = io.up.a.opcode ## io.up.a.address
     val logic = for((s, id) <- downs.zipWithIndex) yield new Area {
-      val hit = decodeA(id, key) //mapping(id).hit(io.up.a.address)// && s.p.node.m.emits.contains(io.up.a.opcode)
+      val hit = decodeA(downsSpec(id).mappeds, key) //mapping(id).hit(io.up.a.address)// && s.p.node.m.emits.contains(io.up.a.opcode)
       s.a.valid := io.up.a.valid && hit
       s.a.payload := io.up.a.payload
-      s.a.address.removeAssignments() := transformers(id)(io.up.a.address).resized
+      s.a.address.removeAssignments() := downsSpec(id).transformers(io.up.a.address).resized
       s.a.size.removeAssignments() := io.up.a.size.resized
       readys += s.a.ready && hit
     }
@@ -118,12 +107,12 @@ case class Decoder(upNode : NodeParameters,
   }
 
   val b = upNode.withBCE generate new Area{
-    val arbiter = StreamArbiterFactory().roundRobin.lambdaLock[ChannelB](_.isLast()).build(ChannelB(upNode), downsNodes.filter(_.withBCE).size)
+    val arbiter = StreamArbiterFactory().roundRobin.lambdaLock[ChannelB](_.isLast()).build(ChannelB(upNode), downsSpec.filter(_.nodeParam.withBCE).size)
     val iter = arbiter.io.inputs.iterator
-    for(i <- 0 until downsSupports.size if downsNodes(i).withBCE){
+    for(i <- 0 until downsSpec.size if downsSpec(i).nodeParam.withBCE){
       val arbiterInput = iter.next()
       arbiterInput << downs(i).b
-      arbiterInput.address.removeAssignments() := transformers(i).invert(downs(i).b.address.resize(upNode.m.addressWidth))
+      arbiterInput.address.removeAssignments() := downsSpec(i).transformers.invert(downs(i).b.address.resize(upNode.m.addressWidth))
       arbiterInput.size.removeAssignments() := downs(i).b.size.resized
     }
     arbiter.io.output >> io.up.b
@@ -133,10 +122,10 @@ case class Decoder(upNode : NodeParameters,
     val readys = ArrayBuffer[Bool]()
     val key = io.up.c.address asBits
     val logic = for((s, id) <- downs.zipWithIndex if s.p.withBCE) yield new Area {
-      val hit = decodeC(id, key) //mapping(id).hit(io.up.c.address)
+      val hit = decodeC(downsSpec(id).mappeds, key) //mapping(id).hit(io.up.c.address)
       s.c.valid := io.up.c.valid && hit
       s.c.payload := io.up.c.payload
-      s.c.address.removeAssignments() := transformers(id)(io.up.c.address).resized
+      s.c.address.removeAssignments() := downsSpec(id).transformers(io.up.c.address).resized
       s.c.size.removeAssignments() := io.up.c.size.resized
       readys += s.c.ready && hit
     }
@@ -145,7 +134,7 @@ case class Decoder(upNode : NodeParameters,
   }
 
   val d = new Area{
-    val arbiter = StreamArbiterFactory().roundRobin.lambdaLock[ChannelD](_.isLast()).build(ChannelD(upNode), downsNodes.size)
+    val arbiter = StreamArbiterFactory().roundRobin.lambdaLock[ChannelD](_.isLast()).build(ChannelD(upNode), downsSpec.size)
     (arbiter.io.inputs, downs).zipped.foreach{(arb, down) =>
       arb.arbitrationFrom(down.d)
       arb.payload.weakAssignFrom(down.d.payload)

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Decoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Decoder.scala
@@ -54,7 +54,7 @@ case class Decoder(upNode : NodeParameters,
   def getTermsA(m : AddressMapping, s : M2sTransfers) : Seq[Masked] = {
     val mappingTerms = AddressMapping.terms(m, io.up.p.addressWidth)
     val opcodeTerms = ArrayBuffer[Masked]()
-    def op(filter : M2sTransfers => Boolean, op : Int) = if(filter(s)) opcodeTerms += Masked(op << io.up.p.addressWidth, 7 << io.up.p.addressWidth)
+    def op(filter : M2sTransfers => Boolean, op : Int) = if(filter(s)) opcodeTerms += Masked(BigInt(op) << io.up.p.addressWidth, BigInt(7) << io.up.p.addressWidth)
     op(_.get.some, 4)
     op(_.putFull.some, 0)
     op(_.putPartial.some, 1)

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/CacheFiber.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/CacheFiber.scala
@@ -24,16 +24,11 @@ class CacheFiber() extends Area{
     coherentRegion = null
   )
 
-
-  val mappingLock = Lock().retain()
   new MemoryConnection{
     override def up = CacheFiber.this.up
     override def down = CacheFiber.this.down
     override def transformers = Nil
-    override def mapping = {
-      mappingLock.get //Ensure that the parameter is final
-      SizeMapping(0, BigInt(1) << parameter.addressWidth)
-    }
+
     override def sToM(down: MemoryTransfers, args: MappedNode) = {
       down match{
         case t : M2sTransfers => {
@@ -97,7 +92,6 @@ class CacheFiber() extends Area{
     up.s2m.setProposedFromParameters()
 
     parameter.unp = up.bus.p.node
-    mappingLock.release()
 
     val transferSpec = MemoryConnection.getMemoryTransfers(up)
     val probeSpec = transferSpec.filter(_.transfers.asInstanceOf[M2sTransfers].withBCE)

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/HubFiber.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/HubFiber.scala
@@ -33,10 +33,6 @@ class HubFiber() extends Area{
     override def up = HubFiber.this.up
     override def down = HubFiber.this.down
     override def transformers = Nil
-    override def mapping = {
-      mappingLock.get //Ensure that the parameter is final
-      SizeMapping(0, BigInt(1) << parameter.addressWidth)
-    }
     override def sToM(down: MemoryTransfers, args: MappedNode) = {
       down match{
         case t : M2sTransfers => {

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Axi4Bridge.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Axi4Bridge.scala
@@ -17,7 +17,6 @@ class Axi4Bridge() extends Area{
     override def up = Axi4Bridge.this.up
     override def down = Axi4Bridge.this.down
     override def transformers = Nil
-    override def mapping = SizeMapping(0, BigInt(1) << Axi4Bridge.this.up.m2s.parameters.addressWidth)
     populate()
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/AxiLite4Bridge.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/AxiLite4Bridge.scala
@@ -17,7 +17,6 @@ class AxiLite4Bridge() extends Area{
     override def up = AxiLite4Bridge.this.up
     override def down = AxiLite4Bridge.this.down
     override def transformers = Nil
-    override def mapping = SizeMapping(0, BigInt(1) << AxiLite4Bridge.this.up.m2s.parameters.addressWidth)
     populate()
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/ConnectionRaw.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/ConnectionRaw.scala
@@ -24,5 +24,7 @@ class ConnectionRaw(m : NodeUpDown, s : NodeUpDown) extends bus.fabric.MappedCon
       val parameters = Handle[S2mParameters]()
     }
   }
+
+  override def mEmits: MemoryTransfers = up.m2s.parameters.emits
 }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Interleaver.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Interleaver.scala
@@ -19,12 +19,13 @@ case class Interleaver(blockSize : Int, ratio : Int, sel : Int) extends Area{
     override def up = Interleaver.this.up
     override def down = Interleaver.this.down
     override def transformers = List(transformer)
-    override def mapping = InterleavedMapping(
-      mapping = SizeMapping(0, BigInt(1) << Interleaver.this.up.m2s.parameters.addressWidth),
-      blockSize = blockSize,
-      ratio = ratio,
-      sel = sel
-    )
+    ???
+//    override def mapping = InterleavedMapping(
+//      mapping = SizeMapping(0, BigInt(1) << Interleaver.this.up.m2s.parameters.addressWidth),
+//      blockSize = blockSize,
+//      ratio = ratio,
+//      sel = sel
+//    )
     populate()
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Interleaver.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Interleaver.scala
@@ -11,21 +11,20 @@ case class Interleaver(blockSize : Int, ratio : Int, sel : Int) extends Area{
   val up = Node.slave()
   val down = Node.master()
 
-  def at(mapping: AddressMapping) = up.at(InterleavedMapping(mapping, blockSize, ratio, sel))
-  def at(base : BigInt, size : BigInt) = up.at(InterleavedMapping(SizeMapping(base, size), blockSize, ratio, sel))
+  def at(mapping: AddressMapping) = up.at(mapping)
+  def at(base: BigInt, size: BigInt) = up.at(base, size)
 
   val transformer = InterleaverTransformer(blockSize, ratio, sel)
   new MemoryConnection {
     override def up = Interleaver.this.up
     override def down = Interleaver.this.down
     override def transformers = List(transformer)
-    ???
-//    override def mapping = InterleavedMapping(
-//      mapping = SizeMapping(0, BigInt(1) << Interleaver.this.up.m2s.parameters.addressWidth),
-//      blockSize = blockSize,
-//      ratio = ratio,
-//      sel = sel
-//    )
+    override def sToM(down: AddressMapping) = InterleavedMapping(
+      mapping = down,
+      blockSize = blockSize,
+      ratio = ratio,
+      sel = sel
+    )
     populate()
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/IoAgent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/IoAgent.scala
@@ -4,6 +4,7 @@ import spinal.core._
 import spinal.core.fiber.Fiber
 import spinal.lib.bus.misc.SizeMapping
 import spinal.lib.bus.tilelink.{M2sParameters, M2sSupport, S2mAgent, S2mParameters, S2mTransfers, SizeRange}
+import spinal.lib.system.tag.{MemoryEndpoint, MemoryTransfers}
 import spinal.lib.{master, slave}
 
 //Will create a interconnect master as an io of the toplevel
@@ -20,6 +21,10 @@ class MasterBus(p : M2sParameters) extends Area{
 //Will create a interconnect slave as an io of the toplevel
 class SlaveBus(m2sSupport : M2sSupport, s2mParameters: S2mParameters = S2mParameters.none) extends Area{
   val node = Node.slave()
+  node.addTag(new MemoryEndpoint {
+    override def mapping = SizeMapping(0, BigInt(1) << node.m2s.parameters.addressWidth)
+    override def transfers: MemoryTransfers = node.m2s.parameters.emits
+  })
   val logic = Fiber build new Area {
     node.m2s.supported.load(m2sSupport.copy(transfers = node.m2s.proposed.transfers.intersect(m2sSupport.transfers)))
     node.s2m.parameters.load(s2mParameters)

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/IoAgent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/IoAgent.scala
@@ -23,7 +23,6 @@ class SlaveBus(m2sSupport : M2sSupport, s2mParameters: S2mParameters = S2mParame
   val node = Node.slave()
   node.addTag(new MemoryEndpoint {
     override def mapping = SizeMapping(0, BigInt(1) << node.m2s.parameters.addressWidth)
-    override def transfers: MemoryTransfers = node.m2s.parameters.emits
   })
   val logic = Fiber build new Area {
     node.m2s.supported.load(m2sSupport.copy(transfers = node.m2s.proposed.transfers.intersect(m2sSupport.transfers)))

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
@@ -54,6 +54,13 @@ class Node() extends NodeUpDown{
     setDownConnection(_.connectFrom(_)(a, b, c, d, e))
   }
 
+  def setEndpoint(): Unit = {
+    addTag(new MemoryEndpoint {
+      override def mapping = SizeMapping(0, BigInt(1) << m2s.parameters.addressWidth)
+      override def transfers: MemoryTransfers = m2s.parameters.emits
+    })
+  }
+
 
   def forceDataWidth(dataWidth : Int): Unit ={
     m2s.proposedModifiers += { s =>

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
@@ -188,20 +188,8 @@ class Node() extends NodeUpDown{
 
     val decoder = (withDowns && downs.size > 1) generate new Area {
       val downSpecs = downs.map{c =>
-        val dmt = MemoryConnection.getMemoryTransfers(c.s)
-        val invertTransform = c.tag.transformers.reverse
-        val remapped = dmt.map { e =>
-          new MappedTransfers(
-            where = new MappedNode(
-              e.node,
-              invertTransform.foldRight(e.mapping)((t, a) => a.withOffsetInvert(t)),
-              c.tag.transformers ++ e.where.transformers
-            ),
-            transfers = c.tag.sToM(e.transfers, e.where)
-          )
-        }
         DecoderDownSpec(
-          remapped,
+          MemoryConnection.getMemoryTransfers(Node.this, List(c.tag)),
           c.tag.transformers,
           NodeParameters(c.up.m2s.parameters, c.up.s2m.parameters)
         )

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
@@ -57,7 +57,6 @@ class Node() extends NodeUpDown{
   def setEndpoint(): Unit = {
     addTag(new MemoryEndpoint {
       override def mapping = SizeMapping(0, BigInt(1) << m2s.parameters.addressWidth)
-      override def transfers: MemoryTransfers = m2s.parameters.emits
     })
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
@@ -188,7 +188,7 @@ class Node() extends NodeUpDown{
 
     val decoder = (withDowns && downs.size > 1) generate new Area {
       val downSpecs = downs.map{c =>
-        val dmt = MemoryConnection.getMemoryTransfersV2(c.s)
+        val dmt = MemoryConnection.getMemoryTransfers(c.s)
         val invertTransform = c.tag.transformers.reverse
         val remapped = dmt.map { e =>
           new MappedTransfers(

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/RamFiber.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/RamFiber.scala
@@ -7,16 +7,16 @@ import spinal.lib.bus.tilelink._
 import spinal.lib.bus.tilelink.coherent.OrderingCmd
 import spinal.lib.system.tag.PMA
 
-class RamFiber() extends Area{
+class RamFiber(var bytes : BigInt) extends Area{
   val up = Node.up()
   up.addTag(PMA.MAIN)
+  up.setEndpoint()
 
   val thread = Fiber build new Area{
-    up.m2s.supported load up.m2s.proposed.intersect(M2sTransfers.allGetPut)
+    up.m2s.supported load up.m2s.proposed.intersect(M2sTransfers.allGetPut).copy(addressWidth = log2Up(bytes))
     up.s2m.none()
 
-    val bytes = up.ups.map(e => e.mapping.value.highestBound - e.mapping.value.lowerBound + 1).max.toInt
-    val logic = new Ram(up.bus.p.node, bytes)
+    val logic = new Ram(up.bus.p.node, bytes toInt)
     logic.io.up << up.bus
   }
 }

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/RamFiber.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/RamFiber.scala
@@ -10,7 +10,6 @@ import spinal.lib.system.tag.PMA
 class RamFiber(var bytes : BigInt) extends Area{
   val up = Node.up()
   up.addTag(PMA.MAIN)
-  up.setEndpoint()
 
   val thread = Fiber build new Area{
     up.m2s.supported load up.m2s.proposed.intersect(M2sTransfers.allGetPut).copy(addressWidth = log2Up(bytes))

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/TransferFilter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/TransferFilter.scala
@@ -7,7 +7,7 @@ import spinal.lib.bus.misc.SizeMapping
 import spinal.lib.bus.tilelink._
 import spinal.lib.bus.tilelink
 import spinal.lib.logic.{Masked, Symplify}
-import spinal.lib.system.tag.{MappedNode, MappedTransfers, MemoryConnection, MemoryTransferTag, MemoryTransfers}
+import spinal.lib.system.tag.{MappedNode, MappedTransfers, MemoryConnection, MemoryEndpoint, MemoryTransferTag, MemoryTransfers}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -21,13 +21,16 @@ class TransferFilter() extends Area {
       override def get = M2sTransfers()
     })
     addTag(TransferFilterTag)
+//    addTag(new MemoryEndpoint {
+//      override def mapping = ???
+//      override def transfers = new M2s
+//    })
   }
 
   new MemoryConnection {
     override def up = TransferFilter.this.up
     override def down = TransferFilter.this.down
     override def transformers = Nil
-    override def mapping = SizeMapping(0, BigInt(1) << TransferFilter.this.up.m2s.parameters.addressWidth)
     populate()
   }
 
@@ -35,7 +38,6 @@ class TransferFilter() extends Area {
     override def up = TransferFilter.this.up
     override def down = TransferFilter.this.deadEnd
     override def transformers = Nil
-    override def mapping = SizeMapping(0, BigInt(1) << TransferFilter.this.up.m2s.parameters.addressWidth)
     populate()
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/TransferFilter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/TransferFilter.scala
@@ -21,10 +21,9 @@ class TransferFilter() extends Area {
       override def get = M2sTransfers()
     })
     addTag(TransferFilterTag)
-//    addTag(new MemoryEndpoint {
-//      override def mapping = ???
-//      override def transfers = new M2s
-//    })
+    addTag(new MemoryEndpoint {
+      override def mapping = SizeMapping(0, BigInt(1) << up.m2s.parameters.addressWidth)
+    })
   }
 
   new MemoryConnection {

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/WidthAdapter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/WidthAdapter.scala
@@ -18,7 +18,6 @@ class WidthAdapter() extends Area{
     override def up = WidthAdapter.this.up
     override def down = WidthAdapter.this.down
     override def transformers = Nil
-    override def mapping = SizeMapping(0, BigInt(1) << WidthAdapter.this.up.m2s.parameters.addressWidth)
     populate()
   }
 

--- a/lib/src/main/scala/spinal/lib/logic/Decoder.scala
+++ b/lib/src/main/scala/spinal/lib/logic/Decoder.scala
@@ -4,6 +4,7 @@ import spinal.core._
 import spinal.core.{BaseType, Bits, Component, EnumLiteral, False, HardType, RegInit, RegNext, SpinalEnumCraft, out}
 import spinal.lib.KeepAttribute
 
+import scala.collection.Seq
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 

--- a/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
+++ b/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
@@ -29,6 +29,10 @@ trait MemoryTransfers {
   def nonEmpty : Boolean
 }
 
+trait MemoryEndpoint extends SpinalTag{
+  def mapping: AddressMapping
+  def transfers: MemoryTransfers
+}
 //Address seen by the slave slave are mapping.foreach(_.base-offset)
 trait MemoryConnection extends SpinalTag {
   def up : Nameable with SpinalTagReady
@@ -79,6 +83,85 @@ case class MappedTransfers(where : MappedNode, transfers: MemoryTransfers){
 }
 
 object MemoryConnection{
+  def getMemoryTransfersV2(m: Node): mutable.ArrayBuffer[MappedTransfers] = {
+    m.await()
+    getMemoryTransfersV2(m.asInstanceOf[Nameable with SpinalTagReady])
+  }
+
+  def getMemoryTransfersV2(up : Nameable with SpinalTagReady): ArrayBuffer[MappedTransfers] = {
+    val ret = ArrayBuffer[MappedTransfers]()
+
+    // Stop on leafs
+    if (!up.existsTag {
+      case c: MemoryConnection if c.up == up => true
+      case _ => false
+    }) {
+      up.getTags().collectFirst{ case t : MemoryEndpoint => t} match {
+        case None => SpinalError(s"Missing enpoint on $up")
+        case Some(ep) => {
+          ret += new MappedTransfers(
+            where = new MappedNode(up, ep.mapping, Nil),
+            transfers = ep.transfers
+          )
+        }
+        return ret
+      }
+    }
+
+
+
+    //Collect slaves supports
+    println("asd")
+    up.foreachTag {
+      case c: MemoryConnection if c.up == up => {
+        val dmt = getMemoryTransfersV2(c.down)
+        val invertTransform = c.transformers.reverse
+        val remapped = dmt.map{ e =>
+          new MappedTransfers(
+            where = new MappedNode(
+              e.node,
+              invertTransform.foldRight(e.mapping)((t, a) => a.withOffsetInvert(t)),
+              c.transformers ++ e.where.transformers
+            ),
+            transfers = c.sToM(e.transfers, e.where)
+          )
+        }
+        ret ++= remapped
+      }
+      case _ =>
+    }
+
+    return ret
+
+//    val unfiltred = mutable.LinkedHashMap[MappedNode, MemoryTransfers]() //The HashMap will allow handle a bus to fork RO WO and join later do a RW join. Will only work for exactly similar mappings
+//    args.foreachSlave { (s, c) =>
+//      val spec = getMemoryTransfersV2(s)
+//      val transformed = for (e <- spec) yield {
+//        val remapped = e.where.remap(c.transformers) // c.offset Give the same address view point as the "args" (master)
+//        val filtred = remapped.copy( // Will handle partial mapping and stuff as InterleavedMapping
+//          mapping = c.mapping.intersect(remapped.mapping)
+//        )
+//        val mt = c.sToM(e.transfers, e.where)
+//        filtred -> mt
+//      }
+//      for ((who, what) <- transformed) {
+//        unfiltred.get(who) match {
+//          case None => unfiltred(who) = what
+//          case Some(x) => unfiltred(who) = what.mincover(x)
+//        }
+//      }
+//    }
+//
+//    //Filter the agregated slave supports with the current node capabilities
+//    MemoryTransfers.of(args.node) match {
+//      case None => unfiltred.foreach(e => ret += MappedTransfers(e._1, e._2))
+//      case Some(x) => unfiltred.foreach(e => ret += MappedTransfers(e._1, e._2.intersect(x)))
+//    }
+//
+//    ret.filter(e => e.transfers.nonEmpty || e.where.node.hasTag(TransferFilterTag))
+  }
+
+
   def getMemoryTransfers(m : Node) : mutable.ArrayBuffer[MappedTransfers] = {
     m.await()
     getMemoryTransfers(MappedNode(m))
@@ -128,6 +211,16 @@ object MemoryConnection{
     m.await()
     MappedNode(m, Nil, 0, BigInt(1) << m.bus.p.addressWidth).foreachSlave(body)
   }
+
+//  def foreachSlave(up : Nameable with SpinalTagReady)(body: (MappedNode, MemoryConnection) => Unit): Unit = {
+//    up.foreachTag {
+//      case c: MemoryConnection if c.up == up => {
+//        val remaped = c.transformers.foldRight(c.mapping)((t, a) => a.withOffset(t))
+//        body(MappedNode(c.down, remaped, Nil), c)
+//      }
+//      case _ =>
+//    }
+//  }
 
 //  def walk(m : InterconnectNode)(body : MappedNode => Unit): Unit = {
 //    m.await()

--- a/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
+++ b/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
@@ -37,7 +37,6 @@ trait MemoryEndpoint extends SpinalTag{
 trait MemoryConnection extends SpinalTag {
   def up : Nameable with SpinalTagReady
   def down : Nameable with SpinalTagReady
-  def mapping : AddressMapping //Specify the memory mapping of the slave from the master address (before transformers are applied)
   def transformers : List[AddressTransformer]  //List of alteration done to the address on this connection (ex offset, interleaving, ...)
   def sToM(downs : MemoryTransfers, args : MappedNode) : MemoryTransfers = downs//Convert the slave MemoryTransfers capabilities into the master ones
 
@@ -65,16 +64,6 @@ case class MappedNode(node : Nameable with SpinalTagReady, mapping : AddressMapp
   def remap(transformers : List[AddressTransformer]) : MappedNode = MappedNode(node, transformers.foldRight(mapping)((t,m) => m.withOffsetInvert(t)), transformers ++ this.transformers)//
   def remap(offset : BigInt) : MappedNode = MappedNode(node, mapping.withOffset(offset), OffsetTransformer(offset) :: transformers)
   override def toString = f"$node mapped=$mapping through=$transformers "
-
-  def foreachSlave(body : (MappedNode, MemoryConnection) => Unit): Unit ={
-    node.foreachTag{
-      case c : MemoryConnection if c.up == node => {
-        val remaped = c.transformers.foldRight(c.mapping)((t, a) => a.withOffset(t))
-        body(MappedNode(c.down, remaped, Nil), c)
-      }
-      case _ =>
-    }
-  }
 }
 
 case class MappedTransfers(where : MappedNode, transfers: MemoryTransfers){
@@ -97,7 +86,7 @@ object MemoryConnection{
       case _ => false
     }) {
       up.getTags().collectFirst{ case t : MemoryEndpoint => t} match {
-        case None => SpinalError(s"Missing enpoint on $up")
+        case None => throw new Exception(s"Missing enpoint on $up")
         case Some(ep) => {
           ret += new MappedTransfers(
             where = new MappedNode(up, ep.mapping, Nil),
@@ -111,7 +100,6 @@ object MemoryConnection{
 
 
     //Collect slaves supports
-    println("asd")
     up.foreachTag {
       case c: MemoryConnection if c.up == up => {
         val dmt = getMemoryTransfersV2(c.down)
@@ -168,49 +156,51 @@ object MemoryConnection{
   }
 
   def getMemoryTransfers(args : MappedNode): ArrayBuffer[MappedTransfers] ={
-    // Stop on leafs
-    if(!args.node.existsTag{
-      case c : MemoryConnection if c.up == args.node => true
-      case _ => false
-    }) {
-      val elem = MemoryTransfers.of(args.node).get
-      return ArrayBuffer(MappedTransfers(args, elem))
-    }
-
-    //Collect slaves supports
-    val ret = ArrayBuffer[MappedTransfers]()
-    val unfiltred = mutable.LinkedHashMap[MappedNode, MemoryTransfers]() //The HashMap will allow handle a bus to fork RO WO and join later do a RW join. Will only work for exactly similar mappings
-    args.foreachSlave{ (s, c) =>
-      val spec = getMemoryTransfers(s)
-      val transformed = for(e <- spec) yield {
-        val remapped = e.where.remap(c.transformers) // c.offset Give the same address view point as the "args" (master)
-        val filtred = remapped.copy( // Will handle partial mapping and stuff as InterleavedMapping
-          mapping = c.mapping.intersect(remapped.mapping)
-        )
-        val mt = c.sToM(e.transfers, e.where)
-        filtred -> mt
-      }
-      for((who, what) <- transformed){
-        unfiltred.get(who) match {
-          case None => unfiltred(who) = what
-          case Some(x) => unfiltred(who) = what.mincover(x)
-        }
-      }
-    }
-
-    //Filter the agregated slave supports with the current node capabilities
-    MemoryTransfers.of(args.node) match {
-      case None => unfiltred.foreach(e => ret += MappedTransfers(e._1, e._2))
-      case Some(x) => unfiltred.foreach(e => ret += MappedTransfers(e._1, e._2.intersect(x)))
-    }
-
-    ret.filter(e => e.transfers.nonEmpty || e.where.node.hasTag(TransferFilterTag))
+    return getMemoryTransfersV2(args.node)
+//
+//    // Stop on leafs
+//    if(!args.node.existsTag{
+//      case c : MemoryConnection if c.up == args.node => true
+//      case _ => false
+//    }) {
+//      val elem = MemoryTransfers.of(args.node).get
+//      return ArrayBuffer(MappedTransfers(args, elem))
+//    }
+//
+//    //Collect slaves supports
+//    val ret = ArrayBuffer[MappedTransfers]()
+//    val unfiltred = mutable.LinkedHashMap[MappedNode, MemoryTransfers]() //The HashMap will allow handle a bus to fork RO WO and join later do a RW join. Will only work for exactly similar mappings
+//    args.foreachSlave{ (s, c) =>
+//      val spec = getMemoryTransfers(s)
+//      val transformed = for(e <- spec) yield {
+//        val remapped = e.where.remap(c.transformers) // c.offset Give the same address view point as the "args" (master)
+//        val filtred = remapped.copy( // Will handle partial mapping and stuff as InterleavedMapping
+//          mapping = c.mapping.intersect(remapped.mapping)
+//        )
+//        val mt = c.sToM(e.transfers, e.where)
+//        filtred -> mt
+//      }
+//      for((who, what) <- transformed){
+//        unfiltred.get(who) match {
+//          case None => unfiltred(who) = what
+//          case Some(x) => unfiltred(who) = what.mincover(x)
+//        }
+//      }
+//    }
+//
+//    //Filter the agregated slave supports with the current node capabilities
+//    MemoryTransfers.of(args.node) match {
+//      case None => unfiltred.foreach(e => ret += MappedTransfers(e._1, e._2))
+//      case Some(x) => unfiltred.foreach(e => ret += MappedTransfers(e._1, e._2.intersect(x)))
+//    }
+//
+//    ret.filter(e => e.transfers.nonEmpty || e.where.node.hasTag(TransferFilterTag))
   }
 
-  def foreachSlave(m : Node)(body : (MappedNode, MemoryConnection) => Unit): Unit = {
-    m.await()
-    MappedNode(m, Nil, 0, BigInt(1) << m.bus.p.addressWidth).foreachSlave(body)
-  }
+//  def foreachSlave(m : Node)(body : (MappedNode, MemoryConnection) => Unit): Unit = {
+//    m.await()
+//    MappedNode(m, Nil, 0, BigInt(1) << m.bus.p.addressWidth).foreachSlave(body)
+//  }
 
 //  def foreachSlave(up : Nameable with SpinalTagReady)(body: (MappedNode, MemoryConnection) => Unit): Unit = {
 //    up.foreachTag {

--- a/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
+++ b/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
@@ -85,6 +85,7 @@ object MemoryConnection{
       case _ => false
     }) {
       val mapping = up.getTags().collectFirst{ case t : MemoryEndpoint => t} match {
+        case Some(ep) => ep.mapping
         case None => {
           up match {
             case up : Node => SizeMapping(0, BigInt(1) << up.m2s.parameters.addressWidth) //backward compatibility

--- a/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
+++ b/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
@@ -31,7 +31,6 @@ trait MemoryTransfers {
 
 trait MemoryEndpoint extends SpinalTag{
   def mapping: AddressMapping
-  def transfers: MemoryTransfers
 }
 //Address seen by the slave slave are mapping.foreach(_.base-offset)
 trait MemoryConnection extends SpinalTag {
@@ -90,7 +89,7 @@ object MemoryConnection{
         case Some(ep) => {
           ret += new MappedTransfers(
             where = new MappedNode(up, ep.mapping, Nil),
-            transfers = ep.transfers
+            transfers = MemoryTransfers.of(up).get
           )
         }
         return ret

--- a/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
+++ b/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
@@ -38,7 +38,7 @@ trait MemoryConnection extends SpinalTag {
   def down : Nameable with SpinalTagReady
   def transformers : List[AddressTransformer]  //List of alteration done to the address on this connection (ex offset, interleaving, ...)
   def sToM(downs : MemoryTransfers, args : MappedNode) : MemoryTransfers = downs//Convert the slave MemoryTransfers capabilities into the master ones
-  def sToM(down : AddressMapping) : AddressMapping = down//Convert the slave MemoryTransfers capabilities into the master ones
+  def sToM(down : AddressMapping) : AddressMapping = down //Convert the slave MemoryMapping capabilities into the master ones
 
   def populate(): Unit ={
     up.addTag(this)

--- a/sim/src/main/scala/spinal/sim/SimManager.scala
+++ b/sim/src/main/scala/spinal/sim/SimManager.scala
@@ -344,7 +344,7 @@ class SimManager(val raw : SimRaw, val random: Random = Random, val testName : S
         raw.sleep(1)
         val str = e.getStackTrace.head.toString
         if(str.contains("spinal.core.") && !str.contains("sim")){
-          System.err.println("It seems like you used some SpinalHDL hardware elaboration API in the simulation. If you did, you shouldn't.")
+          System.err.println(s"It seems like you used some SpinalHDL hardware elaboration API in the simulation. If you did, you shouldn't. From : \n${e.getStackTrace.mkString("\n")}")
         }
         throw e
       }

--- a/tester/src/test/scala/spinal/lib/bus/tilelink/InterconnectTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/tilelink/InterconnectTester.scala
@@ -309,16 +309,27 @@ class InterconnectTester extends AnyFunSuite{
         val probed = MemoryConnection.getMemoryTransfers(m0.node)
         probed.foreach { w =>
           w.node match {
-            case s0.node =>
+            case s0.node => {
               hits += 1
               assert(w.where.transformers == List(OffsetTransformer(0x1000), OffsetTransformer(0x400), OffsetTransformer(0x200)))
               assert(w.mapping == SizeMapping(0x1600, 0x100))
+            }
           }
         }
         assert(hits == 1)
       }
     })
   }
+
+//  test("overlap") {
+//    testInterconnectAll(new Component {
+//      val m0 = simpleMaster(readWrite)
+//      val s0,s1 = simpleSlave(8)
+//      s0.node at 0x100 of m0.node
+//      s1.node at 0x1F0 of m0.node
+//    })
+//  }
+
 
   test("interleaving0") {
     testInterconnectAll(new Component {
@@ -329,6 +340,11 @@ class InterconnectTester extends AnyFunSuite{
 
       val s0 = simpleSlave(8)
       s0.node at InterleavedMapping(SizeMapping(0x200, 0x100), 0x10, 4, 0) of b0
+
+      Fiber build {
+        val probed = MemoryConnection.getMemoryTransfers(m0.node)
+        println(probed)
+      }
     })
   }
 
@@ -342,6 +358,11 @@ class InterconnectTester extends AnyFunSuite{
       val s0,s1 = simpleSlave(8)
       s0.node at InterleavedMapping(SizeMapping(0x200, 0x100), 0x10, 4, 0) of b0
       s1.node at InterleavedMapping(SizeMapping(0x200, 0x100), 0x10, 4, 1) of b0
+
+      Fiber build {
+        val probed = MemoryConnection.getMemoryTransfers(m0.node)
+        println(probed)
+      }
     })
   }
 
@@ -375,6 +396,11 @@ class InterconnectTester extends AnyFunSuite{
       val s1, s2 = simpleSlave(8)
       s1.node at 0x200 of i1.down
       s2.node at 0x200 of i2.down
+
+      Fiber build {
+        val probed = MemoryConnection.getMemoryTransfers(m0.node)
+        println(probed)
+      }
     })
   }
 

--- a/tester/src/test/scala/spinal/lib/bus/tilelink/InterconnectTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/tilelink/InterconnectTester.scala
@@ -206,8 +206,8 @@ class InterconnectTester extends AnyFunSuite{
   test("ram") {
     testInterconnectAll(new Component {
       val m0 = simpleMaster(readWrite)
-      val ram = new RamFiber()
-      ram.up at (0x4200, 4 KiB) of m0.node
+      val ram = new RamFiber(4 KiB)
+      ram.up at (0x4200) of m0.node
 
       Fiber build new Area{
         val sparse = SparseMemory(42)
@@ -225,9 +225,9 @@ class InterconnectTester extends AnyFunSuite{
     testInterconnectAll(new Component {
       val m0 = simpleMaster(readWrite)
       val b0 = Node()
-      val ram = new RamFiber()
+      val ram = new RamFiber(4 KiB)
       b0 << m0.node
-      ram.up at (0x4100, 4 kB) of b0
+      ram.up at (0x4100) of b0
       Fiber build new Area {
         val sparse = SparseMemory(42)
         val v = for (i <- 0 until 4096 by 4) yield {

--- a/tester/src/test/scala/spinal/lib/bus/tilelink/InterconnectTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/tilelink/InterconnectTester.scala
@@ -304,6 +304,20 @@ class InterconnectTester extends AnyFunSuite{
       val s0 = simpleSlave(8)
       s0.node at 0x200 of r0
       s0.node at 0x200 of w0
+
+      Fiber build {
+        var hits = 0
+        val probed = MemoryConnection.getMemoryTransfers(m0.node)
+        probed.foreach { w =>
+          w.node match {
+            case s0.node =>
+              hits += 1
+              assert(w.where.transformers == List(OffsetTransformer(0x1000), OffsetTransformer(0x400), OffsetTransformer(0x200)))
+              assert(w.mapping == SizeMapping(0x1600, 0x100))
+          }
+        }
+        assert(hits == 1)
+      }
     })
   }
 

--- a/tester/src/test/scala/spinal/lib/bus/tilelink/InterconnectTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/tilelink/InterconnectTester.scala
@@ -195,9 +195,7 @@ class InterconnectTester extends AnyFunSuite{
 
       val miaou = Fiber build new Area{
         val v1 = MemoryConnection.getMemoryTransfers(m0.node)
-        val v2 = MemoryConnection.getMemoryTransfersV2(m0.node)
         println(v1)
-        println(v2)
       }
     })
   }

--- a/tester/src/test/scala/spinal/lib/bus/tilelink/demo/Demo.scala
+++ b/tester/src/test/scala/spinal/lib/bus/tilelink/demo/Demo.scala
@@ -138,11 +138,11 @@ object Demo extends App {
         up.s2m.none()
 
         // Here we infer how many bytes our ram need to be, by looking at the memory mapping of the connected masters
-        val bytes = up.ups.map(e => e.mapping.value.highestBound - e.mapping.value.lowerBound + 1).max.toInt
+//        val bytes = up.ups.map(e => e.mapping.value.highestBound - e.mapping.value.lowerBound + 1).max.toInt
 
         // Then we finaly generate the regular hardware
-        val logic = new tilelink.Ram(up.bus.p.node, bytes)
-        logic.io.up << up.bus
+//        val logic = new tilelink.Ram(up.bus.p.node, bytes)
+//        logic.io.up << up.bus
       }
     }
 


### PR DESCRIPTION
Mostly, it rework how the memory mapping is done through the tilelink fabric interconnect.

By the past the user could map things via an SizeMapping or a Default mapping (only one per node), so things were working by layer of decoder.

Now things work as a "fully integrated" address network. The user can still use SizeMapping if he wish, but now, the Default mapping (<<) can be used multiple time on one node, and act as a "map what ever you can though that connection"

Here is an example : 

```scala
  val main = Node()
  val peripheral = peripheralResetCtrl.cd on new Area {
    val busXlen = Node().forceDataWidth(main.param.xlen)
    busXlen << main // <--------- this

    val bus32 = Node().forceDataWidth(32)
    bus32 << main // <--------- and this

    val clint = new TilelinkClintFiber()
    clint.node at 0x10010000 of busXlen

    val plic = new TilelinkPlicFiber()
    plic.node at 0x10C00000 of bus32

    val uart = new TilelinkUartFiber()
    uart.node at 0x10001000 of bus32

    ...
  }  
```

To achieve this, the tilelink fabric decoder now use the MemoryConnection.getMemoryTransfers to get a global look (instead of the previously implemented local mapping)

Doc https://github.com/SpinalHDL/SpinalDoc-RTD/pull/242