### PR TITLE
Bugfix/wb pipelined

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
@@ -22,7 +22,7 @@ object WishboneSlaveFactory {
   */
 class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends BusSlaveFactoryDelayed{
   bus.DAT_MISO := 0
-  if(bus.config.isPipelined) bus.STALL := False
+  if(bus.config.isPipelined) bus.STALL := !bus.ACK
 
   val askWrite = bus.isWrite.allowPruning()
   val askRead = bus.isRead.allowPruning()
@@ -33,7 +33,7 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
     bus.ACK := bus.STB && bus.CYC                 //Acknowledge as fast as possible
   } else if(bus.config.isPipelined){
     val pip_reg = RegNext(bus.STB) init(False)
-    bus.ACK := pip_reg || (bus.STALL && bus.CYC)  //Pipelined: Acknowledge at the next clock cycle
+    bus.ACK := pip_reg || (bus.CYC)  //Pipelined: Acknowledge at the next clock cycle
   } else {
     val reg_reg = RegNext(bus.STB && bus.CYC) init(False)
     bus.ACK := reg_reg && bus.STB                 //Classic: Acknowledge at the next clock cycle


### PR DESCRIPTION
Closes #1310

# Context, Motivation & Description

Fix wishbone pipelined mode

# Impact on code generation

None

# Checklist

- [x ] Unit tests were added
- [ x] API changes are or will be documented:

# [Fix stall usage in wishboneslavefactory](https://github.com/SpinalHDL/SpinalHDL/commit/05ef666c4a2ddb4fbdbd02f705af55c81a9ccf6b) 

This fixes the bug. Mainly setting stall to false is the wrong thing; setting stall to the inverse of ack fixs the logic.

# [Clean up wishbone flags; mark questionable ones for deprecation](https://github.com/SpinalHDL/SpinalHDL/commit/87b6f0bf2316a3361ba21f4f6360ccf0b499a0d5)

Probably needs some discussion. The main thing is that some of the current status checks are not right / meaningful for pipelined mode. I opted to deprecate and make new fields for backwards compatibility reasons. The non pipelined logic makes sense for these but the pipeline path is wrong for some of them:

- isAck is maybe the most harmful. ACK and STALL are independent and it is very possible that there is no timestep where 'ACK && !STALL' is true. 
- isTransfer is a little inconsistent. It's pipelined semantics are effectively if a request exists and is accepted. The non pipelined semantics check if a request exists. 
- isStall is maybe mapped wrong for standard. I'm not sure what use it would have in it's current state. 'isCycle && STALL' seems wrong though since AFAICT STALL is only meaningful when CYC && STB. 