### PR TITLE
Add exit() to StateMachine class

### DIFF
--- a/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
+++ b/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
@@ -362,6 +362,10 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
     wantStart := True
   }
 
+  def exit(): Unit = {
+    exitFsm()
+  }
+
   override def exitFsm(): Unit = {
     wantExit := True
     goto(stateBoot)


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

The two styles of writing state machine should better be consistent. 

For example, the first style of using a StateMachine is

```scala
val stateA: State = new State {
    whenIsActive {
        exit()
    }
}
```

The second style is 
```scala
val stateA = new State

StateA
    .whenIsActive {
        exitFsm()
   }
```
The inconsistency happen when using `exit()`, it can only be use in the first style, and If you want to use it in the
second style, you need to use exitFsm() which is not documented. So from a user friendly perspective, I think add
a new `exit()` method in the StateMachine class would be useful. And the second style would also be written as

```scala
val stateA = new State

StateA
    .whenIsActive {
        exit()
   }
```

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
No impact.
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist
Maybe it's not required for this small modification?

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
