### PR TITLE
Report when a timeout has happened for `BusSlaveFactory.readStreamBlockCycles`

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -603,10 +603,12 @@ trait BusSlaveFactory extends Area{
     val counter = Counter(blockCycles.getWidth bits)
     val wordCount = (1 + that.payload.getBitsWidth - 1) / busDataWidth + 1
     val counterWillOverflow = counter === blockCycles
-    val respReady = RegNextWhen(True, counterWillOverflow || that.valid) init False
+    val readIssued = False
+    val respReady = RegNextWhen(True, counterWillOverflow || (readIssued && !counterWillOverflow && that.valid)) init False
     val counterOverflowed = RegNextWhen(True, counterWillOverflow) init False
     // we only halt the first beat, since if we got a stream payload we got it all
     onReadPrimitive(SingleMapping(address), haltSensitive = false, null) {
+      readIssued := True
       when(!respReady) {
         counter.increment()
         readHalt()


### PR DESCRIPTION
Improvement for `readStreamBlockCycles` to report to caller that a timeout has happened.  This is useful to trigger some action for a timeout (e.g. invalidate a cacheline, etc.)

# Checklist

- [ ] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`