### PR TITLE
Add CountLeadingZeroes utility function

### DIFF
--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimLibTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimLibTester.scala
@@ -76,4 +76,24 @@ class SpinalSimLibTester extends SpinalAnyFunSuite {
         }
     }
   }
+
+  for (bitCount <- 1 to 5) {
+    test("CountLeadingZeroes " + bitCount) {
+      SimConfig.noOptimisation
+        .compile(new Component {
+          val input = in(Bits(bitCount bits))
+          val output = out(UInt(log2Up(bitCount) + 1 bits))
+          output := CountLeadingZeroes(input)
+        })
+        .doSim(seed = 42) { dut =>
+          for (i <- 0 until 1 << bitCount) {
+            val expected = Integer.numberOfLeadingZeros(i) - 32 + bitCount
+            dut.input #= i
+            sleep(1)
+            val out = dut.output.toInt
+            assert(out == expected, f"in: ${i.toBinaryString} bits: ${bitCount}")
+          }
+        }
+    }
+  }
 }


### PR DESCRIPTION
This adds a utility function used for counting the number of consecutive zero bits starting from the MSB.

Such a function is very useful for floating point and posit arithmetic. In fact, several ISA's have a dedicated count leading zeroes instruction, like `lzcnt` in x86.

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
