### PR TITLE
Add BRAM RegIf support; Add BRAMDriver

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/bram/BRAM.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bram/BRAM.scala
@@ -34,8 +34,9 @@ import spinal.lib._
   * Bus BRAM configuration
   * @param dataWidth    : data width
   * @param addressWidth : address width
+  * @param readLatency  : # of cycles between read request and valid data being placed on the bus.
   */
-case class BRAMConfig(dataWidth: Int, addressWidth: Int)
+case class BRAMConfig(dataWidth: Int, addressWidth: Int, readLatency: Int = 1)
 
 
 /**
@@ -64,6 +65,7 @@ case class BRAM(config: BRAMConfig) extends Bundle with IMasterSlave {
   def >> (sink: BRAM): Unit = {
     assert(this.config.addressWidth >= sink.config.addressWidth, "BRAM mismatch width address (slave address is bigger than master address )")
     assert(this.config.dataWidth == sink.config.dataWidth, "BRAM mismatch width data (slave and master doesn't have the same data width)")
+    assert(this.config.readLatency == sink.config.readLatency, "BRAM mismatch read latency (slave and master don't have the same read latency)")
 
     this.rddata := sink.rddata
 

--- a/lib/src/main/scala/spinal/lib/bus/bram/BRAMDecoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bram/BRAMDecoder.scala
@@ -79,6 +79,6 @@ class BRAMDecoder(inputConfig: BRAMConfig, decodings: Seq[SizeMapping]) extends 
     psel := decoding.hit(io.input.addr) & io.input.en
   }
 
-  val selIndex = RegNext(OHToUInt(sel))
+  val selIndex = Delay(OHToUInt(sel), inputConfig.readLatency)
   io.input.rddata := io.outputs(selIndex).rddata
 }

--- a/lib/src/main/scala/spinal/lib/bus/bram/BRAMSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bram/BRAMSlaveFactory.scala
@@ -44,6 +44,7 @@ object BRAMSlaveFactory {
   * @param incAddress   : Incr address (default + dataWidth / 4)
   */
 class BRAMSlaveFactory(bus: BRAM, incAddress: Int = 0) extends BusSlaveFactoryDelayed{
+  assert(bus.config.readLatency == 1, "Slave factory only supports read latency of 1")
 
   override def readHalt()  = {}
   override def writeHalt() = {}

--- a/lib/src/main/scala/spinal/lib/bus/bram/sim/BRAMDriver.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bram/sim/BRAMDriver.scala
@@ -1,0 +1,37 @@
+package spinal.lib.bus.bram.sim
+
+import spinal.core.ClockDomain
+import spinal.core.sim._
+import spinal.lib.bus.bram.BRAM
+
+case class BRAMDriver(bram: BRAM, clockDomain: ClockDomain) {
+  bram.en #= false
+
+  var verbose = false
+
+  def write(address: BigInt, data: BigInt, strb: BigInt = 0xffff): Unit = {
+    if (verbose) println(s"BRAM[0x${address.toString(16)}] = 0x${data.toString(16)}")
+    bram.we #= strb % (1 << bram.we.getWidth)
+    bram.addr #= address
+    bram.wrdata #= data
+    bram.en #= true
+    clockDomain.waitSampling()
+    bram.en #= false
+    bram.we.randomize()
+    bram.addr.randomize()
+    bram.wrdata.randomize()
+  }
+
+  def read(address: BigInt): BigInt = {
+    bram.addr #= address
+    bram.we #= 0
+    bram.en #= true
+    clockDomain.waitSampling()
+    bram.en #= false
+    bram.we.randomize()
+    bram.addr.randomize()
+    bram.wrdata.randomize()
+    clockDomain.waitSampling()
+    bram.rddata.toBigInt
+  }
+}

--- a/lib/src/main/scala/spinal/lib/bus/bram/sim/BRAMDriver.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bram/sim/BRAMDriver.scala
@@ -31,7 +31,7 @@ case class BRAMDriver(bram: BRAM, clockDomain: ClockDomain) {
     bram.we.randomize()
     bram.addr.randomize()
     bram.wrdata.randomize()
-    clockDomain.waitSampling()
+    clockDomain.waitSampling(bram.config.readLatency)
     bram.rddata.toBigInt
   }
 }

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/BRAMBusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/BRAMBusInterface.scala
@@ -33,9 +33,9 @@ case class BRAMBusInterface(bus: BRAM, sizeMap: SizeMapping, regPre: String = ""
 
   override def writeAddress(): UInt = bus.addr << underbitWidth
 
-  override def readHalt(): Unit = {}
+  override def readHalt(): Unit = assert(false, "BRAM bus does not support halting")
 
-  override def writeHalt(): Unit = {}
+  override def writeHalt(): Unit = assert(false, "BRAM bus does not support halting")
 
   override def busDataWidth: Int = bus.config.dataWidth
 

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/BRAMBusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/BRAMBusInterface.scala
@@ -7,10 +7,10 @@ import spinal.lib.Delay
 
 case class BRAMBusInterface(bus: BRAM, sizeMap: SizeMapping, regPre: String = "", readDelay: Int = 1)(implicit moduleName: ClassName) extends BusIf {
   override val withStrb: Boolean = true
-  override val wstrb: Bits = withStrb generate(Bits(strbWidth bit))
-  override val wmask: Bits = withStrb generate(Bits(busDataWidth bit))
-  override val wmaskn: Bits = withStrb generate(Bits(busDataWidth bit))
-  withStrb generate(wstrb := bus.we)
+  override val wstrb: Bits = Bits(strbWidth bit)
+  override val wmask: Bits = Bits(busDataWidth bit)
+  override val wmaskn: Bits = Bits(busDataWidth bit)
+  wstrb := bus.we
   initStrbMasks()
 
   override val askWrite: Bool = bus.we.orR.allowPruning()

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/BRAMBusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/BRAMBusInterface.scala
@@ -5,7 +5,7 @@ import spinal.lib.bus.misc.SizeMapping
 import spinal.lib.bus.bram.BRAM
 import spinal.lib.Delay
 
-case class BRAMBusInterface(bus: BRAM, sizeMap: SizeMapping, regPre: String = "", readDelay: Int = 1)(implicit moduleName: ClassName) extends BusIf {
+case class BRAMBusInterface(bus: BRAM, sizeMap: SizeMapping, regPre: String = "")(implicit moduleName: ClassName) extends BusIf {
   override val withStrb: Boolean = true
   override val wstrb: Bits = Bits(strbWidth bit)
   override val wmask: Bits = Bits(busDataWidth bit)
@@ -23,7 +23,7 @@ case class BRAMBusInterface(bus: BRAM, sizeMap: SizeMapping, regPre: String = ""
 
   override val readData: Bits = Bits(busDataWidth bits)
 
-  bus.rddata := Delay(readData, readDelay) init B(0)
+  bus.rddata := Delay(readData, bus.config.readLatency) init B(0)
 
   override val writeData: Bits = bus.wrdata
 

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/BRAMBusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusIfAdapter/BRAMBusInterface.scala
@@ -1,0 +1,43 @@
+package spinal.lib.bus.regif
+
+import spinal.core._
+import spinal.lib.bus.misc.SizeMapping
+import spinal.lib.bus.bram.BRAM
+import spinal.lib.Delay
+
+case class BRAMBusInterface(bus: BRAM, sizeMap: SizeMapping, regPre: String = "", readDelay: Int = 1)(implicit moduleName: ClassName) extends BusIf {
+  override val withStrb: Boolean = true
+  override val wstrb: Bits = withStrb generate(Bits(strbWidth bit))
+  override val wmask: Bits = withStrb generate(Bits(busDataWidth bit))
+  override val wmaskn: Bits = withStrb generate(Bits(busDataWidth bit))
+  withStrb generate(wstrb := bus.we)
+  initStrbMasks()
+
+  override val askWrite: Bool = bus.we.orR.allowPruning()
+
+  override val askRead: Bool = (!askWrite).allowPruning()
+
+  override val doWrite: Bool = (askWrite && bus.en).allowPruning()
+
+  override val doRead: Bool = (askRead && bus.en).allowPruning()
+
+  override val readData: Bits = Bits(busDataWidth bits)
+
+  bus.rddata := Delay(readData, readDelay) init B(0)
+
+  override val writeData: Bits = bus.wrdata
+
+  override val readError: Bool = False
+
+  override def readAddress(): UInt = bus.addr << underbitWidth // BRAM uses word-aligned addresses
+
+  override def writeAddress(): UInt = bus.addr << underbitWidth
+
+  override def readHalt(): Unit = {}
+
+  override def writeHalt(): Unit = {}
+
+  override def busDataWidth: Int = bus.config.dataWidth
+
+  override def getModuleName: String = moduleName.name
+}

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusInterface.scala
@@ -27,5 +27,4 @@ object BusInterface {
   def apply(bus: AxiLite4, sizeMap: SizeMapping, regPre: String)(implicit moduleName: ClassName): BusIf = AxiLite4BusInterface(bus, sizeMap, regPre)(moduleName)
 
   def apply(bus: BRAM, sizeMap: SizeMapping, regPre: String)(implicit moduleName: ClassName): BusIf = BRAMBusInterface(bus, sizeMap, regPre)(moduleName)
-  def apply(bus: BRAM, sizeMap: SizeMapping, regPre: String, readDelay: Int)(implicit moduleName: ClassName): BusIf = BRAMBusInterface(bus, sizeMap, regPre, readDelay)(moduleName)
 }

--- a/lib/src/main/scala/spinal/lib/bus/regif/BusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusInterface.scala
@@ -7,6 +7,7 @@ import spinal.lib.bus.amba4.axi.Axi4
 import spinal.lib.bus.amba4.axilite.AxiLite4
 import spinal.lib.bus.misc.SizeMapping
 import spinal.lib.bus.wishbone.Wishbone
+import spinal.lib.bus.bram.BRAM
 
 object BusInterface {
   def apply(bus: Apb3, sizeMap: SizeMapping, selID: Int)(implicit moduleName: ClassName): BusIf = Apb3BusInterface(bus, sizeMap, selID)(moduleName)
@@ -24,4 +25,7 @@ object BusInterface {
 
   def apply(bus: AxiLite4, sizeMap: SizeMapping)(implicit moduleName: ClassName): BusIf = AxiLite4BusInterface(bus, sizeMap)(moduleName)
   def apply(bus: AxiLite4, sizeMap: SizeMapping, regPre: String)(implicit moduleName: ClassName): BusIf = AxiLite4BusInterface(bus, sizeMap, regPre)(moduleName)
+
+  def apply(bus: BRAM, sizeMap: SizeMapping, regPre: String)(implicit moduleName: ClassName): BusIf = BRAMBusInterface(bus, sizeMap, regPre)(moduleName)
+  def apply(bus: BRAM, sizeMap: SizeMapping, regPre: String, readDelay: Int)(implicit moduleName: ClassName): BusIf = BRAMBusInterface(bus, sizeMap, regPre, readDelay)(moduleName)
 }

--- a/tester/src/test/scala/spinal/lib/bus/regif/RegIfACC30.scala
+++ b/tester/src/test/scala/spinal/lib/bus/regif/RegIfACC30.scala
@@ -11,6 +11,8 @@ import spinal.lib.bus.amba3.apb.sim.Apb3Driver
 import spinal.lib.bus.amba4.apb._
 import spinal.lib.bus.amba4.apb.sim.Apb4Driver
 import spinal.lib.bus.wishbone.Wishbone
+import spinal.lib.bus.bram._
+import spinal.lib.bus.bram.sim.BRAMDriver
 
 
 class RegIfBasicAccessTest(busname: String) extends Component{
@@ -24,6 +26,10 @@ class RegIfBasicAccessTest(busname: String) extends Component{
       val bus = slave(Apb4(Apb4Config(32, 32)))
       bus -> BusInterface(bus, (0x000, 4 MiB), 0, regPre = "AP")
     }
+    case "bram" => {
+      val bus = slave(BRAM(BRAMConfig(32, 30)))
+      bus -> BusInterface(bus, (0x000, 4 MiB), regPre = "AP")
+    }
     case _ => SpinalError("not support yet")
   }
 
@@ -34,6 +40,7 @@ class RegIfBasicAccessTest(busname: String) extends Component{
     case bs: Apb4 => {
       assert(bs.PSLVERR.toBoolean == aset, msg)
     }
+    case bs: BRAM => {} // BRAM does not support bus errors
     case _ => SpinalError("not support yet")
   }
 
@@ -83,6 +90,7 @@ class RegIfBasicAccessTest(busname: String) extends Component{
       case bs: Apb4     => Apb4Driver(bs, this.clockDomain).write(addr, data, strb)
       case bs: AhbLite3 => SpinalError("AhbLIte3 regif test not support yet")
       case bs: Wishbone => SpinalError("Wishbon  regif test not support yet")
+      case bs: BRAM => BRAMDriver(bs, this.clockDomain).write(addr >> 2, data, strb)
     }
     sleep(0)
   }
@@ -92,6 +100,7 @@ class RegIfBasicAccessTest(busname: String) extends Component{
       case bs: Apb4 => Apb4Driver(bs, this.clockDomain).read(addr)
       case bs: AhbLite3 => SpinalError("AhbLIte3 regif test not support yet")
       case bs: Wishbone => SpinalError("Wishbon  regif test not support yet")
+      case bs: BRAM => BRAMDriver(bs, this.clockDomain).read(addr >> 2)
     }
     sleep(0)
     t
@@ -438,6 +447,7 @@ object BasicTest{
     name match {
       case "apb3" => spinalConfig.generateVerilog(new RegIfBasicAccessTest("apb3"))
       case "apb4" => spinalConfig.generateVerilog(new RegIfBasicAccessTest("apb4"))
+      case "bram" => spinalConfig.generateVerilog(new RegIfBasicAccessTest("bram"))
       case "demo" => spinalConfig.generateVerilog(new RegIfExample)
       case _      => spinalConfig.generateVerilog(new RegIfExample)
     }

--- a/tester/src/test/scala/spinal/lib/bus/regif/RegIfBasicAccessTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/regif/RegIfBasicAccessTester.scala
@@ -11,6 +11,7 @@ class RegIfBasicRtlGenerater extends SpinalAnyFunSuite{
 class RegIfBasicAccessTester extends SpinalAnyFunSuite{
   test("regif_basic_access_tester_apb4"){BasicTest.main(Array("apb4"))}
   test("regif_basic_access_tester_apb3"){BasicTest.main(Array("apb3"))}
+  test("regif_basic_access_tester_bram"){BasicTest.main(Array("bram"))}
 }
 
 class RegIfStrbTester extends SpinalAnyFunSuite{


### PR DESCRIPTION
# Context, Motivation & Description

This adds support for RegIf to the BRAM bus. In order to implement tests, I also added a BRAMDriver.

# Checklist

- [ x ] Unit tests were added
- [ x ] API changes are or will be documented:
  -  I believe the docs for RegIf apply, but let me know if more are needed.
