### PR TITLE
Packed bundle assignment bug

### DIFF
--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -77,7 +77,7 @@ class PackedBundle extends Bundle {
 
   def packed: Bits = {
     val maxWidth = mappings.map(_._1.high).max + 1
-    val packed = B(0, maxWidth bit)
+    val packed = B(0, maxWidth bit).allowOverride()
     for ((range, data) <- mappings) {
       if (range.step > 0) {
         // "Little endian" -- ascending range

--- a/tester/src/test/scala/spinal/lib/SpinalSimPackedBundleTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimPackedBundleTester.scala
@@ -414,4 +414,22 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
         }
       })
   }
+
+  test("pack single field") {
+    SimConfig
+      .compile(new Component {
+
+        val packedBundle = new PackedBundle {
+          val a = Bits(4 bits)
+        }
+
+        val io = new Bundle {
+          val a = in Bits(4 bits)
+          val packed = out Bits(4 bits)
+        }
+
+        packedBundle.a := io.a
+        io.packed := packedBundle.packed
+      })
+  }
 }


### PR DESCRIPTION
Updated PackedBundle's `packed` method to avoid Assignment Overlap errors when the Bundle contains only a single field.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

As demonstrated in #1441, a `PackedBundle` with a single field can cause an `ASSIGNMENT OVERLAP` error. This is likely because assignment completely re-assigns an internal Bits buffer object, whereas in the case of multiple fields, no one single field overwrites the entire buffer. Adding `allowOverride` to the buffer clears up the issue.

# Impact on code generation

None anticipated or expected.

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
