### PR TITLE
Constraint writer for Xilinx Vivado (reopened: CDC rework)

### DIFF
--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -810,7 +810,15 @@ object noLatchCheck                  extends SpinalTag
 object noBackendCombMerge            extends SpinalTag
 object crossClockDomain              extends SpinalTag{ override def moveToSyncNode = true }
 object crossClockBuffer              extends SpinalTag{ override def moveToSyncNode = true }
-case class crossClockFalsePath(source: Option[BaseType] = None, destIsReset: Boolean = false) extends SpinalTag { override def allowMultipleInstance: Boolean = false }
+
+sealed trait TimingEndpointType
+object TimingEndpointType {
+  case object DATA extends TimingEndpointType
+  case object RESET extends TimingEndpointType
+  case object CLOCK_EN extends TimingEndpointType
+}
+
+case class crossClockFalsePath(source: Option[BaseType] = None, destType: TimingEndpointType = TimingEndpointType.DATA) extends SpinalTag { override def allowMultipleInstance: Boolean = false }
 case class crossClockMaxDelay(cycles: Int, useTargetClock: Boolean) extends SpinalTag { override def allowMultipleInstance: Boolean = false }
 object randomBoot                    extends SpinalTag{ override def moveToSyncNode = true }
 object tagAutoResize                 extends SpinalTag{ override def duplicative = true }

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -810,6 +810,8 @@ object noLatchCheck                  extends SpinalTag
 object noBackendCombMerge            extends SpinalTag
 object crossClockDomain              extends SpinalTag{ override def moveToSyncNode = true }
 object crossClockBuffer              extends SpinalTag{ override def moveToSyncNode = true }
+case class crossClockFalsePath(source: Option[BaseType] = None, destIsReset: Boolean = false) extends SpinalTag { override def allowMultipleInstance: Boolean = false }
+case class crossClockMaxDelay(cycles: Int, useTargetClock: Boolean) extends SpinalTag { override def allowMultipleInstance: Boolean = false }
 object randomBoot                    extends SpinalTag{ override def moveToSyncNode = true }
 object tagAutoResize                 extends SpinalTag{ override def duplicative = true }
 object tagTruncated                  extends SpinalTag{

--- a/lib/src/main/scala/spinal/lib/CrossClock.scala
+++ b/lib/src/main/scala/spinal/lib/CrossClock.scala
@@ -135,7 +135,7 @@ object ResetCtrl{
     )
 
     val solvedOutputPolarity = if(outputPolarity == null) clockDomain.config.resetActiveLevel else outputPolarity
-    val falsePathAttrs = List(crossClockFalsePath(Some(input), destIsReset = true))
+    val falsePathAttrs = List(crossClockFalsePath(Some(input), destType = TimingEndpointType.RESET))
     samplerCD(BufferCC(
       input       = (if(solvedOutputPolarity == HIGH) False else True) ^ inputSync,
       init        = if(solvedOutputPolarity == HIGH) True  else False,

--- a/lib/src/main/scala/spinal/lib/CrossClock.scala
+++ b/lib/src/main/scala/spinal/lib/CrossClock.scala
@@ -6,9 +6,10 @@ import scala.collection.Seq
 import scala.collection.mutable.ArrayBuffer
 
 object BufferCC {
-  def apply[T <: Data](input: T, init: => T = null, bufferDepth: Option[Int] = None, randBoot : Boolean = false): T = {
-    val c = new BufferCC(input, init, bufferDepth, randBoot)
+  def apply[T <: Data](input: T, init: => T = null, bufferDepth: Option[Int] = None, randBoot : Boolean = false, inputAttributes: Seq[SpinalTag] = List(), allBufAttributes: Seq[SpinalTag] = List()): T = {
+    val c = new BufferCC(input, init, bufferDepth, randBoot, inputAttributes, allBufAttributes)
     c.setCompositeName(input, "buffercc", true)
+    // keep hierarchy for timing constraint generation
     c.io.dataIn := input
 
     val ret = cloneOf(c.io.dataOut)
@@ -49,7 +50,7 @@ object BufferCC {
   }
 }
 
-class BufferCC[T <: Data](val dataType: T, init :  => T, val bufferDepth: Option[Int], val  randBoot : Boolean = false) extends Component {
+class BufferCC[T <: Data](val dataType: T, init :  => T, val bufferDepth: Option[Int], val  randBoot : Boolean = false, inputAttributes: Seq[SpinalTag] = List(), allBufAttributes: Seq[SpinalTag] = List()) extends Component {
   def getInit() : T = init
   val finalBufferDepth = BufferCC.defaultDepthOptioned(ClockDomain.current, bufferDepth)
   assert(finalBufferDepth >= 1)
@@ -64,12 +65,16 @@ class BufferCC[T <: Data](val dataType: T, init :  => T, val bufferDepth: Option
 
   buffers(0) := io.dataIn
   buffers(0).addTag(crossClockDomain)
+  inputAttributes.foreach(buffers(0).addTag)
   for (i <- 1 until finalBufferDepth) {
     buffers(i) := buffers(i - 1)
     buffers(i).addTag(crossClockBuffer)
   }
+  buffers.map(b => allBufAttributes.foreach(b.addTag))
 
   io.dataOut := buffers.last
+
+  addAttribute("keep_hierarchy", "TRUE")
 }
 
 
@@ -97,7 +102,7 @@ class PulseCCByToggle(clockIn: ClockDomain, clockOut: ClockDomain, withOutputBuf
 
   val finalOutputClock = clockOut.withOptionalBufferedResetFrom(withOutputBufferedReset)(clockIn)
   val outArea = finalOutputClock on new Area {
-    val target = BufferCC(inArea.target, False)
+    val target = BufferCC(inArea.target, False, inputAttributes = List(crossClockFalsePath()))
 
     io.pulseOut := target.edge(False)
   }
@@ -130,10 +135,12 @@ object ResetCtrl{
     )
 
     val solvedOutputPolarity = if(outputPolarity == null) clockDomain.config.resetActiveLevel else outputPolarity
+    val falsePathAttrs = List(crossClockFalsePath(Some(input), destIsReset = true))
     samplerCD(BufferCC(
       input       = (if(solvedOutputPolarity == HIGH) False else True) ^ inputSync,
-      init        = (if(solvedOutputPolarity == HIGH) True  else False),
-      bufferDepth = bufferDepth)
+      init        = if(solvedOutputPolarity == HIGH) True  else False,
+      bufferDepth = bufferDepth,
+      allBufAttributes = falsePathAttrs)
     )
   }
 
@@ -164,7 +171,7 @@ object ResetCtrl{
         inputPolarity = resetCd.config.resetActiveLevel,
         outputPolarity = clockCd.config.resetActiveLevel,
         bufferDepth = bufferDepth
-      ).setCompositeName(resetCd.reset, "syncronized", true)
+      ).setCompositeName(resetCd.reset, "synchronized", true)
     )
   }
 }

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -364,7 +364,7 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
 
     if (crossClockData) {
       rData.addTag(crossClockDomain)
-      rData.addTag(new crossClockMaxDelay(2, true))
+      rData.addTag(crossClockMaxDelay(1, useTargetClock = true))
     }
     if (flush != null) rValid clearWhen(flush)
 
@@ -1562,7 +1562,7 @@ class StreamFifoCC[T <: Data](val dataType: HardType[T],
     val pushPtr     = Reg(UInt(log2Up(2*depth) bits)) init(0)
     val pushPtrPlus = pushPtr + 1
     val pushPtrGray = RegNextWhen(toGray(pushPtrPlus), io.push.fire) init(0)
-    val popPtrGray  = BufferCC(popToPushGray, B(0, ptrWidth bits), inputAttributes = List(new crossClockMaxDelay(1, false)))
+    val popPtrGray  = BufferCC(popToPushGray, B(0, ptrWidth bits), inputAttributes = List(crossClockMaxDelay(1, useTargetClock = false)))
     val full        = isFull(pushPtrGray, popPtrGray)
 
     io.push.ready := !full
@@ -1580,7 +1580,7 @@ class StreamFifoCC[T <: Data](val dataType: HardType[T],
     val popPtr      = Reg(UInt(log2Up(2*depth) bits)) init(0)
     val popPtrPlus  = KeepAttribute(popPtr + 1)
     val popPtrGray  = toGray(popPtr)
-    val pushPtrGray = BufferCC(pushToPopGray, B(0, ptrWidth bit), inputAttributes = List(new crossClockMaxDelay(1, false)))
+    val pushPtrGray = BufferCC(pushToPopGray, B(0, ptrWidth bit), inputAttributes = List(crossClockMaxDelay(1, useTargetClock = false)))
     val addressGen = Stream(UInt(log2Up(depth) bits))
     val empty = isEmpty(popPtrGray, pushPtrGray)
     addressGen.valid := !empty

--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -802,10 +802,6 @@ object AnalysisUtils{
       }
       case o if o.isOutput => {
         val cds = mutable.LinkedHashSet[ClockDomain]()
-        println(o)
-        if(o.getName() == "io_ddrA_r_ready"){
-          println("asd")
-        }
         seekNonCombDrivers(o){
           case bt : BaseType if bt.isReg => cds += bt.clockDomain
           case _ => println("???")

--- a/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoConstraintWriter.scala
+++ b/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoConstraintWriter.scala
@@ -67,7 +67,7 @@ object VivadoConstraintWriter {
 
   // see https://docs.xilinx.com/r/en-US/ug835-vivado-tcl-commands/set_false_path
   def writeFalsePath(s: DataAssignmentStatement, writer: Writer, falsePathTag: crossClockFalsePath): Unit = {
-    val resetIsDriver = falsePathTag.destIsReset
+    val resetIsDriver = falsePathTag.destType == TimingEndpointType.RESET
     var source = s.source.asInstanceOf[BaseType]
     if (!resetIsDriver) {
       AnalysisUtils.seekNonCombDrivers(source) { case b: BaseType =>

--- a/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoConstraintWriter.scala
+++ b/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoConstraintWriter.scala
@@ -12,8 +12,7 @@ import scala.language.postfixOps
 object VivadoConstraintWriter {
   def apply[T <: Component](
                              report: SpinalReport[T],
-                             filename: String = null,
-                             trustSpinalTimings: Boolean = false
+                             filename: String = null
                            ): Unit = {
     val c = report.toplevel
     val realFilename = Option(filename).getOrElse(

--- a/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoConstraintWriter.scala
+++ b/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoConstraintWriter.scala
@@ -1,0 +1,171 @@
+package spinal.lib.eda.xilinx
+
+import spinal.core.ClockDomain.FixedFrequency
+import spinal.core.internals._
+import spinal.core.{crossClockMaxDelay, _}
+import spinal.lib.AnalysisUtils
+
+import java.io.{File, PrintWriter, Writer}
+import scala.collection.mutable
+import scala.language.postfixOps
+
+object VivadoConstraintWriter {
+  def apply[T <: Component](
+                             report: SpinalReport[T],
+                             filename: String = null,
+                             trustSpinalTimings: Boolean = false
+                           ): Unit = {
+    val c = report.toplevel
+    val realFilename = Option(filename).getOrElse(
+      f"${GlobalData.get.phaseContext.config.targetDirectory}/${c.getClass.getSimpleName}.xdc"
+    )
+    val writer = new PrintWriter(new File(realFilename))
+    c.walkComponents(cc => cc.dslBody.walkStatements(doWalkStatements(_, writer)))
+    writer.close()
+
+    val oocFilename = realFilename.split('.').tails.collect {
+      case Array(secondLast, _) => secondLast + "_ooc"
+      case Array(other, _*) => other
+    }.mkString(".")
+    val oocWriter = new PrintWriter(new File(oocFilename))
+
+    val clockDomainNames = mutable.LinkedHashSet[String]()
+    AnalysisUtils.foreachToplevelIoCd(c) {
+      case (p: Bool, List(cd)) if p.isInput =>
+        if (!clockDomainNames.contains(cd.toString)) {
+          writeClockDef(cd, oocWriter)
+          clockDomainNames.add(cd.toString)
+        }
+      case _ =>
+    }
+    oocWriter.close()
+  }
+
+  def doWalkStatements(s: Statement, writer: Writer): Unit = {
+    s match {
+      case da: DataAssignmentStatement =>
+        da.target match {
+          case str: SpinalTagReady if str.hasTag(classOf[crossClockFalsePath]) =>
+            writeFalsePath(da, writer, str.getTag(classOf[crossClockFalsePath]).get)
+          case str: SpinalTagReady if str.hasTag(classOf[crossClockMaxDelay]) =>
+            writeMaxDelay(da, str.getTag(classOf[crossClockMaxDelay]).get, writer)
+          case _ =>
+        }
+      case _ =>
+    }
+  }
+
+  def findDriverCell(s: String, destVar: String = "source"): String =
+    s"""set pin [get_pins -hier -filter {NAME =~ */$s}]
+       |set net [get_nets -segments -of_objects $$pin]
+       |set source_pins [get_pins -of_objects $$net -filter {IS_LEAF && DIRECTION == OUT}]
+       |set $destVar [get_cells -of_objects $$source_pins]""".stripMargin
+
+  def findClockPeriod(cd: ClockDomain, compName: String, destVar: String = "clk_period"): String =
+    s"""set clk_net [get_nets -hier -filter {NAME =~ */$compName/${cd.toString}}]
+       |set clk [get_clocks -include_generated_clocks -of $$clk_net]
+       |set $destVar [get_property -min PERIOD $$clk]""".stripMargin
+
+  // see https://docs.xilinx.com/r/en-US/ug835-vivado-tcl-commands/set_false_path
+  def writeFalsePath(s: DataAssignmentStatement, writer: Writer, falsePathTag: crossClockFalsePath): Unit = {
+    val resetIsDriver = falsePathTag.destIsReset
+    var source = s.source.asInstanceOf[BaseType]
+    if (!resetIsDriver) {
+      AnalysisUtils.seekNonCombDrivers(source) { case b: BaseType =>
+        source = b
+      }
+    }
+    val sourceLocator = if (source.isReg && !resetIsDriver) {
+      // source is register inside spinal design
+      f"set source [get_cells ${source.getRtlPath()}_reg*]"
+    } else {
+      findDriverCell(falsePathTag.source.get.getName())
+    }
+    val quiet = if (resetIsDriver) " -quiet" else ""
+    val target = s.target.asInstanceOf[BaseType].getRtlPath()
+    val pinName = if (resetIsDriver) "(PRE|CLR|S|R)" else "D"
+    writer.write(
+      s"""
+         |# CDC constaints for ${source.getRtlPath()} -> ${target} in ${s.component.getPath()}
+         |$sourceLocator
+         |set_false_path$quiet -from $$source -to [get_pins -regexp ${target}_reg*/$pinName]
+         |""".stripMargin)
+
+  }
+
+  // see https://docs.xilinx.com/r/en-US/ug835-vivado-tcl-commands/set_max_delay
+  // and https://docs.xilinx.com/r/en-US/ug835-vivado-tcl-commands/set_bus_skew
+  def writeMaxDelay(s: DataAssignmentStatement, tag: crossClockMaxDelay, writer: Writer): Unit = {
+    var source = s.source.asInstanceOf[BaseType]
+    AnalysisUtils.seekNonCombDrivers(source) { case b: BaseType =>
+      source = b
+    }
+    val sourceCD = source.getTag(classOf[ClockDomainTag]).map(_.clockDomain).getOrElse(source.clockDomain)
+    val target = s.target.asInstanceOf[BaseType]
+    val targetCD = target.getTag(classOf[ClockDomainTag]).map(_.clockDomain).getOrElse(target.clockDomain)
+    val maxDelay = f"expr {${tag.cycles} * $$${if (tag.useTargetClock) "dst_clk_period" else "src_clk_period"}}"
+    writer.write(
+      s"""
+         |# CDC constraints for ${source.getRtlPath()} -> ${target.getRtlPath()} in ${s.component.getPath()}
+         |${findClockPeriod(sourceCD, s.component.getName(), "src_clk_period")}
+         |${findClockPeriod(targetCD, s.component.getName(), "dst_clk_period")}
+         |set source [get_cells ${source.getRtlPath()}_reg*]
+         |set_max_delay -from $$source -to [get_pins ${target.getRtlPath()}_reg*/D] [$maxDelay] -datapath_only
+         |set_bus_skew -from $$source -to [get_pins ${target.getRtlPath()}_reg*/D] $$dst_clk_period
+         |""".stripMargin)
+  }
+
+  def writeClockDef(cd: ClockDomain, writer: Writer): Unit = {
+    val name = cd.toString
+    val freqNanos = cd.frequency match {
+      case FixedFrequency(freq) => freq.toTime / (1 ns)
+      case _ => BigDecimal(1)
+    }
+    writer.write(
+      s"""
+         |# Clock definition for $name
+         |create_clock -period $freqNanos -name $name [get_ports $name]
+         |""".stripMargin)
+  }
+
+  def fullPath(bt: BaseType) = (if (bt.component != null) bt.component.getPath() + "/" else "") + bt.getDisplayName()
+}
+
+case class Test() extends Component {
+
+  import spinal.lib._
+
+  val io = new Bundle {
+    val i = in port Bool()
+    val o = out port Bool()
+
+    val is = slave port Stream(Bits(2 bit))
+    val os = master port Stream(Bits(2 bit))
+
+    val ib = in port Bits(3 bit)
+    val ob = out port Bits(3 bit)
+
+    val iv = in port Vec(Bits(2 bit), 2)
+    val ov = out port Vec(Bits(2 bit), 2)
+  }
+  val otherCD = ClockDomain.external("someDomain")
+
+  io.o := BufferCC(io.i, inputAttributes = List(crossClockFalsePath()))
+  io.os <> io.is.ccToggle(ClockDomain.current, otherCD)
+
+  otherCD {
+    io.ob := BufferCC(
+      io.ib,
+      inputAttributes = List(new crossClockMaxDelay(2, useTargetClock = true))
+    )
+
+    io.ov := BufferCC(
+      io.iv,
+      inputAttributes = List(new crossClockMaxDelay(2, useTargetClock = true))
+    )
+  }
+}
+
+object Test extends App {
+  VivadoConstraintWriter(SpinalVerilog(Test()))
+}


### PR DESCRIPTION
Redoing #1306.  I think I accidentally closed this due to some branch dancing errors, now the PR head branch should be safe.

I also dropped from the last state of the PR stuff related to `Flow`: `m2sPipe` and `FlowCCByToggle` (cf. #1360), since these are not inherently safe CDC primitives.

@andreasWallner sorry to bother you again but can you review it (or just a brief look, since most of the stuff has been fixed already)?  Thanks a lot!