### PR TITLE
SpinalFormalConfig: Set _hasAsync accodring to clock config; set includeFormal as default in SpinalFormalConfig

### DIFF
--- a/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
+++ b/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
@@ -62,7 +62,7 @@ case class SpinalFormalConfig(
     var _backend: SpinalFormalBackendSel = SpinalFormalBackendSel.SYMBIYOSYS,
     var _keepDebugInfo: Boolean = false,
     var _skipWireReduce: Boolean = false,
-    var _hasAsync: Boolean = false,
+    var _hasAsync: Boolean = true,
     var _timeout: Option[Int] = None,
     var _engines: ArrayBuffer[FormalEngin] = ArrayBuffer()
 ) {

--- a/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
+++ b/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
@@ -25,6 +25,7 @@ import org.apache.commons.io.FileUtils
 import spinal.core.internals.{PhaseContext, PhaseNetlist}
 import spinal.core.sim.SimWorkspace
 import spinal.core.{BlackBox, Component, GlobalData, SpinalConfig, SpinalReport}
+import spinal.core.ASYNC
 import spinal.sim._
 
 import scala.collection.mutable
@@ -62,7 +63,7 @@ case class SpinalFormalConfig(
     var _backend: SpinalFormalBackendSel = SpinalFormalBackendSel.SYMBIYOSYS,
     var _keepDebugInfo: Boolean = false,
     var _skipWireReduce: Boolean = false,
-    var _hasAsync: Boolean = true,
+    var _hasAsync: Boolean = (SpinalConfig().includeFormal.defaultConfigForClockDomains.resetKind == ASYNC),
     var _timeout: Option[Int] = None,
     var _engines: ArrayBuffer[FormalEngin] = ArrayBuffer()
 ) {
@@ -118,7 +119,8 @@ case class SpinalFormalConfig(
   }
 
   def withConfig(config: SpinalConfig): this.type = {
-    _spinalConfig = config
+    _spinalConfig = config.includeFormal
+    _hasAsync =  (_spinalConfig.defaultConfigForClockDomains.resetKind == ASYNC)
     this
   }
 


### PR DESCRIPTION
Closes #

https://github.com/SpinalHDL/SpinalTemplateSbt/issues/39
https://github.com/SpinalHDL/SpinalHDL/issues/1314

# Context, Motivation & Description

- SymbiYosys multiclock mode has to be used when using ResetKind == ASYNC, so enable multiclock mode when using this reset mode in the default clock domain
- always use ".includeFormal" in FormalConfig, to generate the "right" kind of "assert" depending on mode ( simulation vs. verification )

# Impact on code generation

RTL:
- use .includeFormal as default and therefore do not generate "assert(...) else ... begin" blocks in formal verification mode

SymbiYosis configuration file:
- use "multiclock on" when an using an ASYNC reset in the default clock domain

# Checklist
- [X] API changes are or will be documented: No changes on outward facing API