### PR TITLE
Verilog generated when using synchronous resets is not understood by SymbiYosys - remove "assert() else begin end"-block generation for now

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -748,10 +748,7 @@ class ComponentEmitterVerilog(
                 case `FAILURE` => "$fatal"
               }
               if (assertStatement.kind == AssertStatementKind.ASSERT && !spinalConfig.formalAsserts) {
-                b ++= s"${tab}$keyword($cond) else begin\n"
-                b ++= s"""${tab}  $severity("$frontString"$backString); // ${assertStatement.loc.file}.scala:L${assertStatement.loc.line}\n"""
-                if (assertStatement.severity == `FAILURE`) b ++= tab + "  $finish;\n"
-                b ++= s"${tab}end\n"
+                b ++= s"${tab}$keyword($cond);\n"       
               } else {
                 b ++= s"${tab}$keyword($cond); // ${assertStatement.loc.file}.scala:L${assertStatement.loc.line}\n"
               }


### PR DESCRIPTION
See issue https://github.com/SpinalHDL/SpinalHDL/issues/1314

Remove "assert() else begin end"-block generation for now.