### PR TITLE
AFix: Adding a few QFormat helpers

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -70,7 +70,11 @@ object AFix {
     new AFix(maxRaw, minRaw, resolution.value)
   }
 
-  def apply(Q: QFormat): AFix = AFix((Q.width - Q.fraction) exp, -Q.fraction exp, Q.signed)
+  def apply(Q: QFormat): AFix = {
+    val integerWidth = if (Q.signed) { Q.width - Q.fraction - 1 } else { Q.width - Q.fraction }
+    val fractionWidth = -Q.fraction
+    AFix(integerWidth exp, fractionWidth exp, Q.signed)
+  }
 
   def U(width: BitCount): AFix = AFix(width.value exp, 0 exp, signed = false)
   def UQ(integerWidth: BitCount, fractionWidth: BitCount): AFix = AFix(integerWidth.value exp, -fractionWidth.value exp, signed = false)

--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -70,11 +70,7 @@ object AFix {
     new AFix(maxRaw, minRaw, resolution.value)
   }
 
-  def apply(Q: QFormat): AFix = {
-    val integerWidth = if (Q.signed) { Q.width - Q.fraction - 1 } else { Q.width - Q.fraction }
-    val fractionWidth = -Q.fraction
-    AFix(integerWidth exp, fractionWidth exp, Q.signed)
-  }
+  def apply(Q: QFormat): AFix = AFix((Q.width - Q.fraction) exp, -Q.fraction exp, Q.signed)
 
   def U(width: BitCount): AFix = AFix(width.value exp, 0 exp, signed = false)
   def UQ(integerWidth: BitCount, fractionWidth: BitCount): AFix = AFix(integerWidth.value exp, -fractionWidth.value exp, signed = false)

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -21,11 +21,15 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
       check(4095,0,-4)(AFix.UQ(8 bits, 4 bits)) //Q8.4
 //      check(4095,0,-4)(AFix.U(255, -4 exp)) //Q8.4
 //      check(4095,2048,-4)(AFix.U(255, 128, -4 exp)) //Q8.4
+      check(4095, 0, 0)(AFix(QFormat(12, 0, false))) // Q12.0
+      check(4095, 0, -4)(AFix(QFormat(12, 4, false))) // Q8.4
       check(2047,-2048,0)(AFix.S(12 bits)) //Q11.0 + sign bit
       check(2047,-2048,-4)(AFix.S(7 exp, 12 bits)) //Q7.4  + sign bit
       check(2047,-2048,-4)(AFix.S(7 exp, -4 exp)) //Q7.4  + sign bit
       check(2047,-2048,-4)(AFix.SQ(7 bits, 4 bits)) //Q8.4 + sign bit
 //      check(2047,-2048,-4)(AFix.S(127, -128, -4 exp)) //Q7.4 + sign bit
+      check(2047, -2048, 0)(AFix(QFormat(12, 0, true))) // Q12.0
+      check(2047, -2048, -4)(AFix(QFormat(12, 4, true))) // Q7.4 + sign bit
     })
   }
 

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -28,8 +28,8 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
       check(2047,-2048,-4)(AFix.S(7 exp, -4 exp)) //Q7.4  + sign bit
       check(2047,-2048,-4)(AFix.SQ(7 bits, 4 bits)) //Q8.4 + sign bit
 //      check(2047,-2048,-4)(AFix.S(127, -128, -4 exp)) //Q7.4 + sign bit
-      check(2047, -2048, 0)(AFix(QFormat(11, 0, true))) // Q11.0 + sign bit
-      check(2047, -2048, -4)(AFix(QFormat(11, 4, true))) // Q7.4 + sign bit
+      check(2047, -2048, 0)(AFix(QFormat(12, 0, true))) // Q12.0
+      check(2047, -2048, -4)(AFix(QFormat(12, 4, true))) // Q7.4 + sign bit
     })
   }
 

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -21,15 +21,35 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
       check(4095,0,-4)(AFix.UQ(8 bits, 4 bits)) //Q8.4
 //      check(4095,0,-4)(AFix.U(255, -4 exp)) //Q8.4
 //      check(4095,2048,-4)(AFix.U(255, 128, -4 exp)) //Q8.4
-      check(4095, 0, 0)(AFix(QFormat(12, 0, false))) // Q12.0
-      check(4095, 0, -4)(AFix(QFormat(12, 4, false))) // Q8.4
+      check(4095, 0, 0)(AFix(QFormat(12, 0, false))) // 12 bits wide, 12 integral bits, 0 fractional bits, 0 sign bit
+      check(4095, 0, -4)(AFix(QFormat(12, 4, false))) // 12 bits wide, 8 integral bits, 4 fractional bits, 0 sign bit
       check(2047,-2048,0)(AFix.S(12 bits)) //Q11.0 + sign bit
       check(2047,-2048,-4)(AFix.S(7 exp, 12 bits)) //Q7.4  + sign bit
       check(2047,-2048,-4)(AFix.S(7 exp, -4 exp)) //Q7.4  + sign bit
       check(2047,-2048,-4)(AFix.SQ(7 bits, 4 bits)) //Q8.4 + sign bit
 //      check(2047,-2048,-4)(AFix.S(127, -128, -4 exp)) //Q7.4 + sign bit
-      check(2047, -2048, 0)(AFix(QFormat(12, 0, true))) // Q12.0
-      check(2047, -2048, -4)(AFix(QFormat(12, 4, true))) // Q7.4 + sign bit
+      check(2047, -2048, 0)(AFix(QFormat(12, 0, true))) // 12 bits wide, 11 integral bits, 0 fractional bits, 1 sign bit
+      check(2047, -2048, -4)(AFix(QFormat(12, 4, true))) // 12 bits wide, 7 integral bits, 4 fractional bits, 1 sign bit
+    })
+  }
+
+  test("q_format") {
+    SpinalVerilog(new Component{
+      for(intVal <- 1 to 32) {
+        for(fracVal <- 0 to intVal) {
+          val qf_s = QFormat(intVal, fracVal, true)
+          val qf_u = QFormat(intVal, fracVal, false)
+          val af_qf_s = AFix(qf_s)
+          val af_qf_u = AFix(qf_u)
+          val af_sq = AFix.SQ((intVal - fracVal - 1) bits, fracVal bits)
+          val af_uq = AFix.UQ((intVal - fracVal) bits, fracVal bits)
+
+          assert(af_qf_s.Q == qf_s)
+          assert(af_sq.Q == qf_s)
+          assert(af_qf_u.Q == qf_u)
+          assert(af_uq.Q == qf_u)
+        }
+      }
     })
   }
 

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -28,8 +28,8 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
       check(2047,-2048,-4)(AFix.S(7 exp, -4 exp)) //Q7.4  + sign bit
       check(2047,-2048,-4)(AFix.SQ(7 bits, 4 bits)) //Q8.4 + sign bit
 //      check(2047,-2048,-4)(AFix.S(127, -128, -4 exp)) //Q7.4 + sign bit
-      check(2047, -2048, 0)(AFix(QFormat(12, 0, true))) // Q12.0
-      check(2047, -2048, -4)(AFix(QFormat(12, 4, true))) // Q7.4 + sign bit
+      check(2047, -2048, 0)(AFix(QFormat(11, 0, true))) // Q11.0 + sign bit
+      check(2047, -2048, -4)(AFix(QFormat(11, 4, true))) // Q7.4 + sign bit
     })
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

To add a couple helper functions to the AFix type to take QFormat data types for setup and some rounding sizing

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [✅] Unit tests were added
- [✅] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
        [RTD Pull Request](https://github.com/SpinalHDL/SpinalDoc-RTD/pull/253)
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
