### PR TITLE
Constraint writer: use regex to match for net names

### DIFF
--- a/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoConstraintWriter.scala
+++ b/lib/src/main/scala/spinal/lib/eda/xilinx/VivadoConstraintWriter.scala
@@ -76,7 +76,7 @@ object VivadoConstraintWriter {
     }
     val sourceLocator = if (source.isReg && !resetIsDriver) {
       // source is register inside spinal design
-      f"set source [get_cells ${source.getRtlPath()}_reg*]"
+      f"set source [get_cells -hier -filter {NAME =~ */${source.getRtlPath()}_reg*}]"
     } else {
       findDriverCell(falsePathTag.source.get.getName())
     }
@@ -87,7 +87,7 @@ object VivadoConstraintWriter {
       s"""
          |# CDC constaints for ${source.getRtlPath()} -> ${target} in ${s.component.getPath()}
          |$sourceLocator
-         |set_false_path$quiet -from $$source -to [get_pins -regexp ${target}_reg*/$pinName]
+         |set_false_path$quiet -from $$source -to [get_pins -hier -regexp -filter {NAME =~ ".*/${target}_reg.*/$pinName"}]
          |""".stripMargin)
 
   }
@@ -108,9 +108,9 @@ object VivadoConstraintWriter {
          |# CDC constraints for ${source.getRtlPath()} -> ${target.getRtlPath()} in ${s.component.getPath()}
          |${findClockPeriod(sourceCD, s.component.getName(), "src_clk_period")}
          |${findClockPeriod(targetCD, s.component.getName(), "dst_clk_period")}
-         |set source [get_cells ${source.getRtlPath()}_reg*]
-         |set_max_delay -from $$source -to [get_pins ${target.getRtlPath()}_reg*/D] [$maxDelay] -datapath_only
-         |set_bus_skew -from $$source -to [get_pins ${target.getRtlPath()}_reg*/D] $$dst_clk_period
+         |set source [get_cells -hier -filter {NAME =~ */${source.getRtlPath()}_reg*}]
+         |set_max_delay -from $$source -to [get_pins -hier -filter {NAME =~ */${target.getRtlPath()}_reg*/D}] [$maxDelay] -datapath_only
+         |set_bus_skew -from $$source -to [get_pins -hier -filter {NAME =~ */${target.getRtlPath()}_reg*/D}] $$dst_clk_period
          |""".stripMargin)
   }
 


### PR DESCRIPTION
Noticed a commit that I have locally and forgot to push to the PR branch for the constraint writer.  We need to use hierarchical names to find nets, when the generated SpinalHDL module is not the top-level module.