### PR TITLE
Add wave prefix for verilator & VCS

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -325,6 +325,7 @@ object SpinalVCSBackend {
     vconfig.vcsCC = config.vcsCC
     vconfig.waveDepth = config.waveDepth
     vconfig.wavePath = config.wavePath
+    vconfig.wavePrefix = config.wavePrefix
     vconfig.simSetupFile = config.simSetupFile
     vconfig.envSetup = config.envSetup
     vconfig.timePrecision = config.timePrecision match {
@@ -689,6 +690,7 @@ case class SpinalSimConfig(
                             var _timePrecision     : TimeNumber = null,
                             var _timeScale         : TimeNumber = null,
                             var _testPath          : String = "$WORKSPACE/$COMPILED/$TEST",
+                            var _waveFilePrefix    : String = null,
                             var _ghdlFlags: GhdlFlags = GhdlFlags()
   ){
 
@@ -821,6 +823,11 @@ case class SpinalSimConfig(
 
   def workspaceName(name: String): this.type = {
     _workspaceName = name
+    this
+  }
+
+  def waveFilePrefix(prefix: String): this.type = {
+    _waveFilePrefix = prefix
     this
   }
 
@@ -1031,7 +1038,7 @@ case class SpinalSimConfig(
           cachePath = if (!_disableCache) (if (_cachePath != null) _cachePath else s"${_workspacePath}/.cache") else null,
           workspacePath = s"${_workspacePath}/${_workspaceName}",
           vcdPath = wavePath,
-          vcdPrefix = null,
+          vcdPrefix = _waveFilePrefix,
           workspaceName = "verilator",
           waveDepth = _waveDepth,
           optimisationLevel = _optimisationLevel,
@@ -1059,7 +1066,7 @@ case class SpinalSimConfig(
           waveFormat = _waveFormat,
           workspacePath = s"${_workspacePath}/${_workspaceName}",
           wavePath = wavePath,
-          wavePrefix = null,
+          wavePrefix = _waveFilePrefix,
           workspaceName = "ghdl",
           waveDepth = _waveDepth,
           optimisationLevel = _optimisationLevel,
@@ -1099,7 +1106,7 @@ case class SpinalSimConfig(
           waveFormat = _waveFormat,
           workspacePath = s"${_workspacePath}/${_workspaceName}",
           wavePath = s"${_workspacePath}/${_workspaceName}",
-          wavePrefix = null,
+          wavePrefix = _waveFilePrefix,
           workspaceName = "iverilog",
           waveDepth = _waveDepth,
           optimisationLevel = _optimisationLevel,
@@ -1125,7 +1132,7 @@ case class SpinalSimConfig(
           waveFormat = _waveFormat,
           workspacePath = s"${_workspacePath}/${_workspaceName}",
           wavePath = s"${_workspacePath}/${_workspaceName}",
-          wavePrefix = null,
+          wavePrefix = _waveFilePrefix,
           workspaceName = "vcs",
           waveDepth = _waveDepth,
           optimisationLevel = _optimisationLevel,

--- a/sim/src/main/scala/spinal/sim/GhdlBackend.scala
+++ b/sim/src/main/scala/spinal/sim/GhdlBackend.scala
@@ -38,11 +38,11 @@ class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
   }
 
   if (!(Array(WaveFormat.DEFAULT, WaveFormat.NONE) contains format)) {
-    wavePath = wavePath.split('.').init ++ Seq(format.ext) mkString "."
+    val fixedPath = wavePath.split('.').init ++ Seq(format.ext) mkString "."
     if (format == WaveFormat.GHW) {
-      runFlags += " --wave=" + wavePath
+      runFlags += " --wave=" + fixedPath
     } else {
-      runFlags += " --" + format.ext + "=" + wavePath
+      runFlags += " --" + format.ext + "=" + fixedPath
     }
   }
 

--- a/sim/src/main/scala/spinal/sim/VCSBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VCSBackend.scala
@@ -130,6 +130,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
     println("Wave format " + config.waveFormat + " not supported by VCS for now")
     WaveFormat.NONE
   }
+  val fullWaveName = Some(config.wavePrefix).map(_ + "_").getOrElse("") + toplevelName
 
   val vpiModuleName = "vpi_vcs.so"
   val vpiModulePath = pluginsPath + "/" + vpiModuleName
@@ -213,7 +214,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
     }
 
     val dump = waveFormat match {
-      case WaveFormat.VCD => List(s"+vcs+dumpvars+$toplevelName.vcd")
+      case WaveFormat.VCD => List(s"+vcs+dumpvars+$fullWaveName.vcd")
       case WaveFormat.VPD => List(s"+vcs+vcdpluson")
       case WaveFormat.FSDB =>
         List(s"-P ${verdi_home}/share/PLI/VCS/LINUX64/novas.tab", s"$verdi_home/share/PLI/VCS/LINUX64/pli.a")
@@ -262,7 +263,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
          |`timescale $timeScale
          |module __simulation_def;
          |initial begin
-         |  $$fsdbDumpfile("$toplevelName.fsdb");
+         |  $$fsdbDumpfile("$fullWaveName.fsdb");
          |  $$fsdbDumpvars(${config.waveDepth}, $toplevelName);
          |  $$fsdbDumpflush;
          |end

--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -772,9 +772,10 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
   val nativeInstance: IVerilatorNative = nativeImpl.getConstructor().newInstance().asInstanceOf[IVerilatorNative]
 
   def instanciate(name: String, seed: Int) = nativeInstance.synchronized{ //synchronized is used as a Verilator isn't thread safe on construction (bug ?)
-    val patched = config.vcdPath.replace("$TEST", name)
-    val wavePath = s"${new File(patched).getAbsolutePath.replace("\\","\\\\")}/${if(config.vcdPrefix != null) config.vcdPrefix + "_" else ""}"
-    FileUtils.forceMkdirParent(new File(wavePath, "."))
+    val patchedPath = new File(config.vcdPath.replace("$TEST", name)).getAbsolutePath.replace("\\", "/")
+    val patchedPrefix = if(config.vcdPrefix == null) "" else config.vcdPrefix.replace("$TEST", name) + "_"
+    val wavePath = patchedPath + "/" + patchedPrefix
+    FileUtils.forceMkdirParent(new File(patchedPath, "."))
     nativeInstance.newHandle(name, wavePath, seed)
   }
 

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -21,6 +21,7 @@ case class VpiBackendConfig(
   var workspacePath: String  = null,
   var workspaceName: String  = null,
   var wavePath: String       = null,
+  var wavePrefix: String     = null,
   var waveFormat: WaveFormat = WaveFormat.NONE,
   var analyzeFlags: String   = "",
   var runFlags: String       = "",
@@ -40,7 +41,7 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
   val pluginsPath     = config.pluginsPath     
   val workspacePath   = config.workspacePath   
   val workspaceName   = config.workspaceName   
-  var wavePath        = config.wavePath        
+  val wavePath        = config.wavePath
   val waveFormat      = config.waveFormat      
   val analyzeFlags    = config.analyzeFlags
   var runFlags        = config.runFlags        


### PR DESCRIPTION
The prefix was already somewhat implement in the backends, expose it to the user (at least for verilator and VCS).
IVerilog and GHDL will follow, but I saw that they are currently also missing support for the `_testFile` parameter which I´d add at the same time.

# Context, Motivation & Description

`_testFile` does allow us to specify a separate folder for just the waveform file, but we can't put the results from multiple tests into the same directory due to the name collision. This is nice for two reasons:

- workspace folder may be renamed automatically, making it a chore to pick the right one
- if your waveform viewer supports switching between files, keeping signals the same they are easier to find.

# Impact on code generation

None