### PR TITLE
Update C++ version CFLAGS as Verilator requires C++14 or newer

### DIFF
--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -27,7 +27,7 @@ case class VpiBackendConfig(
   var runFlags: String       = "",
   var sharedMemSize: Int     = 65536,
   var CC: String             = "g++",
-  var CFLAGS: String         = "-std=c++11 -Wall -Wextra -pedantic -O2 -Wno-strict-aliasing -Wno-write-strings", 
+  var CFLAGS: String         = "-std=c++14 -Wall -Wextra -pedantic -O2 -Wno-strict-aliasing -Wno-write-strings", 
   var LDFLAGS: String        = "-lpthread ", 
   var useCache: Boolean      = false,
   var logSimProcess: Boolean = false,


### PR DESCRIPTION


<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

I stumbled on this when I used a Docker container with newer Verilator versions, SpinalHDL would not be able to build the Verilator simulations as an Error about the C++ Version (c++11 instead c++14) occurs.

```
In file included from /usr/share/verilator/include/verilated_dpi.cpp:30:
/usr/share/verilator/include/verilatedos.h:271:3: error: #error "Verilator requires a C++14 or newer compiler"
  271 | # error "Verilator requires a C++14 or newer compiler"
      |   ^~~~~
In file included from /usr/share/verilator/include/verilated.h:42,
                 from ./VMurax.h:11,
                 from ../main.cpp:1:
/usr/share/verilator/include/verilatedos.h:271:3: error: #error "Verilator requires a C++14 or newer compiler"
  271 | # error "Verilator requires a C++14 or newer compiler"
      |   ^~~~~
```


This commit should at least fix it for now.

Is there any further checks I need to do or what I can do to help this?

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
