### PR TITLE
fix sv Interface filelist error

### DIFF
--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -102,7 +102,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
           ifFile.write(interface.result())
           ifFile.flush()
           ifFile.close()
-          fileList + ifFileName
+          fileList += ifFileName
         }
       }
 


### PR DESCRIPTION
Fix a typo error that leads to interface declare files not being included in the filelist when 'oneFilePerComponent' is enabled