### PR TITLE
Fix verilator version parsing

### DIFF
--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -566,7 +566,7 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
 
     val verilatorVersionProcess = Process(Seq(verilatorBinFilename, "--version"), new File(workspacePath))
     val verilatorVersion = verilatorVersionProcess.lineStream.mkString("\n") // blocks and throws an exception if exit status != 0
-    val verilatorVersionDeci = BigDecimal("v([0-9]*\\.[0-9]*)".r.findFirstIn(verilatorVersion).get.tail)
+    val verilatorVersionDeci = BigDecimal("([0-9]+\\.[0-9]+)".r.findFirstIn(verilatorVersion).get)
 
     if (cacheEnabled) {
       // calculate hash of verilator version+options and source file contents


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

On my system, verilator parsing fails since the regex in question does not seem to match the output of `verilator --version`. This is the output:
```
Verilator 5.022 2024-02-24 rev UNKNOWN.REV
```

I also tested on a Ubuntu system and it seems the output does not seem to match there either:
```
Verilator 4.038 2020-07-11 rev v4.036-114-g0cd4a57ad
```

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
