### PR TITLE
ACE & ACE-Lite signals

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4.scala
@@ -29,7 +29,15 @@ package spinal.lib.bus.amba4.axi
 import spinal.core._
 import spinal.lib._
 
-
+case class Ace4Config(isAceLite       : Boolean = true,
+                      useSnoopData    : Boolean = false,
+                      useAwUnique     : Boolean = false,
+                      snoopDataWidth  : Int = -1,
+                     ) {
+  if (useSnoopData)
+    require(List(32, 64, 128, 256, 512, 1024) contains snoopDataWidth,
+      "Valid snoop data width: 32, 64, 128, 256, 512 or 1024 bit")
+}
 
 /**
  * Configuration class for the Axi4 bus
@@ -56,6 +64,8 @@ case class Axi4Config(addressWidth : Int,
                       wUserWidth   : Int = -1,
                       bUserWidth   : Int = -1,
 
+                      aceConfig    : Option[Ace4Config] = None,
+
                       readIssuingCapability     : Int = -1,
                       writeIssuingCapability    : Int = -1,
                       combinedIssuingCapability : Int = -1,
@@ -69,6 +79,10 @@ case class Axi4Config(addressWidth : Int,
   def useBUser = bUserWidth >= 0
   def useArwUser = arwUserWidth >= 0 //Shared AR/AW channel
   def arwUserWidth = Math.max(arUserWidth, awUserWidth)
+
+  def isAce = aceConfig.nonEmpty
+  def isAceFull = isAce && !aceConfig.get.isAceLite
+  def isAceLite = isAce && aceConfig.get.isAceLite
 
   if(useId)
     require(idWidth >= 0,"You need to set idWidth")
@@ -122,14 +136,27 @@ case class Axi4(config: Axi4Config) extends Bundle with IMasterSlave with Axi4Bu
   val ar = Stream(Axi4Ar(config))
   val r  = Stream(Axi4R(config))
 
+  val ac = if (config.isAceFull) Stream(Ace4Ac(config)) else null
+  val cr = if (config.isAceFull) Stream(Ace4Cr(config)) else null
+  val cd = if (config.isAceFull && config.aceConfig.get.useSnoopData) Stream(Ace4Cd(config)) else null
+
+  val rack = if (config.isAceFull) Bool() else null
+  val wack = if (config.isAceFull) Bool() else null
+
   def writeCmd  = aw
   def writeData = w
   def writeRsp  = b
   def readCmd   = ar
   def readRsp   = r
 
+  def snoopCmd = ac
+  def snoopRsp = cr
+  def snoopData = cd
+
   def <<(that : Axi4) : Unit = that >> this
   def >> (that : Axi4) : Unit = {
+    require(!config.isAce && !that.config.isAce, "bus connection with ACE is not implemented yet")
+
     this.readCmd drive that.readCmd
     this.writeCmd drive that.writeCmd
     this.writeData drive that.writeData
@@ -162,8 +189,9 @@ case class Axi4(config: Axi4Config) extends Bundle with IMasterSlave with Axi4Bu
   }
 
   override def asMaster(): Unit = {
-    master(ar,aw,w)
-    slave(r,b)
+    master(ar,aw,w,cr,cd)
+    slave(r,b,ac)
+    out(rack,wack)
   }
 
   def toReadOnly(idleOthers: Boolean = false): Axi4ReadOnly ={
@@ -296,6 +324,91 @@ object Axi4{
     def EXOKAY = B"01" // Exclusive access okay
     def SLVERR = B"10" // Slave error
     def DECERR = B"11" // Decode error
+  }
+
+  // ARM IHI 0022E, Table C3-7
+  object arsnoop {
+    def apply() = Bits(4 bits)
+    // Non-snooping:      ARBAR=0b0, ARDOMAIN=0b00 / 0b11
+    def READ_NO_SNOOP         = B"0000"
+    // Coherent:          ARBAR=0b0, ARDOMAIN=0b01 / 0b10
+    def READ_ONCE             = B"0000"
+    def READ_SHARED           = B"0001"
+    def READ_CLEAN            = B"0010"
+    def READ_NOT_SHARED_DIRTY = B"0011"
+    def READ_UNIQUE           = B"0111"
+    def CLEAN_UNIQUE          = B"1011"
+    def MAKE_UNIQUE           = B"1100"
+    // Cache maintenance: ARBAR=0b0, ARDOMAIN=0b00 / 0b01 / 0b10
+    def CLEAN_SHARED          = B"1000"
+    def CLEAN_INVALID         = B"1001"
+    def MAKE_INVALID          = B"1101"
+    // Barrier:           ARBAR=0b1
+    def BARRIER               = B"0000"
+    // DVM:               ARBAR=0b0, ARDOMAIN=0b01 / 0b10
+    def DVM_COMPLETE          = B"1110"
+    def DVM_MESSAGE           = B"1111"
+  }
+
+  // ARM IHI 0022E, Table C3-8
+  object awsnoop {
+    def apply() = Bits(3 bits)
+    // Non-snooping:      AWBAR=0b0, AWDOMAIN=0b00 / 0b11
+    def WRITE_NO_SNOOP        = B"000"
+    // Coherent:          AWBAR=0b0, AWDOMAIN=0b01 / 0b10
+    def WRITE_UNIQUE          = B"000"
+    def WRITE_LINE_UNIQUE     = B"001"
+    // Memory update:     AWBAR=0b0, AWDOMAIN=0b00 / 0b01 / 0b10
+    def WRITE_CLEAN           = B"010"
+    def WRITE_BACK            = B"011"
+    // Memory update:     AWBAR=0b0, AWDOMAIN=0b01 / 0b10
+    def EVICT                 = B"100"
+    def WRITE_EVICT           = B"101"
+    // Barrier:           AWBAR=0b1
+    def BARRIER               = B"000"
+  }
+
+  // ARM IHI 0022E, Table C3-20
+  object acsnoop {
+    def apply() = Bits(4 bits)
+    def READ_ONCE             = B"0000"
+    def READ_SHARED           = B"0001"
+    def READ_CLEAN            = B"0010"
+    def READ_NOT_SHARED_DIRTY = B"0011"
+    def READ_UNIQUE           = B"0111"
+    def CLEAN_SHARED          = B"1000"
+    def CLEAN_INVALID         = B"1001"
+    def MAKE_INVALID          = B"1101"
+    def DVM_COMPLETE          = B"1110"
+    def DVM_MESSAGE           = B"1111"
+  }
+
+  // ARM IHI 0022E, Table C3-22
+  object crresp {
+    def apply() = Bits(5 bits)
+    def DATA_TANSFER = M"----1"
+    def ERROR        = M"---1-"
+    def PASS_DIRTY   = M"--1--"
+    def IS_SHARED    = M"-1---"
+    def WAS_UNIQUE   = M"1----"
+  }
+
+  // ARM IHI 0022E, Table C3-2
+  object domain {
+    def apply() = Bits(2 bits)
+    def NON_SHAREABLE   = B"00"
+    def INNER_SHAREABLE = B"01"
+    def OUTER_SHAREABLE = B"10"
+    def SYSTEM          = B"11"
+  }
+
+  // ARM IHI 0022E, Table C3-5
+  object axbar {
+    def apply() = Bits(2 bits)
+    def NORM_RESPECT_BAR = B"00"
+    def MEM_BAR          = B"01"
+    def NORM_IGNORE_BAR  = B"10"
+    def SYN_BAR          = B"11"
   }
 
   //Return the increment of a address depending the burst configuration (INCR,WRAP,FIXED)


### PR DESCRIPTION
As discussed in #1445, this is still a draft.

- [x] basic signals for ACE4 and ACE4-Lite
- [x] encodings for enums
- [x] basic test for signals (checked locally, test not pushed)
- [ ] `>>` operator, upgrade & downgrade between ACE and ACE-Lite
- [ ] test if it connects to the Zynq ACE port
- [ ] sample app to see if it actually works
- [ ] better abstraction?
- [ ] stretch goal: a bridge to/from TL-C?