### PR TITLE
BlackBox Generic update

### DIFF
--- a/core/src/main/scala/spinal/core/BlackBox.scala
+++ b/core/src/main/scala/spinal/core/BlackBox.scala
@@ -44,7 +44,7 @@ class Generic {
 }
 
 case class GenericValue(e : Expression) extends SpinalTag
-case class RawExpression(e: String)
+case class VerilogValues(v: String)
 
 class BlackBoxImpl{
 //  def getRtl(mode : SpinalMode): Unit = {
@@ -112,7 +112,7 @@ abstract class BlackBox extends Component{
 
   def addGeneric(name : String, that : Any) : Unit = that match {
     case bt: BaseType => genericElements += Tuple2(name, bt.addTag(GenericValue(bt.head.source)))
-    case raw: RawExpression => genericElements += Tuple2(name, raw)
+    case vv: VerilogValues => genericElements += Tuple2(name, vv)
     case s: String    => genericElements += Tuple2(name, s)
     case i: Int       => genericElements += Tuple2(name, i)
     case i: BigInt if i <= Integer.MAX_VALUE && i >= Integer.MIN_VALUE => genericElements += Tuple2(name, i.toInt)

--- a/core/src/main/scala/spinal/core/BlackBox.scala
+++ b/core/src/main/scala/spinal/core/BlackBox.scala
@@ -44,7 +44,7 @@ class Generic {
 }
 
 case class GenericValue(e : Expression) extends SpinalTag
-
+case class RawExpression(e: String)
 
 class BlackBoxImpl{
 //  def getRtl(mode : SpinalMode): Unit = {
@@ -112,6 +112,7 @@ abstract class BlackBox extends Component{
 
   def addGeneric(name : String, that : Any) : Unit = that match {
     case bt: BaseType => genericElements += Tuple2(name, bt.addTag(GenericValue(bt.head.source)))
+    case raw: RawExpression => genericElements += Tuple2(name, raw)
     case s: String    => genericElements += Tuple2(name, s)
     case i: Int       => genericElements += Tuple2(name, i)
     case i: BigInt if i <= Integer.MAX_VALUE && i >= Integer.MIN_VALUE => genericElements += Tuple2(name, i.toInt)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -366,7 +366,7 @@ class ComponentEmitterVerilog(
           val ret = genericFlat.map{ e =>
             e match {
               case (name: String, bt: BaseType)      => name -> s"${emitExpression(bt.getTag(classOf[GenericValue]).get.e)}"
-              case (name: String, rs: RawExpression) => name -> s"${rs.e}"
+              case (name: String, rs: VerilogValues) => name -> s"${rs.v}"
               case (name: String, s: String)         => name -> s"""\"$s\""""
               case (name: String, i: Int)            => name -> s"$i"
               case (name: String, d: Double)         => name -> s"$d"

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2791,7 +2791,7 @@ object SpinalVhdlBoot{
     phases += new PhaseGetInfoRTL(prunedSignals, unusedSignals, counterRegister, blackboxesSourcesPaths)(pc)
     val report = new SpinalReport[T]()
     report.globalData = pc.globalData
-    phases += new PhaseDummy(SpinalProgress("Generate VHDL"))
+    phases += new PhaseDummy(SpinalProgress(s"Generate VHDL to ${config.targetDirectory}"))
     phases += new PhaseVhdl(pc, report)
 
     for(inserter <-config.phasesInserters){
@@ -2916,7 +2916,7 @@ object SpinalVerilogBoot{
 
     phases += new PhaseGetInfoRTL(prunedSignals, unusedSignals, counterRegister, blackboxesSourcesPaths)(pc)
 
-    phases += new PhaseDummy(SpinalProgress("Generate Verilog"))
+    phases += new PhaseDummy(SpinalProgress(s"Generate Verilog to ${config.targetDirectory}"))
 
     val report = new SpinalReport[T]()
     report.globalData = pc.globalData


### PR DESCRIPTION
1. BlackBox Generic add RawExpression for som special use  
   for example ,  we want pass an verilog expression ` {256{1'b1}}` or  `{2*4{1'b1}, 32'h323, 16'b001110}`  directly,  current string can't meet our requirement
```scala
addGenric("XXX_TABLE", RawExpression("{2*32*4{1‘b1}}")
```
```verilog
    .RT_PORT_NUM        (2             ),
    .XXX_TABLE          ({2*32*4{1'b1}}),
    .TGTID_W            (8             ),
```
   Of course, it also carries risks and does not check whether the expression is a valid and legal Verilog expression. Therefore, when you want to use it, you must be clear about what you are doing. I suggest keeping `RawExpression`  for those special needs

2. Optimize generate code style for paramter instance ， Especially alignment

![image](https://github.com/SpinalHDL/SpinalHDL/assets/6213885/115dbc4b-9ba2-4311-aea4-37514a745432)


4. show path when generate verilog/vhdl log
Convenient for users to see the location of generated code
```SHELL
[Progress] at 6.046 : Checks and transforms
[Progress] at 6.191 : Generate Verilog to ./out/xxgen/xxxgen20240314/
```