### PR TITLE
Compile tester with compiler plugin in Mill

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -104,8 +104,9 @@ trait Core extends SpinalModule with SpinalPublishModule with CrossSbtModule {
   }
 }
 
-object tester extends Cross[Tester](Version.SpinalVersion.compilers)
+object crossTester extends Cross[Tester](Version.SpinalVersion.compilers)
 trait Tester extends SpinalModule with SpinalPublishModule with CrossSbtModule {
+  override def millSourcePath = os.pwd / "tester"
   def mainClass = Some("spinal.tester")
   def moduleDeps = Seq(core(crossScalaVersion), sim(crossScalaVersion), lib(crossScalaVersion))
   def scalacOptions = super.scalacOptions() ++ idslplugin(crossScalaVersion).pluginOptions()
@@ -114,4 +115,10 @@ trait Tester extends SpinalModule with SpinalPublishModule with CrossSbtModule {
   object test extends CrossSbtModuleTests with TestModule.ScalaTest {
     def ivyDeps = Agg(ivy"org.scalatest::scalatest::${scalatestVersion}")
   }
+}
+
+object tester extends Module {
+  val defaultTester = crossTester(Version.SpinalVersion.compilers.head)
+  def testOnly(args: String*) = T.command { defaultTester.test.testOnly(args: _*) }
+  def runMain(mainClass: String) = T.command { defaultTester.runMain(mainClass) }
 }

--- a/build.sc
+++ b/build.sc
@@ -104,8 +104,8 @@ trait Core extends SpinalModule with SpinalPublishModule with CrossSbtModule {
   }
 }
 
-object crossTester extends Cross[Tester](Version.SpinalVersion.compilers)
-trait Tester extends SpinalModule with SpinalPublishModule with CrossSbtModule {
+object crossTester extends Cross[CrossTester](Version.SpinalVersion.compilers)
+trait CrossTester extends SpinalModule with SpinalPublishModule with CrossSbtModule {
   override def millSourcePath = os.pwd / "tester"
   def mainClass = Some("spinal.tester")
   def moduleDeps = Seq(core(crossScalaVersion), sim(crossScalaVersion), lib(crossScalaVersion))
@@ -119,6 +119,8 @@ trait Tester extends SpinalModule with SpinalPublishModule with CrossSbtModule {
 
 object tester extends Module {
   val defaultTester = crossTester(Version.SpinalVersion.compilers.head)
-  def testOnly(args: String*) = T.command { defaultTester.test.testOnly(args: _*) }
+  object test extends Module {
+    def testOnly(args: String*) = T.command { defaultTester.test.testOnly(args: _*) }
+  }
   def runMain(mainClass: String) = T.command { defaultTester.runMain(mainClass) }
 }

--- a/build.sc
+++ b/build.sc
@@ -108,7 +108,7 @@ object tester extends Cross[Tester](Version.SpinalVersion.compilers)
 trait Tester extends SpinalModule with SpinalPublishModule with CrossSbtModule {
   def mainClass = Some("spinal.tester")
   def moduleDeps = Seq(core(crossScalaVersion), sim(crossScalaVersion), lib(crossScalaVersion))
-  def scalacOptions = super.scalacOptions()
+  def scalacOptions = super.scalacOptions() ++ idslplugin(crossScalaVersion).pluginOptions()
   def ivyDeps = super.ivyDeps() ++ Agg(ivy"org.scalatest::scalatest:${scalatestVersion}")
 
   object test extends CrossSbtModuleTests with TestModule.ScalaTest {


### PR DESCRIPTION
To run the test cases in Mill correctly, `tester` should be compiled with the IDSL plugin.

The equivalence of `sbt tester/testOnly` is `mill "tester[2.13.12].test.testOnly"` (replace `2.13.12` with `_` to test for all cross targets).