### PR TITLE
Moving simulation temporary builds to Workspace Path

### DIFF
--- a/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
+++ b/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
@@ -154,11 +154,14 @@ case class SpinalFormalConfig(
   }
 
   def compileCloned[T <: Component](rtl: => T): FormalBackend = {
+    if (_workspacePath.startsWith("~"))
+      _workspacePath = System.getProperty("user.home") + _workspacePath.drop(1)
+
     val uniqueId = FormalWorkspace.allocateUniqueId()
-    new File(s"tmp").mkdirs()
-    new File(s"tmp/job_$uniqueId").mkdirs()
+    new File(s"${_workspacePath}/tmp").mkdirs()
+    new File(s"${_workspacePath}/tmp/job_$uniqueId").mkdirs()
     val config = _spinalConfig
-      .copy(targetDirectory = s"tmp/job_$uniqueId")
+      .copy(targetDirectory = s"${_workspacePath}/tmp/job_$uniqueId")
       .addTransformationPhase(new PhaseNetlist {
         override def impl(pc: PhaseContext): Unit = pc.walkComponents {
           case b: BlackBox if b.isBlackBox && b.isSpinalSimWb => b.clearBlackBox()

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -924,11 +924,14 @@ case class SpinalSimConfig(
   }
 
   def compileCloned[T <: Component](rtl: => T) : SimCompiled[T] = {
+    if (_workspacePath.startsWith("~"))
+      _workspacePath = System.getProperty("user.home") + _workspacePath.drop(1)
+
     val uniqueId = SimWorkspace.allocateUniqueId()
-    new File(s"tmp").mkdirs()
-    new File(s"tmp/job_$uniqueId").mkdirs()
+    new File(s"${_workspacePath}/tmp").mkdirs()
+    new File(s"${_workspacePath}/tmp/job_$uniqueId").mkdirs()
     _spinalConfig.noAssertAtTimeZero = true
-    val config = _spinalConfig.copy(targetDirectory = s"tmp/job_$uniqueId").addTransformationPhase(new PhaseNetlist {
+    val config = _spinalConfig.copy(targetDirectory = s"${_workspacePath}/tmp/job_$uniqueId").addTransformationPhase(new PhaseNetlist {
       override def impl(pc: PhaseContext): Unit = {
         //Ensure the toplevel pull its clock domain
         pc.topLevel.rework{


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
