### PR TITLE
Wishbone bus bugfixes

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/WishboneBusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/WishboneBusInterface.scala
@@ -53,6 +53,7 @@ case class WishboneBusInterface(
   if (bus.config.useERR) bus.ERR := readError
   override def readAddress() = bus.ADR
   override def writeAddress() = bus.ADR
+  override def wordAddressInc = bus.config.wordAddressInc(addressGranularityIfUnspecified = AddressGranularity.Byte)
 
   override def readHalt() = halted := True
   override def writeHalt() = halted := True

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/WishboneBusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/WishboneBusInterface.scala
@@ -52,7 +52,7 @@ case class WishboneBusInterface(
 
   if (bus.config.useERR) bus.ERR := readError
 
-  val byteAddress = bus.byteAddress(AddressGranularity.Byte)
+  val byteAddress = bus.byteAddress(AddressGranularity.BYTE)
   override def readAddress() = byteAddress
   override def writeAddress() = byteAddress
 

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/WishboneBusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/WishboneBusInterface.scala
@@ -51,9 +51,10 @@ case class WishboneBusInterface(
   val writeData = bus.DAT_MOSI
 
   if (bus.config.useERR) bus.ERR := readError
-  override def readAddress() = bus.ADR
-  override def writeAddress() = bus.ADR
-  override def wordAddressInc = bus.config.wordAddressInc(addressGranularityIfUnspecified = AddressGranularity.Byte)
+
+  val byteAddress = bus.byteAddress(AddressGranularity.Byte)
+  override def readAddress() = byteAddress
+  override def writeAddress() = byteAddress
 
   override def readHalt() = halted := True
   override def writeHalt() = halted := True

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusInterface.scala
@@ -18,10 +18,9 @@ object BusInterface {
   def apply(bus: AhbLite3, sizeMap: SizeMapping, regPre: String)(implicit moduleName: ClassName): BusIf = AhbLite3BusInterface(bus, sizeMap, regPre = regPre)(moduleName)
 
   def apply(bus: Wishbone, sizeMap: SizeMapping)(implicit moduleName: ClassName): BusIf = WishboneBusInterface(bus, sizeMap)(moduleName)
-  def apply(bus: Wishbone, sizeMap: SizeMapping, selID: Int)(implicit moduleName: ClassName): BusIf = WishboneBusInterface(bus, sizeMap, selID)(moduleName)
-  def apply(bus: Wishbone, sizeMap: SizeMapping, selID: Int, regPre: String)(implicit moduleName: ClassName): BusIf = WishboneBusInterface(bus, sizeMap, selID, regPre = regPre)(moduleName)
-  def apply(bus: Wishbone, sizeMap: SizeMapping, selID: Int, readSync: Boolean)(implicit moduleName: ClassName): BusIf = WishboneBusInterface(bus, sizeMap, selID, readSync)(moduleName)
-  def apply(bus: Wishbone, sizeMap: SizeMapping, selID: Int, readSync: Boolean, regPre: String)(implicit moduleName: ClassName): BusIf = WishboneBusInterface(bus, sizeMap, selID, readSync, regPre = regPre)(moduleName)
+  def apply(bus: Wishbone, sizeMap: SizeMapping, regPre: String)(implicit moduleName: ClassName): BusIf = WishboneBusInterface(bus, sizeMap, regPre = regPre)(moduleName)
+  def apply(bus: Wishbone, sizeMap: SizeMapping, readSync: Boolean)(implicit moduleName: ClassName): BusIf = WishboneBusInterface(bus, sizeMap, readSync)(moduleName)
+  def apply(bus: Wishbone, sizeMap: SizeMapping, readSync: Boolean, regPre: String)(implicit moduleName: ClassName): BusIf = WishboneBusInterface(bus, sizeMap, readSync, regPre = regPre)(moduleName)
 
   def apply(bus: AxiLite4, sizeMap: SizeMapping)(implicit moduleName: ClassName): BusIf = AxiLite4BusInterface(bus, sizeMap)(moduleName)
   def apply(bus: AxiLite4, sizeMap: SizeMapping, regPre: String)(implicit moduleName: ClassName): BusIf = AxiLite4BusInterface(bus, sizeMap, regPre)(moduleName)

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
@@ -5,20 +5,20 @@ import spinal.lib._
 
 object AddressGranularity extends Enumeration {
   type AddressGranularity = Value
-  @deprecated("This option will be REMOVED in future versions, and the default will be Word granular. It exists " +
+  @scala.deprecated("This option will be REMOVED in future versions, and the default will be Word granular. It exists " +
     "to prevent changing library behavior for existing code.")
-  val Unspecified = Value
+  val UNSPECIFIED = Value
 
   /**
    * Word granular addressing increments by one per word. This is the standard defined behavior of the bus.
    */
-  val Word = Value
+  val WORD = Value
 
   /**
    * Byte granular addressing increments by one per byte. This is not in adherence with the wishbone standard but is
    * a commonly encountered configuration with external IP.
    */
-  val Byte = Value
+  val BYTE = Value
 }
 
 
@@ -54,7 +54,7 @@ case class WishboneConfig(
   val tgcWidth : Int = 0,
   val tgdWidth : Int = 0,
   val useBTE : Boolean = false,
-  private val addressGranularity : AddressGranularity.AddressGranularity = AddressGranularity.Unspecified
+  private val addressGranularity : AddressGranularity.AddressGranularity = AddressGranularity.UNSPECIFIED
 ){
   def useTGA = tgaWidth > 0
   def useTGC = tgcWidth > 0
@@ -65,11 +65,11 @@ case class WishboneConfig(
 
   def pipelined : WishboneConfig = this.copy(useSTALL = true)
 
-  def wordAddressInc(addressGranularityIfUnspecified : AddressGranularity.AddressGranularity = AddressGranularity.Unspecified): Int = {
-    val effectiveAddressGranularity = if (addressGranularity == AddressGranularity.Unspecified) addressGranularityIfUnspecified else addressGranularity
-    require(effectiveAddressGranularity != AddressGranularity.Unspecified, "If the bus has not been configured with an address granularity, one must be provided to wordAddressInc")
+  def wordAddressInc(addressGranularityIfUnspecified : AddressGranularity.AddressGranularity = AddressGranularity.UNSPECIFIED): Int = {
+    val effectiveAddressGranularity = if (addressGranularity == AddressGranularity.UNSPECIFIED) addressGranularityIfUnspecified else addressGranularity
+    require(effectiveAddressGranularity != AddressGranularity.UNSPECIFIED, "If the bus has not been configured with an address granularity, one must be provided to wordAddressInc")
     effectiveAddressGranularity match {
-      case AddressGranularity.Byte => dataWidth / 8
+      case AddressGranularity.BYTE => dataWidth / 8
       case _ => 1
     }
   }
@@ -268,7 +268,7 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
   def doWrite : Bool    = doSend &&  WE
   def doRead  : Bool    = doSend && !WE
 
-  def byteAddress(addressGranularityIfUnspecified : AddressGranularity.AddressGranularity = AddressGranularity.Unspecified) : UInt = {
+  def byteAddress(addressGranularityIfUnspecified : AddressGranularity.AddressGranularity = AddressGranularity.UNSPECIFIED) : UInt = {
     ADR << log2Up((config.dataWidth / 8) / config.wordAddressInc(addressGranularityIfUnspecified))
   }
 }

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
@@ -52,8 +52,9 @@ case class WishboneConfig(
 
   def pipelined : WishboneConfig = this.copy(useSTALL = true)
 
-  def wordAddressInc(addressGranularityIfUnspecified : AddressGranularity.AddressGranularity): Int = {
+  def wordAddressInc(addressGranularityIfUnspecified : AddressGranularity.AddressGranularity = AddressGranularity.Unspecified): Int = {
     val effectiveAddressGranularity = if (addressGranularity == AddressGranularity.Unspecified) addressGranularityIfUnspecified else addressGranularity
+    require(effectiveAddressGranularity != AddressGranularity.Unspecified, "If the bus has not been configured with an address granularity, one must be provided to wordAddressInc")
     effectiveAddressGranularity match {
       case AddressGranularity.Byte => dataWidth / 8
       case _ => 1

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
@@ -5,7 +5,20 @@ import spinal.lib._
 
 object AddressGranularity extends Enumeration {
   type AddressGranularity = Value
-  val Unspecified, Byte, Word = Value
+  @deprecated("This option will be REMOVED in future versions, and the default will be Word granular. It exists " +
+    "to prevent changing library behavior for existing code.")
+  val Unspecified = Value
+
+  /**
+   * Word granular addressing increments by one per word. This is the standard defined behavior of the bus.
+   */
+  val Word = Value
+
+  /**
+   * Byte granular addressing increments by one per byte. This is not in adherence with the wishbone standard but is
+   * a commonly encountered configuration with external IP.
+   */
+  val Byte = Value
 }
 
 
@@ -41,7 +54,7 @@ case class WishboneConfig(
   val tgcWidth : Int = 0,
   val tgdWidth : Int = 0,
   val useBTE : Boolean = false,
-  val addressGranularity : AddressGranularity.AddressGranularity = AddressGranularity.Unspecified
+  private val addressGranularity : AddressGranularity.AddressGranularity = AddressGranularity.Unspecified
 ){
   def useTGA = tgaWidth > 0
   def useTGC = tgcWidth > 0

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
@@ -3,6 +3,12 @@ package spinal.lib.bus.wishbone
 import spinal.core._
 import spinal.lib._
 
+object AddressGranularity extends Enumeration {
+  type AddressGranularity = Value
+  val Unspecified, Byte, Word = Value
+}
+
+
 /** This class is used for configuring the Wishbone class
   * @param addressWidth size in bits of the address line
   * @param dataWidth size in bits of the data line
@@ -16,6 +22,7 @@ import spinal.lib._
   * @param tgcWidth size in bits of the tag cycle line, deafult to 0 (disabled)
   * @param tgdWidth size in bits of the tag data line, deafult to 0 (disabled)
   * @param useBTE activate the Burst Type Extension, default to false (disabled)
+  * @param addressGranularity This specifies the address granularity for the bus.
   * @example {{{
   * val wishboneBusConf = new WishboneConfig(32,8).withCycleTag(8).withDataTag(8)
   * val wishboneBus = new Wishbone(wishboneBusConf)
@@ -33,7 +40,8 @@ case class WishboneConfig(
   val tgaWidth : Int = 0,
   val tgcWidth : Int = 0,
   val tgdWidth : Int = 0,
-  val useBTE : Boolean = false
+  val useBTE : Boolean = false,
+  val addressGranularity : AddressGranularity.AddressGranularity = AddressGranularity.Unspecified
 ){
   def useTGA = tgaWidth > 0
   def useTGC = tgcWidth > 0
@@ -43,6 +51,14 @@ case class WishboneConfig(
   def isPipelined = useSTALL
 
   def pipelined : WishboneConfig = this.copy(useSTALL = true)
+
+  def wordAddressInc(addressGranularityIfUnspecified : AddressGranularity.AddressGranularity): Int = {
+    val effectiveAddressGranularity = if (addressGranularity == AddressGranularity.Unspecified) addressGranularityIfUnspecified else addressGranularity
+    effectiveAddressGranularity match {
+      case AddressGranularity.Byte => dataWidth / 8
+      case _ => 1
+    }
+  }
 
   def withDataTag(size : Int)    : WishboneConfig = this.copy(tgdWidth = size)
   def withAddressTag(size : Int) : WishboneConfig = this.copy(tgaWidth = size)

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
@@ -255,6 +255,9 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
   def doWrite : Bool    = doSend &&  WE
   def doRead  : Bool    = doSend && !WE
 
+  def byteAddress(addressGranularityIfUnspecified : AddressGranularity.AddressGranularity = AddressGranularity.Unspecified) : UInt = {
+    ADR << log2Up((config.dataWidth / 8) / config.wordAddressInc(addressGranularityIfUnspecified))
+  }
 }
 
 object Wishbone{

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneArbiter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneArbiter.scala
@@ -40,47 +40,52 @@ class WishboneArbiter(config : WishboneConfig, inputCount : Int) extends Compone
     val output = master(Wishbone(config))
   }
 
-  //Permanently connect DAT_MISO and TGD_MISO (if used) for save on logic usage
-  io.inputs.map{ in =>
-    in.DAT_MISO := io.output.DAT_MISO
-    Wishbone.driveWeak(io.output.TGD_MISO, in.TGD_MISO, null, false, false)
+  if(inputCount == 1) {
+    io.inputs(0) <> io.output
+  } else {
+    //Permanently connect DAT_MISO and TGD_MISO (if used) for save on logic usage
+    io.inputs.map{ in =>
+      in.DAT_MISO := io.output.DAT_MISO
+      Wishbone.driveWeak(io.output.TGD_MISO, in.TGD_MISO, null, false, false)
+    }
+
+    //Implement a round robin algorithm.
+    //The channel will remain selected is either LOCK or CYC are equals to true
+    //and pass to the next channel after the master clears CYC and LOCK
+    //this output a One Hot encoded vector/bit array
+    val requests =  if(config.useLOCK)  Vec(io.inputs.map(func => func.CYC && !func.LOCK))
+                    else                Vec(io.inputs.map(func => func.CYC))
+
+    val maskLock : Vec[Bool] = RegInit(B(1,inputCount bits).asBools)
+    val roundRobin : Vec[Bool] = OHMasking.roundRobin(requests, maskLock)
+    val selector: Vec[Bool] = RegNext(roundRobin.orR ? roundRobin | maskLock,
+                                      B(1, inputCount bits).asBools)
+
+    when (roundRobin.orR) {
+      maskLock := roundRobin
+    }
+
+    //Implement the selector for the output slave signals
+    //This is ok becouse the signal is assumed as oneHotEncoded
+                        (io.inputs.map(_.ACK),   selector).zipped.foreach(_ := _ && io.output.ACK)
+    if(config.useSTALL) (io.inputs.map(_.STALL), selector).zipped.foreach(_ := _ && io.output.STALL)
+    if(config.useERR)   (io.inputs.map(_.ERR),   selector).zipped.foreach(_ := _ && io.output.ERR)
+    if(config.useRTY)   (io.inputs.map(_.RTY),   selector).zipped.foreach(_ := _ && io.output.RTY)
+
+    //Implement the selector for the input slave signals
+    io.output.CYC       := MuxOH(selector, Vec(io.inputs.map(_.CYC)))
+    io.output.STB       := MuxOH(selector, Vec(io.inputs.map(_.STB)))
+    io.output.WE        := MuxOH(selector, Vec(io.inputs.map(_.WE)))
+    io.output.ADR       := MuxOH(selector, Vec(io.inputs.map(_.ADR)))
+    io.output.DAT_MOSI  := MuxOH(selector, Vec(io.inputs.map(_.DAT_MOSI)))
+
+    if(config.useSEL)   io.output.SEL       := MuxOH(selector, Vec(io.inputs.map(_.SEL)))
+    if(config.useLOCK)  io.output.LOCK      := MuxOH(selector, Vec(io.inputs.map(_.LOCK)))
+    if(config.useCTI)   io.output.CTI       := MuxOH(selector, Vec(io.inputs.map(_.CTI)))
+    if(config.useTGD)   io.output.TGD_MOSI  := MuxOH(selector, Vec(io.inputs.map(_.TGD_MOSI)))
+    if(config.useTGA)   io.output.TGA       := MuxOH(selector, Vec(io.inputs.map(_.TGA)))
+    if(config.useTGC)   io.output.TGC       := MuxOH(selector, Vec(io.inputs.map(_.TGC)))
+    if(config.useBTE)   io.output.BTE       := MuxOH(selector, Vec(io.inputs.map(_.BTE)))
+
   }
-
-  //Implement a round robin algorithm.
-  //The channel will remain selected is either LOCK or CYC are equals to true
-  //and pass to the next channel after the master clears CYC and LOCK
-  //this output a One Hot encoded vector/bit array
-  val requests =  if(config.useLOCK)  Vec(io.inputs.map(func => func.CYC && !func.LOCK))
-                  else                Vec(io.inputs.map(func => func.CYC))
-
-  val maskLock : Vec[Bool] = RegInit(B(1,inputCount bits).asBools)
-  val roundRobin : Vec[Bool] = OHMasking.roundRobin(requests, maskLock)
-  val selector: Vec[Bool] = RegNext(roundRobin.orR ? roundRobin | maskLock,
-                                    B(1, inputCount bits).asBools)
-
-  when (roundRobin.orR) {
-    maskLock := roundRobin
-  }
-
-  //Implement the selector for the output slave signals
-  //This is ok becouse the signal is assumed as oneHotEncoded
-                      (io.inputs.map(_.ACK),   selector).zipped.foreach(_ := _ && io.output.ACK)
-  if(config.useSTALL) (io.inputs.map(_.STALL), selector).zipped.foreach(_ := _ && io.output.STALL)
-  if(config.useERR)   (io.inputs.map(_.ERR),   selector).zipped.foreach(_ := _ && io.output.ERR)
-  if(config.useRTY)   (io.inputs.map(_.RTY),   selector).zipped.foreach(_ := _ && io.output.RTY)
-
-  //Implement the selector for the input slave signals
-  io.output.CYC       := MuxOH(selector, Vec(io.inputs.map(_.CYC)))
-  io.output.STB       := MuxOH(selector, Vec(io.inputs.map(_.STB)))
-  io.output.WE        := MuxOH(selector, Vec(io.inputs.map(_.WE)))
-  io.output.ADR       := MuxOH(selector, Vec(io.inputs.map(_.ADR)))
-  io.output.DAT_MOSI  := MuxOH(selector, Vec(io.inputs.map(_.DAT_MOSI)))
-
-  if(config.useSEL)   io.output.SEL       := MuxOH(selector, Vec(io.inputs.map(_.SEL)))
-  if(config.useLOCK)  io.output.LOCK      := MuxOH(selector, Vec(io.inputs.map(_.LOCK)))
-  if(config.useCTI)   io.output.CTI       := MuxOH(selector, Vec(io.inputs.map(_.CTI)))
-  if(config.useTGD)   io.output.TGD_MOSI  := MuxOH(selector, Vec(io.inputs.map(_.TGD_MOSI)))
-  if(config.useTGA)   io.output.TGA       := MuxOH(selector, Vec(io.inputs.map(_.TGA)))
-  if(config.useTGC)   io.output.TGC       := MuxOH(selector, Vec(io.inputs.map(_.TGC)))
-  if(config.useBTE)   io.output.BTE       := MuxOH(selector, Vec(io.inputs.map(_.BTE)))
 }

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
@@ -13,14 +13,14 @@ object WishboneDecoder{
   * @param decodings it will use for configuring the partial address decoder
   * @return a [[spinal.lib.bus.wishbone.WishboneDecoder]] instance
   */
-  def apply(config: WishboneConfig, decodings: Seq[SizeMapping]) = new WishboneDecoder(config,decodings)
+  def apply(config: WishboneConfig, decodings: Seq[AddressMapping]) = new WishboneDecoder(config,decodings)
 
   /** Create an istance of WishboneDecoder, and autocconect all input/outputs
     * @param master connect the input to this master interface, the [[spinal.lib.bus.wishbone.Wishbone.config]] will be used for all input/output
     * @param slaves connect the ouput to the slaves, with the correct address
     * @return a [[spinal.lib.bus.wishbone.WishboneDecoder]] instance with all the input and output connected automatically
     */
-  def apply(master: Wishbone, slaves: Seq[(Wishbone, SizeMapping)]): WishboneDecoder = {
+  def apply(master: Wishbone, slaves: Seq[(Wishbone, AddressMapping)]): WishboneDecoder = {
     val decoder = new WishboneDecoder(master.config, slaves.map(_._2))
     decoder.io.input <> master
     (slaves.map(_._1), decoder.io.outputs).zipped.map(_ <> _)
@@ -32,7 +32,7 @@ object WishboneDecoder{
   * @param config it will use for configuring all the input/output wishbone port
   * @param decodings it will use for configuring the partial address decoder
   */
-class WishboneDecoder(config : WishboneConfig, decodings : Seq[SizeMapping]) extends Component {
+class WishboneDecoder(config : WishboneConfig, decodings : Seq[AddressMapping]) extends Component {
   val io = new Bundle {
     val input = slave(Wishbone(config))
     val outputs = Vec(master(Wishbone(config)),decodings.size)

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
@@ -55,15 +55,19 @@ class WishboneDecoder(config : WishboneConfig, decodings : Seq[AddressMapping]) 
 
   // the selector will use the decodings list to select the right slave based on the address line
   val selector = Vec(decodings.map(_.hit(io.input.ADR) && io.input.CYC))
+  val selectorIndex = OHToUInt(selector)
 
   // Generate the CYC sygnal for the selected slave
   (io.outputs.map(_.CYC), selector).zipped.foreach(_ := _)
-  //Implementing the multiplexer logic, it thakes the one Hot bit vector/bit array as input
-  io.input.ACK      := MuxOH(selector, Vec(io.outputs.map(_.ACK)))
-  io.input.DAT_MISO := MuxOH(selector, Vec(io.outputs.map(_.DAT_MISO)))
 
-  if(config.useSTALL) io.input.STALL    := MuxOH(selector, Vec(io.outputs.map(_.STALL)))
-  if(config.useERR)   io.input.ERR      := MuxOH(selector, Vec(io.outputs.map(_.ERR)))
-  if(config.useRTY)   io.input.RTY      := MuxOH(selector, Vec(io.outputs.map(_.RTY)))
-  if(config.useTGD)   io.input.TGD_MISO := MuxOH(selector, Vec(io.outputs.map(_.TGD_MISO)))
+  //Implementing the multiplexer logic, it thakes the one Hot bit vector/bit array as input
+  val selectedOutput = io.outputs(selectorIndex)
+
+  io.input.ACK := selectedOutput.ACK
+  io.input.DAT_MISO := selectedOutput.DAT_MISO
+
+  if(config.useSTALL) io.input.STALL    := selectedOutput.STALL
+  if(config.useERR)   io.input.ERR      := selectedOutput.ERR
+  if(config.useRTY)   io.input.RTY      := selectedOutput.RTY
+  if(config.useTGD)   io.input.TGD_MISO := selectedOutput.TGD_MISO
 }

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneIntercon.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneIntercon.scala
@@ -113,11 +113,16 @@ case class WishboneInterconFactory(){
     for((bus, model) <- slaves){
       val busConnections = connections.filter(_.s == bus)
       val busMasters = busConnections.map(c => masters(c.m))
-      val arbiter = new WishboneArbiter(bus.config, busMasters.size)
-      arbiter.setCompositeName(bus, "arbiter")
-      model.connector(arbiter.io.output, bus)
-      for((connection, arbiterInput) <- (busConnections, arbiter.io.inputs).zipped) {
-        connectionsOutput(connection) = arbiterInput
+
+      if (busMasters.size != 1) {
+        val arbiter = new WishboneArbiter(bus.config, busMasters.size)
+        arbiter.setCompositeName(bus, "arbiter")
+        model.connector(arbiter.io.output, bus)
+        for ((connection, arbiterInput) <- (busConnections, arbiter.io.inputs).zipped) {
+          connectionsOutput(connection) = arbiterInput
+        }
+      } else {
+        connectionsOutput(busConnections(0)) = bus
       }
     }
 

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneIntercon.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneIntercon.scala
@@ -12,7 +12,7 @@ object WishboneConnectors{
 
 case class WishboneInterconFactory(){
   case class MasterModel(var connector : (Wishbone,Wishbone) => Unit = WishboneConnectors.direct)
-  case class SlaveModel(mapping : SizeMapping, var connector : (Wishbone,Wishbone) => Unit = WishboneConnectors.direct, var transactionLock : Boolean = true)
+  case class SlaveModel(mapping : AddressMapping, var connector : (Wishbone,Wishbone) => Unit = WishboneConnectors.direct, var transactionLock : Boolean = true)
   case class ConnectionModel(m : Wishbone, s : Wishbone, var connector : (Wishbone,Wishbone) => Unit = WishboneConnectors.direct)
 
 
@@ -46,9 +46,9 @@ case class WishboneInterconFactory(){
 
   /** add a slave to the intercon, and specify its address space
     * @param bus the slave device
-    * @param mapping the address defined via [[spinal.lib.bus.misc.SizeMapping]]
+    * @param mapping the address defined via [[spinal.lib.bus.misc.AddressMapping]]
     */
-  def addSlave(bus: Wishbone,mapping: SizeMapping) : this.type = {
+  def addSlave(bus: Wishbone,mapping: AddressMapping) : this.type = {
     slaves(bus) = SlaveModel(mapping)
     this
   }
@@ -65,7 +65,7 @@ case class WishboneInterconFactory(){
     * )
     * }}}
     */
-  def addSlaves(orders : (Wishbone,SizeMapping)*) : this.type = {
+  def addSlaves(orders : (Wishbone,AddressMapping)*) : this.type = {
     orders.foreach(order => addSlave(order._1,order._2))
     this
   }

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
@@ -18,7 +18,7 @@ object WishboneSlaveFactory {
 
 /** This is the slave facotory fot the wishbone bus
   * @param bus the wishbone bus istance that will connect with the module
-  * @param reg_fedback if set to false, the slave will acknoledge as soon as possible otherwise will wait the next clock cycle(default)
+  * @param reg_fedback if set to false, the slave will acknowledge as soon as possible otherwise will wait the next clock cycle(default)
   */
 class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends BusSlaveFactoryDelayed{
   bus.DAT_MISO := 0
@@ -30,13 +30,13 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
   val doRead = bus.doRead.allowPruning()
 
   if(!reg_fedback){
-    bus.ACK := bus.STB && bus.CYC                 //Acknoledge as fast as possible
+    bus.ACK := bus.STB && bus.CYC                 //Acknowledge as fast as possible
   } else if(bus.config.isPipelined){
     val pip_reg = RegNext(bus.STB) init(False)
-    bus.ACK := pip_reg || (bus.STALL && bus.CYC)  //Pipelined: Acknoledge at the next clock cycle
+    bus.ACK := pip_reg || (bus.STALL && bus.CYC)  //Pipelined: Acknowledge at the next clock cycle
   } else {
     val reg_reg = RegNext(bus.STB && bus.CYC) init(False)
-    bus.ACK := reg_reg && bus.STB                 //Classic: Acknoledge at the next clock cycle
+    bus.ACK := reg_reg && bus.STB                 //Classic: Acknowledge at the next clock cycle
   }
 
   val byteAddress = bus.ADR << log2Up(bus.config.dataWidth/8)

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
@@ -39,7 +39,7 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
     bus.ACK := reg_reg && bus.STB                 //Classic: Acknowledge at the next clock cycle
   }
 
-  val byteAddress = bus.ADR << (log2Up(bus.config.dataWidth / 8) - log2Up(wordAddressInc))
+  val byteAddress = bus.byteAddress(AddressGranularity.Word)
 
   override def readAddress()  = byteAddress
   override def writeAddress() = byteAddress
@@ -48,7 +48,7 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
   override def writeHalt() = bus.ACK := False
 
   override def busDataWidth = bus.config.dataWidth
-  override def wordAddressInc = bus.config.wordAddressInc(addressGranularityIfUnspecified = AddressGranularity.Word)
+
   override def writeByteEnable() = bus.SEL
 
   override def build(): Unit = {

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
@@ -39,7 +39,7 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
     bus.ACK := reg_reg && bus.STB                 //Classic: Acknowledge at the next clock cycle
   }
 
-  val byteAddress = bus.ADR << log2Up(bus.config.dataWidth/8)
+  val byteAddress = bus.ADR << (log2Up(bus.config.dataWidth / 8) - log2Up(wordAddressInc))
 
   override def readAddress()  = byteAddress
   override def writeAddress() = byteAddress
@@ -48,7 +48,7 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
   override def writeHalt() = bus.ACK := False
 
   override def busDataWidth = bus.config.dataWidth
-  override def wordAddressInc = busDataWidth / 8
+  override def wordAddressInc = bus.config.wordAddressInc(addressGranularityIfUnspecified = AddressGranularity.Word)
   override def writeByteEnable() = bus.SEL
 
   override def build(): Unit = {

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
@@ -39,7 +39,7 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
     bus.ACK := reg_reg && bus.STB                 //Classic: Acknowledge at the next clock cycle
   }
 
-  val byteAddress = bus.byteAddress(AddressGranularity.Word)
+  val byteAddress = bus.byteAddress(AddressGranularity.WORD)
 
   override def readAddress()  = byteAddress
   override def writeAddress() = byteAddress

--- a/lib/src/main/scala/spinal/lib/sim/bus/wishbone/WishboneDriver.scala
+++ b/lib/src/main/scala/spinal/lib/sim/bus/wishbone/WishboneDriver.scala
@@ -59,7 +59,7 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
         counter = counter + 1
       }
     }
-    transactions.foreach(sendAsMaster(_, true))
+    transactions.foreach(sendAsMaster(_, we))
     bus.STB #= false
     ackCounter.join()
     bus.CYC #= false

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneBusInterfaceTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneBusInterfaceTester.scala
@@ -45,7 +45,7 @@ class SpinalSimWishboneBusInterfaceTester extends SpinalAnyFunSuite{
 
       dut.clockDomain.waitSampling()
 
-      val wordInc = conf.wordAddressInc(AddressGranularity.Byte)
+      val wordInc = conf.wordAddressInc(AddressGranularity.BYTE)
 
       val sco = ScoreboardInOrder[WishboneTransaction]()
       for(ref_output <- List(
@@ -76,12 +76,12 @@ class SpinalSimWishboneBusInterfaceTester extends SpinalAnyFunSuite{
   }
 
   test("sync_byte"){
-    val conf = WishboneConfig(32,32, addressGranularity = AddressGranularity.Byte)
+    val conf = WishboneConfig(32,32, addressGranularity = AddressGranularity.BYTE)
     testBus(conf, description="sync_byte")
   }
 
   test("sync_word"){
-    val conf = WishboneConfig(32,32, addressGranularity = AddressGranularity.Word)
+    val conf = WishboneConfig(32,32, addressGranularity = AddressGranularity.WORD)
     testBus(conf, description="sync_word")
   }
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneBusInterfaceTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneBusInterfaceTester.scala
@@ -45,11 +45,13 @@ class SpinalSimWishboneBusInterfaceTester extends SpinalAnyFunSuite{
 
       dut.clockDomain.waitSampling()
 
+      val wordInc = conf.wordAddressInc(AddressGranularity.Byte)
+
       val sco = ScoreboardInOrder[WishboneTransaction]()
       for(ref_output <- List(
-        WishboneTransaction(0, 0x12345678L), WishboneTransaction(4, 1),
-        WishboneTransaction(0, 0), WishboneTransaction(4, 0),
-        WishboneTransaction(0, 0x12345678L), WishboneTransaction(4, 2)
+        WishboneTransaction(0, 0x12345678L), WishboneTransaction(1 * wordInc, 1),
+        WishboneTransaction(0, 0), WishboneTransaction(1 * wordInc, 0),
+        WishboneTransaction(0, 0x12345678L), WishboneTransaction(1 * wordInc, 2)
       )) {
         sco.pushRef(ref_output)
       }
@@ -59,9 +61,9 @@ class SpinalSimWishboneBusInterfaceTester extends SpinalAnyFunSuite{
       }
 
       val dri = new WishboneDriver(dut.io.bus, dut.clockDomain)
-      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0), WishboneTransaction(4)), we = false)
-      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0, 100), WishboneTransaction(4, 2)), we = true)
-      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0), WishboneTransaction(4)), we = false)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0), WishboneTransaction(1 * wordInc)), we = false)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0, 100), WishboneTransaction(1 * wordInc, 2)), we = true)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0), WishboneTransaction(1 * wordInc)), we = false)
 
       sco.checkEmptyness()
     }
@@ -71,6 +73,16 @@ class SpinalSimWishboneBusInterfaceTester extends SpinalAnyFunSuite{
   test("sync"){
     val conf = WishboneConfig(32,32)
     testBus(conf, description="sync")
+  }
+
+  test("sync_byte"){
+    val conf = WishboneConfig(32,32, addressGranularity = AddressGranularity.Byte)
+    testBus(conf, description="sync_byte")
+  }
+
+  test("sync_word"){
+    val conf = WishboneConfig(32,32, addressGranularity = AddressGranularity.Word)
+    testBus(conf, description="sync_word")
   }
 
   test("async"){

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneBusInterfaceTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneBusInterfaceTester.scala
@@ -1,0 +1,78 @@
+package spinal.tester.scalatest
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.misc.SizeMapping
+import spinal.lib.bus.regif.{AccessType, WishboneBusInterface}
+import spinal.lib.bus.wishbone._
+import spinal.lib.sim._
+import spinal.lib.wishbone.sim._
+
+import scala.language.postfixOps
+import scala.util.Random
+
+class WishboneSimpleBusInterface( config : WishboneConfig,
+                                  readSync: Boolean = true) extends Component{
+  val io = new Bundle{
+    val bus = slave(Wishbone(config))
+  }
+
+  val busIf = WishboneBusInterface(io.bus, SizeMapping(0, 32), readSync = readSync)
+  val id = busIf.newReg("Register1").field(UInt(32 bits), AccessType.RO, "ID of registers")
+  val value = busIf.newReg("Register2").field(UInt(32 bits), AccessType.RW, 1, "RW value")
+  id := 0x12345678L
+
+  if(!readSync) {
+    assert(io.bus.isRead === (!io.bus.WE && io.bus.ACK), "Bus interface is configured for async operation; ACK should be wired to CYC && STB && !WE")
+  }
+}
+
+class SpinalSimWishboneBusInterfaceTester extends SpinalAnyFunSuite{
+  def testBus(conf:WishboneConfig, readSync: Boolean = true, description : String = ""): Unit = {
+    val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneSimpleBusInterface(conf, readSync))
+    fixture.doSim(description){ dut =>
+      dut.clockDomain.forkStimulus(period=10)
+      SimTimeout(1000*20*100)
+
+      dut.io.bus.CYC #= false
+      dut.io.bus.STB #= false
+      dut.io.bus.WE #= false
+      dut.io.bus.ADR #= 0
+      dut.io.bus.DAT_MOSI #= 0
+      if(dut.io.bus.config.useLOCK) dut.io.bus.LOCK #= false
+      if(dut.io.bus.config.isPipelined) dut.io.bus.STALL #= false
+
+      dut.clockDomain.waitSampling()
+
+      val sco = ScoreboardInOrder[WishboneTransaction]()
+      val monitor = WishboneMonitor(dut.io.bus, dut.clockDomain){ bus =>
+        sco.pushRef(WishboneTransaction.sampleAsMaster(bus))
+      }
+
+      val dri = new WishboneDriver(dut.io.bus, dut.clockDomain)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0), WishboneTransaction(4)), we = false)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0, 100), WishboneTransaction(4, 2)), we = true)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0), WishboneTransaction(4)), we = false)
+
+      val expectedOutput = List(
+        WishboneTransaction(0, 0x12345678L), WishboneTransaction(4, 1),
+        WishboneTransaction(0, 0), WishboneTransaction(4, 0),
+        WishboneTransaction(0, 0x12345678L), WishboneTransaction(4, 2)
+      )
+      print(sco.ref)
+      assert(sco.ref.toList == expectedOutput)
+    }
+  }
+
+
+  test("sync"){
+    val conf = WishboneConfig(32,32)
+    testBus(conf, description="sync")
+  }
+
+  test("async"){
+    val conf = WishboneConfig(32,32)
+    testBus(conf,readSync = false, description="async")
+  }
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSimTester.scala
@@ -37,7 +37,7 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
      dut.io.busmaster.ADR #= 0
      dut.io.busmaster.DAT_MOSI #= 0
      dut.io.busslave.ACK #= false
-     dut.io.busslave.DAT_MOSI #= 0
+     dut.io.busslave.DAT_MISO #= 0
      dut.clockDomain.waitSampling(10)
      SimTimeout(500 * 1000)
      val sco = ScoreboardInOrder[WishboneTransaction]()
@@ -48,12 +48,12 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
        WishboneTransaction(BigInt(Random.nextInt(200)),BigInt(Random.nextInt(200)))
       }
 
-     val mon1 = WishboneMonitor(dut.io.busmaster, dut.clockDomain){ bus =>
-       sco.pushRef(WishboneTransaction.sampleAsMaster(bus))
+     WishboneMonitor(dut.io.busmaster, dut.clockDomain){ bus =>
+       sco.pushRef(WishboneTransaction.sampleAsSlave(bus))
      }
 
-     val mon2 = WishboneMonitor(dut.io.busslave, dut.clockDomain){ bus =>
-       sco.pushDut(WishboneTransaction.sampleAsMaster(bus))
+     WishboneMonitor(dut.io.busslave, dut.clockDomain){ bus =>
+       sco.pushDut(WishboneTransaction.sampleAsSlave(bus))
      }
 
      dri2.slaveSink()
@@ -63,7 +63,7 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
        val ddd = fork{
          while(!seq.isEmpty){
            val tran = seq.nextTransaction
-           dri.drive(tran ,true)
+           dri.drive(tran, we = true)
            dut.clockDomain.waitSampling(1)
          }
        }
@@ -82,7 +82,7 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
      dut.io.busmaster.ADR #= 0
      dut.io.busmaster.DAT_MOSI #= 0
      dut.io.busslave.ACK #= false
-     dut.io.busslave.DAT_MOSI #= 0
+     dut.io.busslave.DAT_MISO #= 0
      dut.clockDomain.waitSampling(10)
      SimTimeout(10000 * 1000)
       val sco = ScoreboardInOrder[WishboneTransaction]()
@@ -94,12 +94,12 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
            yield WishboneTransaction(BigInt(Random.nextInt(200)),BigInt(Random.nextInt(200)))
       }
 
-     val mon1 = WishboneMonitor(dut.io.busmaster, dut.clockDomain){ bus =>
-       sco.pushRef(WishboneTransaction.sampleAsMaster(bus))
+     WishboneMonitor(dut.io.busmaster, dut.clockDomain){ bus =>
+       sco.pushRef(WishboneTransaction.sampleAsSlave(bus))
      }
 
-     val mon2 = WishboneMonitor(dut.io.busslave, dut.clockDomain){ bus =>
-       sco.pushDut(WishboneTransaction.sampleAsMaster(bus))
+     WishboneMonitor(dut.io.busslave, dut.clockDomain){ bus =>
+       sco.pushDut(WishboneTransaction.sampleAsSlave(bus))
      }
 
      dri2.slaveSink()
@@ -109,7 +109,7 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
        val ddd = fork{
          while(!seq.isEmpty){
            val tran = seq.nextTransaction
-           dri.drive(tran ,true)
+           dri.drive(tran, we = true)
            dut.clockDomain.waitSampling(1)
          }
        }
@@ -129,7 +129,7 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
       dut.io.busmaster.ADR #= 0
       dut.io.busmaster.DAT_MOSI #= 0
       dut.io.busslave.ACK #= false
-      dut.io.busslave.DAT_MOSI #= 0
+      dut.io.busslave.DAT_MISO #= 0
       dut.clockDomain.waitSampling(10)
 
       SimTimeout(1000 * 1000)
@@ -141,11 +141,11 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
         WishboneTransaction(BigInt(Random.nextInt(200)),BigInt(Random.nextInt(200)))
        }
 
-      val mon1 = WishboneMonitor(dut.io.busmaster, dut.clockDomain){ bus =>
+      WishboneMonitor(dut.io.busmaster, dut.clockDomain){ bus =>
         sco.pushRef(WishboneTransaction.sampleAsMaster(bus))
       }
 
-      val mon2 = WishboneMonitor(dut.io.busslave, dut.clockDomain){ bus =>
+      WishboneMonitor(dut.io.busslave, dut.clockDomain){ bus =>
         sco.pushDut(WishboneTransaction.sampleAsMaster(bus))
       }
 
@@ -176,7 +176,7 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
       dut.io.busmaster.ADR #= 0
       dut.io.busmaster.DAT_MOSI #= 0
       dut.io.busslave.ACK #= false
-      dut.io.busslave.DAT_MOSI #= 0
+      dut.io.busslave.DAT_MISO #= 0
       dut.clockDomain.waitSampling(10)
 
       SimTimeout(1000 * 1000000)
@@ -189,12 +189,12 @@ class SpinalSimWishboneSimTester extends SpinalAnyFunSuite{
            yield WishboneTransaction(BigInt(Random.nextInt(200)),BigInt(Random.nextInt(200)))
        }
 
-      val mon1 = WishboneMonitor(dut.io.busmaster, dut.clockDomain){ bus =>
-        sco.pushRef(WishboneTransaction.sampleAsMaster(bus))
+      WishboneMonitor(dut.io.busmaster, dut.clockDomain){ bus =>
+        sco.pushRef(WishboneTransaction.sampleAsSlave(bus))
       }
 
-      val mon2 = WishboneMonitor(dut.io.busslave, dut.clockDomain){ bus =>
-        sco.pushDut(WishboneTransaction.sampleAsMaster(bus))
+      WishboneMonitor(dut.io.busslave, dut.clockDomain){ bus =>
+        sco.pushDut(WishboneTransaction.sampleAsSlave(bus))
       }
 
       dri2.slaveSink()

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
@@ -37,11 +37,13 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
 
       dut.clockDomain.waitSampling()
 
+      val wordInc = conf.wordAddressInc(AddressGranularity.Word)
+
       val scoreboard = ScoreboardInOrder[WishboneTransaction]()
       for(ref <- List(
-        WishboneTransaction(10, 100), WishboneTransaction(0, 1),
-        WishboneTransaction(10, 100), WishboneTransaction(0, 1),
-        WishboneTransaction(10, 100), WishboneTransaction(0, 2)
+        WishboneTransaction(10 * wordInc, 100), WishboneTransaction(0, 1),
+        WishboneTransaction(10 * wordInc, 100), WishboneTransaction(0, 1),
+        WishboneTransaction(10 * wordInc, 100), WishboneTransaction(0, 2)
       )) {
         scoreboard.pushRef(ref)
       }
@@ -51,9 +53,9 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
       }
 
       val dri = new WishboneDriver(dut.io.bus, dut.clockDomain)
-      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10), WishboneTransaction(0)), we = false)
-      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10, 200), WishboneTransaction(0, 2)), we = true)
-      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10), WishboneTransaction(0)), we = false)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10*wordInc), WishboneTransaction(0)), we = false)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10*wordInc, 200), WishboneTransaction(0, 2)), we = true)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10*wordInc), WishboneTransaction(0)), we = false)
 
       scoreboard.checkEmptyness()
 //
@@ -78,7 +80,17 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
     testBus(conf, description="classic32")
   }
 
-//  test("pipelined"){
+  test("classic32_byte"){
+    val conf = WishboneConfig(32, 32, addressGranularity = AddressGranularity.Byte)
+    testBus(conf, description="classic32_byte")
+  }
+
+  test("classic32_word"){
+    val conf = WishboneConfig(32, 32, addressGranularity = AddressGranularity.Word)
+    testBus(conf, description="classic32_word")
+  }
+
+  //  test("pipelined"){
 //    val conf = WishboneConfig(8,8).pipelined
 //    testBus(conf,description="pipelined")
 //  }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
@@ -37,7 +37,7 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
 
       dut.clockDomain.waitSampling()
 
-      val wordInc = conf.wordAddressInc(AddressGranularity.Word)
+      val wordInc = conf.wordAddressInc(AddressGranularity.WORD)
 
       val scoreboard = ScoreboardInOrder[WishboneTransaction]()
       for(ref <- List(
@@ -81,12 +81,12 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
   }
 
   test("classic32_byte"){
-    val conf = WishboneConfig(32, 32, addressGranularity = AddressGranularity.Byte)
+    val conf = WishboneConfig(32, 32, addressGranularity = AddressGranularity.BYTE)
     testBus(conf, description="classic32_byte")
   }
 
   test("classic32_word"){
-    val conf = WishboneConfig(32, 32, addressGranularity = AddressGranularity.Word)
+    val conf = WishboneConfig(32, 32, addressGranularity = AddressGranularity.WORD)
     testBus(conf, description="classic32_word")
   }
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
@@ -1,21 +1,23 @@
 package spinal.tester.scalatest
 
-import org.scalatest.funsuite.AnyFunSuite
 import spinal.core._
 import spinal.core.sim._
-import spinal.sim._
 import spinal.lib._
 import spinal.lib.bus.wishbone._
 import spinal.lib.wishbone.sim._
 import spinal.lib.sim._
-import scala.util.Random
+
+import scala.language.postfixOps
 
 class WishboneSimpleSlave(config : WishboneConfig) extends Component{
   val io = new Bundle{
     val bus = slave(Wishbone(config))
   }
   val busCtrl = WishboneSlaveFactory(io.bus)
-  val reg = busCtrl.createReadWrite(Bits(busCtrl.busDataWidth bits),10)
+  val regA = busCtrl.createReadOnly(Bits(busCtrl.busDataWidth bits), 10 * config.dataWidth / 8)
+  regA := 100
+  val regB = busCtrl.createReadAndWrite(Bits(busCtrl.busDataWidth bits), 0)
+  regB.init(1)
 }
 
 class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
@@ -33,25 +35,34 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
       if(dut.io.bus.config.useLOCK) dut.io.bus.LOCK #= false
       if(dut.io.bus.config.isPipelined) dut.io.bus.STALL #= false
 
-      dut.io.bus.ACK #= false
-      dut.io.bus.DAT_MISO #= 0
+      dut.clockDomain.waitSampling()
 
       val scoreboard = ScoreboardInOrder[WishboneTransaction]()
-      val driver = new WishboneDriver(dut.io.bus, dut.clockDomain)
-      // val monitor = WishboneMonitor(dut.io.bus, dut.clockDomain){ bus =>
-      //   if(bus.WE.toBoolean)
-      //     scoreboard.pushRef(WishboneTransaction.sampleAsSlave(bus))
-      //   else
-      //     scoreboard.pushDut(WishboneTransaction.sampleAsMaster(bus))
-      // }
+      scoreboard.ref ++= List(
+        WishboneTransaction(10, 100), WishboneTransaction(0, 1),
+        WishboneTransaction(10, 100), WishboneTransaction(0, 1),
+        WishboneTransaction(10, 100), WishboneTransaction(0, 2)
+      )
 
-      for(repeat <- 0 until 1000){
-        driver.drive(for(x <- 1 to 10) yield WishboneTransaction(address=10).randomizeData(dut.io.bus.config.dataWidth),true)
-        dut.clockDomain.waitSampling(10)
-        driver.drive(for(x <- 1 to 10) yield WishboneTransaction(address=10),false)
-        dut.clockDomain.waitSampling(10)
-
+      val monitor = WishboneMonitor(dut.io.bus, dut.clockDomain){ bus =>
+           scoreboard.pushDut(WishboneTransaction.sampleAsMaster(bus))
       }
+
+      val dri = new WishboneDriver(dut.io.bus, dut.clockDomain)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10), WishboneTransaction(0)), we = false)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10, 200), WishboneTransaction(0, 2)), we = true)
+      dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10), WishboneTransaction(0)), we = false)
+
+      println(scoreboard.dut)
+//
+//      for(repeat <- 0 until 100){
+//        driver.drive(for(x <- 1 to 10) yield WishboneTransaction(address=10).randomizeData(dut.io.bus.config.dataWidth), we = true)
+//        dut.clockDomain.waitSampling(10)
+//        driver.drive(for(x <- 1 to 10) yield WishboneTransaction(address=10), we = false)
+//        dut.clockDomain.waitSampling(10)
+//      }
+//
+
     }
   }
 
@@ -60,8 +71,13 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
     testBus(conf,description="classic")
   }
 
-  test("pipelined"){
-    val conf = WishboneConfig(8,8).pipelined
-    testBus(conf,description="pipelined")
+  test("classic32"){
+    val conf = WishboneConfig(32, 32)
+    testBus(conf, description="classic32")
   }
+
+//  test("pipelined"){
+//    val conf = WishboneConfig(8,8).pipelined
+//    testBus(conf,description="pipelined")
+//  }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
@@ -38,13 +38,15 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
       dut.clockDomain.waitSampling()
 
       val scoreboard = ScoreboardInOrder[WishboneTransaction]()
-      scoreboard.ref ++= List(
+      for(ref <- List(
         WishboneTransaction(10, 100), WishboneTransaction(0, 1),
         WishboneTransaction(10, 100), WishboneTransaction(0, 1),
         WishboneTransaction(10, 100), WishboneTransaction(0, 2)
-      )
+      )) {
+        scoreboard.pushRef(ref)
+      }
 
-      val monitor = WishboneMonitor(dut.io.bus, dut.clockDomain){ bus =>
+      WishboneMonitor(dut.io.bus, dut.clockDomain){ bus =>
            scoreboard.pushDut(WishboneTransaction.sampleAsMaster(bus))
       }
 
@@ -53,7 +55,7 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
       dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10, 200), WishboneTransaction(0, 2)), we = true)
       dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10), WishboneTransaction(0)), we = false)
 
-      println(scoreboard.dut)
+      scoreboard.checkEmptyness()
 //
 //      for(repeat <- 0 until 100){
 //        driver.drive(for(x <- 1 to 10) yield WishboneTransaction(address=10).randomizeData(dut.io.bus.config.dataWidth), we = true)


### PR DESCRIPTION
Closes #1311 
Addresses #201 too

# Context, Motivation & Description

There were a few issues in WishBone related library code that are fixed by this PR. I can split this into multiple PRs if that makes it easier to go through.

## [Remove selMatch logic; buffer out the ACK signal to match the spec](https://github.com/SpinalHDL/SpinalHDL/commit/0da1c222342538e4bf2d747f961134191d84f14c)

Fixes #1311. Also only asserts ACK after a valid cycle.

## [Make wb arbiter a pass through when there is only one input](https://github.com/SpinalHDL/SpinalHDL/commit/17eda435eac98885fa6ba6f6726e54397ea81d4a)

Makes an instantiated arbiter behave as a passthrough when it is 1 to 1

I did this to make it easier to read the generated code and it seemed worth including.

## [Add config option to Wishbone bus to specify if it's byte addressable…](https://github.com/SpinalHDL/SpinalHDL/commit/19e8051c6a23bded12c5c893ca74530b7b5aa75e) 

There is an issue in the current code base where `WishboneSlaveFactory` assumed the bus was word addressable, but the `BusIf` subsystem assumed it was byte addressable. This makes it a configuration option on the bus config, defaulting to word addressable. I have no strong opinions on whether or not the default should be byte or word addressable, but AFAICT it's not mandated either way by the spec and I've seen both used. 


## [Update wishbone interconnect to use AddressMapping instead of just Si…](https://github.com/SpinalHDL/SpinalHDL/commit/32958ae7d32c4d533268ab1101a64fa3c49c434f) 

This lets you use DefaultMapping and friends with the wishbone interconnect. 

## [Only insert an arbiter in a wishbone interconnect when necessary](https://github.com/SpinalHDL/SpinalHDL/commit/7fefcec799f22a925e62ae216b3245bb67eb7a36)

Related to [Make wb arbiter a pass through when there is only one input](https://github.com/SpinalHDL/SpinalHDL/commit/17eda435eac98885fa6ba6f6726e54397ea81d4a), but this removes the arbiter component altogether. This generates simpler code but should have no behavioral impact. 

Note that I did not do this for the decoders because that could change behavior.

## [Bring WishboneDecoder more in line with other decoders. This commit c…](https://github.com/SpinalHDL/SpinalHDL/commit/b442c0441be11fea140f4145a029c084f3146dbe)

`MuxOH` has an oddity where the index which wins in the event of a tie changes from the end of the vector for n > 2 to the beginning of the vector when n == 2. This meant that if you had a DefaultMapping (or equivalent SizeMapping) entry in the decoder, it needed to be at the end of list with two slaves and at the beginning of the list for N > 2. This was confusing behavior. The AXI decoder doesn't have this issue because it doesn't use `MuxOH`; and instead does something more like this commit. 

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

There is no impact on code generation directly; but these should make the generated code somewhat easier to read since it indirectly simplifies some of the arbiter constructs. 

# Checklist

- [x] Unit tests were added: 
- [X] API changes are or will be documented: The only user facing API change has a docstring for it
