### PR TITLE
Correct frequency calculation in newSlowedClockDomain

### DIFF
--- a/core/src/main/scala/spinal/core/ClockDomain.scala
+++ b/core/src/main/scala/spinal/core/ClockDomain.scala
@@ -442,7 +442,7 @@ def renamePulledWires(clock     : String = null,
   }
 
   def newSlowedClockDomain(freq: HertzNumber): ClockDomain = {
-    val currentFreq = ClockDomain.current.frequency.getValue.toBigDecimal
+    val currentFreq = frequency.getValue.toBigDecimal
     freq match {
       case x if x.toBigDecimal > currentFreq => SpinalError("To high frequancy")
       case x                                 => newClockDomainSlowedBy((currentFreq/freq.toBigDecimal).toBigInt)
@@ -497,8 +497,3 @@ def renamePulledWires(clock     : String = null,
     }
   }
 }
-
-
-
-
-


### PR DESCRIPTION
`ClockDomain.newSlowedClockDomain()` was using the current clockdomain's frequency rather than the clock domain on which the method was called to calculate the resulting domain's factor.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1422

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
