### PR TITLE
RegIf: Fix invalid HTML in DocTemplate

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/DocTemplate.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/DocTemplate.scala
@@ -120,7 +120,7 @@ object DocTemplate {
       |          <th>Reset value</th>
       |          <th>Field-Description</th>
       |        </tr>
-      |      <thead>
+      |      </thead>
       |""".stripMargin
 
   def getHTML(moduleName: String, tbody: String): String = s"""


### PR DESCRIPTION
Fix invalid HTML generated by `DocTemplate` of `RegIf`.

Thanks to @thoeby for helping to track this down.