### PR TITLE
Handle Quotes in Attribute values

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -1152,7 +1152,7 @@ class ComponentEmitterVhdl(
   def emitAttributes(node: String, attributes: Iterable[Attribute], vhdlType: String, ret: StringBuilder, postfix: String): Unit = {
     for (attribute <- attributes){
       val value = attribute match {
-        case attribute: AttributeString  => "\"" + attribute.value + "\""
+        case attribute: AttributeString  => "\"" + attribute.value.replace("\"", "\"\"") + "\""
         case attribute: AttributeInteger => attribute.value.toString
         case attribute: AttributeFlag    => "true"
       }

--- a/core/src/main/scala/spinal/core/internals/VerilogBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VerilogBase.scala
@@ -80,10 +80,12 @@ trait VerilogBase extends VhdlVerilogBase{
       }
     } ${reset}"
   }
-
+  def emitQuotedString(string: String): String = {
+    string.replace("\"", "\\\"")
+  }
   def emitSyntaxAttributes(attributes: Iterable[Attribute]): String = {
     val values = for (attribute <- attributes if attribute.attributeKind() == DEFAULT_ATTRIBUTE) yield attribute match {
-      case attribute: AttributeString => attribute.getName + " = \"" + attribute.value + "\""
+      case attribute: AttributeString => attribute.getName + " = " + emitQuotedString(attribute.value)
       case attribute: AttributeInteger => attribute.getName + " = " + attribute.value.toString
       case attribute: AttributeFlag => attribute.getName
     }
@@ -95,7 +97,7 @@ trait VerilogBase extends VhdlVerilogBase{
 
   def emitCommentAttributes(attributes: Iterable[Attribute]): String = {
     val values = for (attribute <- attributes if attribute.attributeKind() == COMMENT_ATTRIBUTE) yield attribute match {
-      case attribute: AttributeString => attribute.getName + " = \"" + attribute.value + "\""
+      case attribute: AttributeString => attribute.getName + " = " + emitQuotedString(attribute.value)
       case attribute: AttributeInteger => attribute.getName + " = " + attribute.value.toString
       case attribute: AttributeFlag => attribute.getName
     }
@@ -107,7 +109,7 @@ trait VerilogBase extends VhdlVerilogBase{
 
   def emitCommentEarlyAttributes(attributes: Iterable[Attribute]): String = {
     val values = for (attribute <- attributes if attribute.attributeKind() == COMMENT_TYPE_ATTRIBUTE) yield attribute match {
-      case attribute: AttributeString => attribute.getName + " = \"" + attribute.value + "\""
+      case attribute: AttributeString => attribute.getName + " = " + emitQuotedString(attribute.value)
       case attribute: AttributeInteger => attribute.getName + " = " + attribute.value.toString
       case attribute: AttributeFlag => attribute.getName
     }

--- a/core/src/main/scala/spinal/core/internals/VerilogBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VerilogBase.scala
@@ -81,7 +81,7 @@ trait VerilogBase extends VhdlVerilogBase{
     } ${reset}"
   }
   def emitQuotedString(string: String): String = {
-    string.replace("\"", "\\\"")
+    "\"" + string.replace("\"", "\\\"") + "\""
   }
   def emitSyntaxAttributes(attributes: Iterable[Attribute]): String = {
     val values = for (attribute <- attributes if attribute.attributeKind() == DEFAULT_ATTRIBUTE) yield attribute match {

--- a/tester/src/test/scala/spinal/tester/scalatest/AttributeEmitTests.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/AttributeEmitTests.scala
@@ -1,0 +1,17 @@
+package spinal.tester.scalatest
+
+import spinal.tester.SpinalAnyFunSuite
+import spinal.core._
+
+class AttributeEmitTests extends SpinalAnyFunSuite {
+  test("check escaping of quotes in attributes") {
+    class Test extends Component {
+      val a = RegInit(False)
+      a.addAttribute("testname", "test \"value\" ")
+    }
+    val verilog = SpinalVerilog(new Test)
+    assert(verilog.getRtlString().contains("test \\\"value\\\""))
+    val vhdl = SpinalVhdl(new Test)
+    assert(vhdl.getRtlString().contains("test \"\"value\"\""))
+  }
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/AttributeEmitTests.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/AttributeEmitTests.scala
@@ -7,11 +7,11 @@ class AttributeEmitTests extends SpinalAnyFunSuite {
   test("check escaping of quotes in attributes") {
     class Test extends Component {
       val a = RegInit(False)
-      a.addAttribute("testname", "test \"value\" ")
+      a.addAttribute("testname", "test \"value\" bar")
     }
     val verilog = SpinalVerilog(new Test)
-    assert(verilog.getRtlString().contains(raw"""test \"value\""""))
+    assert(verilog.getRtlString().contains(raw""""test \"value\" bar""""))
     val vhdl = SpinalVhdl(new Test)
-    assert(vhdl.getRtlString().contains(raw"""test ""value"""""))
+    assert(vhdl.getRtlString().contains(raw""""test ""value"" bar""""))
   }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/AttributeEmitTests.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/AttributeEmitTests.scala
@@ -10,8 +10,8 @@ class AttributeEmitTests extends SpinalAnyFunSuite {
       a.addAttribute("testname", "test \"value\" ")
     }
     val verilog = SpinalVerilog(new Test)
-    assert(verilog.getRtlString().contains("test \\\"value\\\""))
+    assert(verilog.getRtlString().contains(raw"""test \"value\""""))
     val vhdl = SpinalVhdl(new Test)
-    assert(vhdl.getRtlString().contains("test \"\"value\"\""))
+    assert(vhdl.getRtlString().contains(raw"""test ""value"""""))
   }
 }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->



# Context, Motivation & Description

Attribute values currently do not escape double quote characters, thus invalid vhdl/verilog is emitted when there are quotes in string attribute values.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->



# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
