### PR TITLE
add missing match case for ElabOrderId.getName

### DIFF
--- a/core/src/main/scala/spinal/core/fiber/Fiber.scala
+++ b/core/src/main/scala/spinal/core/fiber/Fiber.scala
@@ -18,6 +18,7 @@ object ElabOrderId{
     case INIT  => "init"
     case SETUP => "setup"
     case BUILD => "build"
+    case PATCH => "patch"
     case CHECK => "check"
   }
 }


### PR DESCRIPTION
`ElabOrderId.getName` does not assign a name to the patch phase, which would cause a match error during elaboration.