### PR TITLE
Rename FlowByCCToggle, deprecating the old name

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba3/apb/Apb3CCToggle.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/apb/Apb3CCToggle.scala
@@ -65,7 +65,7 @@ case class Apb3CC(config : Apb3Config,
   }
 
   val outputLogic = new ClockingArea(outputClock){
-    val outputCmdFlow = FlowCCByToggle(inputLogic.inputCmd, inputClock, outputClock, withOutputM2sPipe = false)
+    val outputCmdFlow = FlowCCUnsafeByToggle(inputLogic.inputCmd, inputClock, outputClock, withOutputM2sPipe = false)
     val outputCmd = outputCmdFlow.toStream.m2sPipe(crossClockData = true, holdPayload = true)
     val state = RegInit(False)
 
@@ -96,7 +96,7 @@ case class Apb3CC(config : Apb3Config,
     outputRsp.PRDATA := io.output.PRDATA
     if(config.useSlaveError) outputRsp.PSLVERROR := io.output.PSLVERROR
 
-    inputLogic.inputRsp := FlowCCByToggle(outputRsp, outputClock, inputClock)
+    inputLogic.inputRsp := FlowCCUnsafeByToggle(outputRsp, outputClock, inputClock)
   }
 }
 

--- a/lib/src/main/scala/spinal/lib/com/jtag/JtagTapInstructions.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/JtagTapInstructions.scala
@@ -155,7 +155,7 @@ class JtagTapInstructionFlowFragmentPush(sink : Flow[Fragment[Bits]], sinkClockD
   source.last := !(ctrl.enable && ctrl.shift)
   source.fragment.lsb := data
 
-  sink << FlowCCByToggle(source, outputClock = sinkClockDomain)
+  sink << FlowCCUnsafeByToggle(source, outputClock = sinkClockDomain)
 
   ctrl.tdo := False
 }

--- a/lib/src/main/scala/spinal/lib/com/jtag/lattice/ecp5/JtagTapCommands.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/lattice/ecp5/JtagTapCommands.scala
@@ -179,7 +179,7 @@ class JtagTapInstructionFlowFragmentPush(sink : Flow[Fragment[Bits]], sinkClockD
   source.last := !(ctrl.enable && ctrl.shift)
   source.fragment.lsb := data
 
-  sink << FlowCCByToggle(source, outputClock = sinkClockDomain)
+  sink << FlowCCUnsafeByToggle(source, outputClock = sinkClockDomain)
 
   ctrl.tdo := False
 }


### PR DESCRIPTION
FlowByCCToggle is different than other CDC primitives in that it's unsafe to use in a general use-case. It must be used as a component in a CDC structure, or only in certain circumstances.

Rename to indicate this, add a comment to explain.

Checking the current uses in lib:
- Apb3CCToggle is fine, since both uses are part of a handshake, limiting datarate
- Jtag uses both are limited by the protocol to wait for a response to the instruction

# Checklist

No documentation update needed since FlowCCByToggle is undocumented atm.