### PR TITLE
Resize StateDelay cycleCount, fixing width mismatch

### DIFF
--- a/lib/src/main/scala/spinal/lib/fsm/State.scala
+++ b/lib/src/main/scala/spinal/lib/fsm/State.scala
@@ -230,7 +230,7 @@ class StateDelay(cyclesCount: UInt)(implicit stateMachineAccessor: StateMachineA
   cache.addMinWidth(cyclesCount.getWidth)
 
   onEntry{
-    cache.value := cyclesCount
+    cache.value := cyclesCount.resized
   }
 
   whenIsActiveWithPriority(1){


### PR DESCRIPTION
Fixes an issue that occurs when using two differently sized `UInt` as delays:
```
object Blub extends App {
  SpinalVerilog(new Component {
    val fsm = new StateMachine() {
      val u5 = in(UInt(5 bit))
      val u6 = in(UInt(6 bit))
      val s0: State = new StateDelay(u5) with EntryPoint {
        whenCompleted { goto(s1) }
      }
      val s1: State = new StateDelay(u6) {
        whenCompleted { goto(s0) }
      }
    }
  })
}
```
which with the old code leads to an error:
```
WIDTH MISMATCH (6 bits <- 5 bits) on (toplevel/??? :  UInt[6 bits]) := (toplevel/fsm_u5 : in UInt[5 bits]) at 
    spinal.lib.fsm.StateDelay.$anonfun$new$14(State.scala:233)
    spinal.lib.fsm.StateMachine.$anonfun$build$30(StateMachine.scala:254)
```