### PR TITLE
Proof of concept for isunknown usage

### DIFF
--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -515,5 +515,5 @@ abstract class BitVector extends BaseType with Widthable {
     cloneOf(this).setWidth(w).asInstanceOf[T]
   }
 
-  def isUnknown: Bool = wrapUnaryWithBool(new Operator.Formal.IsUnknown)
+  def isUnknown: Bool = wrapUnaryWithBool(new Operator.BitVector.IsUnknown)
 }

--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -514,4 +514,6 @@ abstract class BitVector extends BaseType with Widthable {
     val w = list.filter(!_.hasTag(tagAutoResize)).map(e => widthOf(e)).max
     cloneOf(this).setWidth(w).asInstanceOf[T]
   }
+
+  def isUnknown: Bool = wrapUnaryWithBool(new Operator.Formal.IsUnknown)
 }

--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -82,6 +82,8 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
     */
   def unary_! : Bool = wrapUnaryOperator(new Operator.Bool.Not)
 
+  def isUnknown: Bool = wrapUnaryOperator(new Operator.Formal.IsUnknown)
+
   override def unary_~ : Bool = ! this
 
   /** this is assigned to True */

--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -82,7 +82,7 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
     */
   def unary_! : Bool = wrapUnaryOperator(new Operator.Bool.Not)
 
-  def isUnknown: Bool = wrapUnaryOperator(new Operator.Formal.IsUnknown)
+  def isUnknown: Bool = wrapUnaryOperator(new Operator.BitVector.IsUnknown)
 
   override def unary_~ : Bool = ! this
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -1704,6 +1704,12 @@ end
     case  e: Operator.BitVector.orR                    => s"(|${emitExpression(e.source)})"
     case  e: Operator.BitVector.andR                   => s"(&${emitExpression(e.source)})"
     case  e: Operator.BitVector.xorR                   => s"(^${emitExpression(e.source)})"
+    case e: Operator.BitVector.IsUnknown =>
+      if (systemVerilog) s"$$isunknown(${emitExpression(e.source)})"
+      else {
+        SpinalWarning(s"IsUnknown is always false since system verilog is not active.")
+        "0"
+      }
 
     case e : Operator.Formal.Past                     => s"$$past(${emitExpression(e.source)}, ${e.delay})"
     case e : Operator.Formal.Rose                     => s"$$rose(${emitExpression(e.source)})"
@@ -1726,7 +1732,6 @@ end
       }
       s"$prefix($width)"
     }
-    case e : Operator.Formal.IsUnknown                 => s"`IS_UNKNOWN(${emitExpression(e.source)})"
   }
 
   elaborate()

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -1726,6 +1726,7 @@ end
       }
       s"$prefix($width)"
     }
+    case e : Operator.Formal.IsUnknown                 => s"`IS_UNKNOWN(${emitExpression(e.source)})"
   }
 
   elaborate()

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -1512,7 +1512,10 @@ class ComponentEmitterVhdl(
     case  e: BitVectorRangedAccessFixed              => accessBitVectorFixed(e)
     case  e: BitVectorRangedAccessFloating           => accessBitVectorFloating(e)
 
-    case  e: Operator.Formal.IsUnknown => "pkg_toStdLogic(false)"
+    case e: Operator.BitVector.IsUnknown => {
+      SpinalWarning(s"IsUnknown is always false in vhdl")
+      "pkg_toStdLogic(false)"
+    }
   }
 
   elaborate()

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -1511,6 +1511,8 @@ class ComponentEmitterVhdl(
     case  e: BitVectorBitAccessFloating              => accessBoolFloating(e)
     case  e: BitVectorRangedAccessFixed              => accessBitVectorFixed(e)
     case  e: BitVectorRangedAccessFloating           => accessBitVectorFloating(e)
+
+    case  e: Operator.Formal.IsUnknown => "pkg_toStdLogic(false)"
   }
 
   elaborate()

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -433,6 +433,12 @@ object Operator {
       override def getTypeObject = TypeBool
       override def opName: String = "$initstate(...)"
     }
+
+    class IsUnknown extends UnaryOperator {
+      override def opName: String = "$isunknown(Bits)"
+      override def getTypeObject: Any = TypeBool
+    }
+
   }
 
   /**

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -433,12 +433,6 @@ object Operator {
       override def getTypeObject = TypeBool
       override def opName: String = "$initstate(...)"
     }
-
-    class IsUnknown extends UnaryOperator {
-      override def opName: String = "$isunknown(Bits)"
-      override def getTypeObject: Any = TypeBool
-    }
-
   }
 
   /**
@@ -665,6 +659,12 @@ object Operator {
       override def calcWidth: Int = left.getWidth
       override def simplifyNode: Expression = if(right.getWidth == 0) left else this
       override def toString() = s"(${super.toString()})[$getWidth bits]"
+    }
+
+    class IsUnknown extends UnaryOperator {
+      override def opName: String = "$isunknown(Bits)"
+
+      override def getTypeObject: Any = TypeBool
     }
   }
 

--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -44,15 +44,6 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
 
       outFile.write("`timescale 1ns/1ps")
 
-      outFile.write(
-        s"""
-           |`ifdef __HAS_SYSTEM_VERILOG__
-           |`define IS_UNKNOWN(x) $$isunknown(x)
-           |`else
-           |`define IS_UNKNOWN(x) 0
-           |`endif
-           |""".stripMargin
-      )
       emitEnumPackage(outFile)
 
       val componentsText = ArrayBuffer[() => String]()

--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -44,6 +44,15 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
 
       outFile.write("`timescale 1ns/1ps")
 
+      outFile.write(
+        s"""
+           |`ifdef __HAS_SYSTEM_VERILOG__
+           |`define IS_UNKNOWN(x) $$isunknown(x)
+           |`else
+           |`define IS_UNKNOWN(x) 0
+           |`endif
+           |""".stripMargin
+      )
       emitEnumPackage(outFile)
 
       val componentsText = ArrayBuffer[() => String]()

--- a/tester/src/test/scala/spinal/tester/scalatest/IsUnknownTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/IsUnknownTester.scala
@@ -1,0 +1,58 @@
+package spinal.tester.scalatest
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import spinal.lib._
+import spinal.core.sim._
+
+import scala.language.postfixOps
+
+class IsUnknownTester extends SpinalAnyFunSuite {
+  test("Test if isUnknown is supported") {
+    class Dut extends Component {
+      val io = new Bundle {
+        val input = in Bits(16 bits)
+        val isUnknown = out Bool()
+      }
+
+      io.isUnknown := io.input(0).isUnknown
+    }
+
+    SimConfig.withIVerilog.addSimulatorFlag("-g2012").addSimulatorFlag("-D__HAS_SYSTEM_VERILOG__")
+      .withConfig(SpinalConfig(defaultClockDomainFrequency = FixedFrequency(4000 Hz)))
+      .compile(new Dut())
+      .doSim { dut =>
+        dut.clockDomain.forkStimulus(10)
+        dut.clockDomain.waitSampling()
+        assert(dut.io.isUnknown.toBoolean)
+        dut.clockDomain.waitSampling()
+        dut.io.input #= 0
+        dut.clockDomain.waitSampling()
+        assert(!dut.io.isUnknown.toBoolean)
+      }
+
+    SimConfig.withIVerilog
+      .withConfig(SpinalConfig(defaultClockDomainFrequency = FixedFrequency(4000 Hz)))
+      .compile(new Dut())
+      .doSim { dut =>
+        dut.clockDomain.forkStimulus(10)
+        dut.clockDomain.waitSampling()
+
+        dut.clockDomain.waitSampling()
+        dut.io.input #= 0
+        dut.clockDomain.waitSampling()
+      }
+
+    SimConfig.withGhdl
+      .withConfig(SpinalConfig(defaultClockDomainFrequency = FixedFrequency(4000 Hz)))
+      .compile(new Dut())
+      .doSim { dut =>
+        dut.clockDomain.forkStimulus(10)
+        dut.clockDomain.waitSampling()
+        dut.clockDomain.waitSampling()
+        dut.io.input #= 0
+        dut.clockDomain.waitSampling()
+      }
+
+  }
+}


### PR DESCRIPTION
Closes #1347 

# Context, Motivation & Description

This isn't ready to merge in this form it's mostly just for discussion. I didn't realize initially that it would require adding command line flags to enable SV functionality. 

Having to add in `.addSimulatorFlag("-g2012").addSimulatorFlag("-D__HAS_SYSTEM_VERILOG__")` is maybe bearable but makes this a pretty niche feature. IVerilog at least on my setup requires the -g2012 flag to support $isunknown. 

AFAICT verilog has no standard macro definitions for which version of the standard is being used -- which coming from a C/C++ background is bewildering and I'd love to be wrong on this. 

Here is the task list I imagine would need to be completed to make this mergable:
- The sim config would need some high level option for which standard of verilog to adhere to which dutifully enables the correct simulator flags based on the backend, and also some notion of whether that version supports system verilog or not would generate the other macro. 
- The IS_UNKNOWN macro would have to be moved somewhere sensible; and probably only emitted whenever the macro was used. 
- When the backend doesn't support the $isunknown directive -- non SV verilog and VHDL -- a warning should be emitted that says 'this will always be 0'. 

I still think it's worth doing but would understand if that wasn't the overall consensus. Being able to add in verification into components to assert they don't leak 'X' out in simulations is useful; particularly since all Mem's come up with that by default. But it is a lot of hoops to jump through to get there. 

# Checklist

- [ x] Unit tests were added
- [x ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
