### PR TITLE
Fix simulator flags not passed to elaboration

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -277,9 +277,12 @@ object SpinalGhdlBackend {
 
   def apply[T <: Component](config: SpinalGhdlBackendConfig[T]) : Backend = {
     val vconfig = new GhdlBackendConfig()
-    vconfig.analyzeFlags = config.simulatorFlags.mkString(" ")
-    if (config.timePrecision != null) {
-      vconfig.elaborationFlags = s"--time-resolution=${config.timePrecision.decompose._2}"
+    val flagsConcat = config.simulatorFlags.mkString(" ")
+    vconfig.analyzeFlags = flagsConcat
+    vconfig.elaborationFlags = flagsConcat + {
+      if (config.timePrecision != null) {
+        s" --time-resolution=${config.timePrecision.decompose._2}"
+      } else ""
     }
     vconfig.runFlags = config.runFlags.mkString(" ")
     vconfig.logSimProcess = config.enableLogging


### PR DESCRIPTION
For the RTL sources I was using, ghdl required the `-frelaxed` option for analysis and elaboration. However, setting this flag via `addSimulatorFlag` only resulted in the flag being used for analysis.

Not sure if this was done on purpose, so I will ping those I saw made related contributions: @likewise @wswslzp @jiegec 