### PR TITLE
Streamhistory

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1653,12 +1653,7 @@ class StreamHistory[T <: Data](dataType: HardType[T], length: Int) extends Compo
         {
           val stream = Stream(dataType)
           stream <-< prev
-
-          val next = Stream(dataType)
-          next.valid := stream.valid
-          next.payload := stream.payload
-          stream.ready := next.ready | !stream.valid
-          next
+          stream
         },
         left - 1)
     }

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1669,7 +1669,6 @@ class StreamHistory[T <: Data](dataType: HardType[T], length: Int) extends Compo
     x.valid := y.valid
     x.payload := y.payload
   })
-  // (0 to length).map(x => io.states(x).valid := connections(x).valid, io.states(x).payload := connections(x).payload)
 }
 
 object StreamCCByToggle {

--- a/tester/src/test/scala/spinal/lib/SpinalSimStreamHistoryTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimStreamHistoryTester.scala
@@ -1,0 +1,130 @@
+package spinal.lib
+
+import scala.collection.mutable
+import scala.util.Random
+
+import spinal.core._
+import spinal.lib.sim._
+import spinal.core.sim._
+import spinal.tester.SpinalSimFunSuite
+
+class SpinalSimStreamHistoryTester extends SpinalSimFunSuite {
+    def prepare(
+        dut: StreamHistory[UInt],
+        alwaysInput: Boolean = false,
+        alwaysOutput: Boolean = false,
+        inQueue: mutable.Queue[BigInt],
+        outQueue: mutable.Queue[BigInt],
+    ) {
+        dut.clockDomain.forkStimulus(period = 10)
+        dut.io.push.valid #= false
+
+        if (alwaysOutput) {
+            dut.io.pop.ready #= true
+        } else {
+            val randomReady = StreamReadyRandomizer(dut.io.pop, dut.clockDomain)
+        }
+
+        val driver = StreamDriver(dut.io.push, dut.clockDomain) { payload =>
+            if (inQueue.nonEmpty) {
+                payload #= inQueue.dequeue()
+                true
+            } else {
+                false
+            }
+        }
+        driver.transactionDelay = () => {
+            if (!alwaysInput) {
+                val x = Random.nextDouble()
+                (x * x * 10).toInt
+            } else {
+                0
+            }
+        }
+
+        val monitor = StreamMonitor(dut.io.pop, dut.clockDomain) { payload =>
+            {
+                val expected = outQueue.dequeue()
+                val data = payload.toBigInt
+                assert(data == expected)
+            }
+        }
+
+        for (j <- 0 until 10000) {
+            val data = Random.nextInt(0xffffff)
+
+            inQueue.enqueue(data)
+            outQueue.enqueue(data)
+        }
+    }
+
+    test("testRandomInOut") {
+        val compiled = SimConfig.withFstWave.allOptimisation.compile {
+            val dut = new StreamHistory(
+                UInt(32 bits),
+                12,
+            )
+            dut
+        }
+        compiled.doSimUntilVoid { dut =>
+            val inQueue    = mutable.Queue[BigInt]()
+            val outQueue   = mutable.Queue[BigInt]()
+            prepare(dut, false, false, inQueue, outQueue)
+            dut.clockDomain.waitSampling((1 KiB).toInt)
+            simSuccess()
+        }
+    }
+
+    test("testRandomIn") {
+        val compiled = SimConfig.allOptimisation.compile {
+            val dut = new StreamHistory(
+                UInt(32 bits),
+                12
+            )
+            dut
+        }
+        compiled.doSimUntilVoid { dut =>
+            val inQueue    = mutable.Queue[BigInt]()
+            val outQueue   = mutable.Queue[BigInt]()
+            prepare(dut, false, true, inQueue, outQueue)
+            dut.clockDomain.waitSampling((1 KiB).toInt)
+            simSuccess()
+        }
+    }
+
+    test("testRandomOut") {
+        val lastQueue = mutable.Queue[Boolean]()
+        val compiled = SimConfig.allOptimisation.compile {
+            val dut = new StreamHistory(
+                UInt(32 bits),
+                12
+            )
+            dut
+        }
+        compiled.doSimUntilVoid { dut =>
+            val inQueue    = mutable.Queue[BigInt]()
+            val outQueue   = mutable.Queue[BigInt]()
+            prepare(dut, true, false, inQueue, outQueue)
+            dut.clockDomain.waitSampling((1 KiB).toInt)
+            simSuccess()
+        }
+    }
+
+    test("testFullPipeline") {
+        val lastQueue = mutable.Queue[Boolean]()
+        val compiled = SimConfig.allOptimisation.compile {
+            val dut = new StreamHistory(
+                UInt(32 bits),
+                12
+            )
+            dut
+        }
+        compiled.doSimUntilVoid { dut =>
+            val inQueue    = mutable.Queue[BigInt]()
+            val outQueue   = mutable.Queue[BigInt]()
+            prepare(dut, true, true, inQueue, outQueue)
+            dut.clockDomain.waitSampling((1 KiB).toInt)
+            simSuccess()
+        }
+    }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

StreamHistory is a kind of history which would have a valid for each element to demonstrate if the data is valid for using.
It acts like FIFO, also follow first in first out policy, but with internal data visibility.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ x ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
