### PR TITLE
Fix spaces in file paths for sby generation

### DIFF
--- a/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
+++ b/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
@@ -225,7 +225,7 @@ case class SpinalFormalConfig(
 
       val dst = rtlDir.resolve(src.getName)
       FileUtils.copyFileToDirectory(src, rtlDir.toFile())
-      rtlFiles.append(dst.toString)
+      rtlFiles.append(workingWorksplace.relativize(dst).toString)
     }
 
     _backend match {

--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -117,7 +117,7 @@ class SymbiYosysBackend(val config: SymbiYosysBackendConfig) extends FormalBacke
   }
 
   def genSby(): Unit = {
-    val localSources = config.rtlSourcesPaths.map(f => new File(f).getAbsolutePath).mkString("\n")
+    val localSources = config.rtlSourcesPaths.map(f => new File(f)).mkString("\n")
     val read = config.rtlSourcesPaths
       .map(f => {
         Paths.get(f).getFileName


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1408 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
The `sby` tool does not support spaces in paths. Since absolute paths are used in the "files" section of the .sby file, users whose projects are in paths with spaces cannot currently use SpinalHDL formal verification.

This fixes the issue by using relative paths instead of absolute paths. That is, as long as the component does not have a space in its name, but this shouldn't be support by VHDL/Verilog anyways.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
Files in the .sby "files" section use relative paths instead of absolute paths.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?

@TheImunityGamer it would be great if you could confirm this fixes your issue.