### PR TITLE
add an option to remove timescale

### DIFF
--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -175,7 +175,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         var singleTopLevel             : Boolean = true,
                         var noAssertAtTimeZero         : Boolean = false,
                         var cutLongExpressions         : Boolean = true,
-                        var withTimescale              : Boolean = true,
+                        var withTimescale              : Boolean = false,
                         var emitFullComponentBindings  : Boolean = true
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)

--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -175,6 +175,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         var singleTopLevel             : Boolean = true,
                         var noAssertAtTimeZero         : Boolean = false,
                         var cutLongExpressions         : Boolean = true,
+                        var withTimescale              : Boolean = true,
                         var emitFullComponentBindings  : Boolean = true
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)

--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -42,7 +42,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
       outFile = new java.io.FileWriter(targetPath)
       outFile.write(VhdlVerilogBase.getHeader("//", pc.config.rtlHeader, topLevel, config.headerWithDate, config.headerWithRepoHash))
 
-      outFile.write("`timescale 1ns/1ps")
+      if(pc.config.withTimescale) outFile.write("`timescale 1ns/1ps")
 
       emitEnumPackage(outFile)
 
@@ -96,7 +96,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
           if (!c.isInBlackBoxTree) {
             outFile = new java.io.FileWriter(targetFilePath)
             outFile.write(VhdlVerilogBase.getHeader("//", pc.config.rtlHeader, c, config.headerWithDate, config.headerWithRepoHash))
-            outFile.write("`timescale 1ns/1ps ")
+            if(pc.config.withTimescale) outFile.write("`timescale 1ns/1ps ")
 //            emitEnumPackage(outFile)
             outFile.write(moduleContent)
             outFile.flush()
@@ -111,7 +111,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
                 if(!bbImplStrings.contains(str)) {
                   outFile = new java.io.FileWriter(targetFilePath)
                   outFile.write(VhdlVerilogBase.getHeader("//", pc.config.rtlHeader, c, config.headerWithDate, config.headerWithRepoHash))
-                  outFile.write("`timescale 1ns/1ps ")
+                  if(pc.config.withTimescale) outFile.write("`timescale 1ns/1ps ")
                   outFile.write(str)
                   outFile.flush()
                   outFile.close()


### PR DESCRIPTION
add a `withTimescale` option in SpinalConfig so that people can choose wheather or not generate this:
```verilog
`timescale 1ns/1ps
```
the first commit default to `with timescale`, and the second commit change the default to `without timescale`