### PR TITLE
Fix bin files passed to .sby read statement

### DIFF
--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -119,6 +119,7 @@ class SymbiYosysBackend(val config: SymbiYosysBackendConfig) extends FormalBacke
   def genSby(): Unit = {
     val localSources = config.rtlSourcesPaths.map(f => new File(f).getAbsolutePath).mkString("\n")
     val read = config.rtlSourcesPaths
+      .filter(!_.endsWith(".bin"))
       .map(f => {
         Paths.get(f).getFileName
       })


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description
<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
Currently, generating `.sby` files for formal verification fails if the design contains initialized memory. This is because the `.bin` file is currently being passed to the `read` statement, which expects only Verilog and SystemVerilog files.

This MR adds a simple filter to not include `.bin` files for the purposes of the `read` statement. I think this solution is not as robust as it could be, but `SpinalReport` currently does not seems to convey the distinction between generated RTL sources and bin files.


# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
