### PR TITLE
If the output is not connected, set it to be an empty pair of parentheses

### DIFF
--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -175,7 +175,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         var singleTopLevel             : Boolean = true,
                         var noAssertAtTimeZero         : Boolean = false,
                         var cutLongExpressions         : Boolean = true,
-                        var cleanOutput                : Boolean = false
+                        var emitFullComponentBindings  : Boolean = true
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)
   def generateVhdl   [T <: Component](gen: => T): SpinalReport[T] = Spinal(this.copy(mode = VHDL))(gen)

--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -174,7 +174,8 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         bitVectorWidthMax              : Int = 4096,
                         var singleTopLevel             : Boolean = true,
                         var noAssertAtTimeZero         : Boolean = false,
-                        var cutLongExpressions         : Boolean = true
+                        var cutLongExpressions         : Boolean = true,
+                        var cleanOutput                : Boolean = false
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)
   def generateVhdl   [T <: Component](gen: => T): SpinalReport[T] = Spinal(this.copy(mode = VHDL))(gen)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -165,7 +165,7 @@ class ComponentEmitterVerilog(
         val componentSignalName = (sub.getNameElseThrow + "_" + io.getNameElseThrow)
         val name = component.localNamingScope.allocateName(componentSignalName)
         val noUse = signalNoUse(io)
-        if (!io.isSuffix && (io.isVital || !noUse))
+        if (!io.isSuffix && ((io.isVital || !noUse) || !spinalConfig.cleanOutput))
           declarations ++= emitExpressionWrap(io, name)
         referencesOverrides(io) = name
       }
@@ -423,7 +423,7 @@ class ComponentEmitterVerilog(
             case spinal.core.inout => "~"
             case _ => SpinalError("Not founded IO type")
           }
-          if(data.isVital || !noUse)
+          if(data.isVital || !noUse || !spinalConfig.cleanOutput)
             Some((s"    .${portAlign} (", s"${wireAlign}", s")${comma} //${dirtag}\n"))
           else {
             referencesOverrides.remove(data)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -426,7 +426,7 @@ class ComponentEmitterVerilog(
             Some((s"    .${portAlign} (", s"${wireAlign}", s")${comma} //${dirtag}\n"))
           else {
             referencesOverrides.remove(data)
-            Some((s"    .${portAlign} (", s"", s")${comma} //${dirtag}\n"))
+            Some((s"    .${portAlign} (", s" ", s")${comma} //${dirtag}\n"))
           }
         }
       }

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -1736,25 +1736,25 @@ end
     }
   }
 
-  var outputSignalNoUse: Set[BaseType] = Set()
+  var outputSignalNoUse: mutable.LinkedHashSet[BaseType] = mutable.LinkedHashSet()
   if(!spinalConfig.emitFullComponentBindings) {
     component.children.foreach(sub =>
       sub.getAllIo
       .foreach(io => if(io.isOutput) {
-        outputSignalNoUse = outputSignalNoUse + io
+        outputSignalNoUse.add(io)
       }
     ))
-  }
-  component.dslBody.walkStatements {
-    case s: BaseType =>
-    case s => {
-      s.walkExpression {
-        case e: BaseType => {
-          if(outputSignalNoUse contains e) {
-            outputSignalNoUse = outputSignalNoUse - e
+    component.dslBody.walkStatements {
+      case s: BaseType =>
+      case s => {
+        s.walkExpression {
+          case e: BaseType => {
+            if(outputSignalNoUse contains e) {
+              outputSignalNoUse.remove(e)
+            }
           }
+          case _ =>
         }
-        case _ =>
       }
     }
   }


### PR DESCRIPTION
If the child component output connect to nothing, the origin way is:
```verilog
  wire                a_io_y;
  wire                a_io_z;
  wire                a_io_p;
  wire                useless;

  Sub a (
    .io_x (io_x  ), //i
    .io_y (a_io_y), //o
    .io_z (a_io_z), //o
    .io_p (a_io_p)  //o
  );
  assign useless = (a_io_y && 1'b1);
  assign io_t = a_io_z;
```
this pr will change this to:
```verilog
  wire                a_io_y;
  wire                a_io_z;
  wire                useless;

  Sub a (
    .io_x (io_x  ), //i
    .io_y (a_io_y), //o
    .io_z (a_io_z), //o
    .io_p (      )  //o
  );
  assign useless = (a_io_y && 1'b1);
  assign io_t = a_io_z;
```
the testcase above is generate from this:
```scala
class TestOutput extends Component {
  val io = new Bundle {
    val x = in Bool()
    val t = out Bool()
  }

  val a = new Sub
  a.io.x := io.x
  val useless = Bool()
  useless := a.io.y && True
  io.t := a.io.z

}

class Sub extends BlackBox {
  val io = new Bundle {
    val x = in Bool()
    val y = out Bool()
    val z = out Bool()
    val p = out Bool()
  }

}
```