### PR TITLE
Fix corner case of `readStreamBlockCycles`

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -604,7 +604,7 @@ trait BusSlaveFactory extends Area{
     val wordCount = (1 + that.payload.getBitsWidth - 1) / busDataWidth + 1
     val counterWillOverflow = counter === blockCycles
     val readIssued = False
-    val respReady = RegNextWhen(True, counterWillOverflow || (readIssued && !counterWillOverflow && that.valid)) init False
+    val respReady = RegNextWhen(True, readIssued && (counterWillOverflow || (!counterWillOverflow && that.valid))) init False
     val counterOverflowed = RegNextWhen(True, counterWillOverflow) init False
     // we only halt the first beat, since if we got a stream payload we got it all
     onReadPrimitive(SingleMapping(address), haltSensitive = false, null) {


### PR DESCRIPTION
We should only set `respReady` when we have issued the read; otherwise, we could issue a spurious NACK due to the counter overflowing in the previous iteration.