### PR TITLE
Add offset field to generated regif json

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Document/JsonGenerator.scala
@@ -41,6 +41,7 @@ final case class JsonGenerator(fileName : String) extends BusIfVisitor {
                   |           "accType" : "${f.getAccessType()}",
                   |           "name"    : "${f.getName()}",
                   |           "width"   : ${f.getWidth()},
+                  |           "offset"  : ${f.getSection().end},
                   |           "reset"   : ${f.getResetValue()},
                   |           "doc"     : "${clean(f.getDoc())}"
                   |       }""".stripMargin


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

The JSON automatically generated by a register interface had no information about the position of a register field within the word. It is possible to deduce this position by adding up the sizes of each register, but it adds unnecessary overhead to the parsing program.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
