### PR TITLE
jtagvpi: Don't use blocking IO, to avoid blocking the simulation

### DIFF
--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
@@ -78,6 +78,11 @@ object JtagVpi {
       // main receive and processing loop
       while (this.synchronized(connection) != null) {
         try {
+          // Wait for input data, otherwise readFully would block the simulation
+          while(inputStream.available() < MaxSizeOfVpiCmd) {
+            sleep(jtagClkPeriod * 200)
+          }
+
           inputStream.readFully(buffer)
 
           val vpiCmd = deserializeVpiCmd(buffer)


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1349 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

A first trivial fix for the blocking IO problem in the JTAG VPI implementation. Just adds a `while` loop with a `sleep`, which is similar to the behaviour of the `JtagTCP` implementation.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

Shouldn't have any impact on code generation, just the simulation. 

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
