### PR TITLE
add driveTo method return stream directly.

### DIFF
--- a/lib/src/main/scala/spinal/lib/misc/pipeline/Node.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/Node.scala
@@ -150,20 +150,20 @@ trait NodeApi extends NodeBaseApi {
     con(that.payload, getNode)
   }
 
-  def driveTo[T <: Data](con: (Node) => T): Stream[T] = {
+  def driveTo[T <: Data](that: Flow[T])(con: (T, Node) => Unit): Unit = {
+    arbitrateTo(that)
+    con(that.payload, getNode)
+  }
+
+  def toStream[T <: Data](con: (Node) => T): Stream[T] = {
     val newPayload = con(getNode)
     val that = Stream(cloneOf(newPayload))
     that.payload := newPayload 
     arbitrateTo(that)
     that
   }
-
-  def driveTo[T <: Data](that: Flow[T])(con: (T, Node) => Unit): Unit = {
-    arbitrateTo(that)
-    con(that.payload, getNode)
-  }
   
-  def driveToFlow[T <: Data](con: (Node) => T): Flow[T] = {
+  def toFlow[T <: Data](con: (Node) => T): Flow[T] = {
     val newPayload = con(getNode)
     val that = Flow(cloneOf(newPayload))
     that.payload := newPayload 

--- a/lib/src/main/scala/spinal/lib/misc/pipeline/Node.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/Node.scala
@@ -150,9 +150,25 @@ trait NodeApi extends NodeBaseApi {
     con(that.payload, getNode)
   }
 
+  def driveTo[T <: Data](con: (Node) => T): Stream[T] = {
+    val newPayload = con(getNode)
+    val that = Stream(cloneOf(newPayload))
+    that.payload := newPayload 
+    arbitrateTo(that)
+    that
+  }
+
   def driveTo[T <: Data](that: Flow[T])(con: (T, Node) => Unit): Unit = {
     arbitrateTo(that)
     con(that.payload, getNode)
+  }
+  
+  def driveToFlow[T <: Data](con: (Node) => T): Flow[T] = {
+    val newPayload = con(getNode)
+    val that = Flow(cloneOf(newPayload))
+    that.payload := newPayload 
+    arbitrateTo(that)
+    that
   }
 }
 

--- a/tester/src/test/scala/spinal/lib/misc/pipeline/PipelineTester.scala
+++ b/tester/src/test/scala/spinal/lib/misc/pipeline/PipelineTester.scala
@@ -98,10 +98,9 @@ class PipelineTester extends SpinalAnyFunSuite{
     val OUT = Payload(UInt(16 bits))
 
     val up = slave Stream (IN)
-    val down = master Stream (OUT)
 
     n0.driveFrom(up)((self, payload) => self(IN) := payload)
-    n3.driveTo(down)((payload, self) => payload := self(OUT))
+    val down = master(n3.driveTo((self) => self(OUT)))
 
     val connectors = List(s01, s12, s23)
     afterElaboration(Builder(connectors))

--- a/tester/src/test/scala/spinal/lib/misc/pipeline/PipelineTester.scala
+++ b/tester/src/test/scala/spinal/lib/misc/pipeline/PipelineTester.scala
@@ -100,7 +100,7 @@ class PipelineTester extends SpinalAnyFunSuite{
     val up = slave Stream (IN)
 
     n0.driveFrom(up)((self, payload) => self(IN) := payload)
-    val down = master(n3.driveTo((self) => self(OUT)))
+    val down = master(n3.toStream((self) => self(OUT)))
 
     val connectors = List(s01, s12, s23)
     afterElaboration(Builder(connectors))


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1446
return stream directly by driveTo which simplify usage.

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
