### PR TITLE
Added skipOver method to PackedBundle

### DIFF
--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -168,6 +168,13 @@ class PackedBundle extends Bundle {
     }
   }
 
+  /** Skip to the specified bit. The next unspecified field will be packed starting from here.
+    * @param pos Bit position to skip to
+    * */
+  protected def skipTo(pos: Int): Unit = {
+    this.mapBuilder.nextPos = pos
+  }
+
   override def valCallbackRec(ref: Any, name: String): Unit = {
     super.valCallbackRec(ref, name)
 

--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -173,8 +173,8 @@ class PackedBundle extends Bundle {
     * of bits after the last placed field.
     * @param count Number of bits to skip over
     */
-  protected def skipOver(count: Int): Unit = {
-    this.mapBuilder.nextPos += count
+  protected def skipOver(count: BitCount): Unit = {
+    this.mapBuilder.nextPos += count.value
   }
 
   override def valCallbackRec(ref: Any, name: String): Unit = {

--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -168,11 +168,13 @@ class PackedBundle extends Bundle {
     }
   }
 
-  /** Skip to the specified bit. The next unspecified field will be packed starting from here.
-    * @param pos Bit position to skip to
-    * */
-  protected def skipTo(pos: Int): Unit = {
-    this.mapBuilder.nextPos = pos
+  /**
+    * Skips over the specified number of bits. The next unspecified field will be placed starting `count` number
+    * of bits after the last placed field.
+    * @param count Number of bits to skip over
+    */
+  protected def skipOver(count: Int): Unit = {
+    this.mapBuilder.nextPos += count
   }
 
   override def valCallbackRec(ref: Any, name: String): Unit = {

--- a/tester/src/test/scala/spinal/lib/SpinalSimPackedBundleTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimPackedBundleTester.scala
@@ -415,13 +415,13 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
       })
   }
 
-  test("pack with skipTo") {
+  test("pack with skipOver") {
     SimConfig
       .compile(new Component {
         val packedBundle = new PackedBundle {
           val a = Bits(4 bits) // Bits 0 1 2 3
-          skipTo(8)
-          val b = Bits(8 bits)
+          skipOver(4)
+          val b = Bits(8 bits) // Bits 8 9 10 11 12 13 14 15
         }
 
         val io = new Bundle {
@@ -462,13 +462,13 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
       })
   }
 
-  test("unpack with skipTo") {
+  test("unpack with skipOver") {
     SimConfig
       .compile(new Component {
         val packedBundle = new PackedBundle {
           val a = Bits(4 bits) // Bits 0 1 2 3
-          skipTo(8)
-          val b = Bits(8 bits)
+          skipOver(4)
+          val b = Bits(8 bits) // Bits 8 9 10 11 12 13 14 15
         }
 
         val io = new Bundle {

--- a/tester/src/test/scala/spinal/lib/SpinalSimPackedBundleTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimPackedBundleTester.scala
@@ -420,7 +420,7 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
       .compile(new Component {
         val packedBundle = new PackedBundle {
           val a = Bits(4 bits) // Bits 0 1 2 3
-          skipOver(4)
+          skipOver(4 bits)
           val b = Bits(8 bits) // Bits 8 9 10 11 12 13 14 15
         }
 
@@ -467,7 +467,7 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
       .compile(new Component {
         val packedBundle = new PackedBundle {
           val a = Bits(4 bits) // Bits 0 1 2 3
-          skipOver(4)
+          skipOver(4 bits)
           val b = Bits(8 bits) // Bits 8 9 10 11 12 13 14 15
         }
 

--- a/tester/src/test/scala/spinal/lib/SpinalSimPackedBundleTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimPackedBundleTester.scala
@@ -414,4 +414,98 @@ class SpinalSimPackedBundleTester extends SpinalAnyFunSuite {
         }
       })
   }
+
+  test("pack with skipTo") {
+    SimConfig
+      .compile(new Component {
+        val packedBundle = new PackedBundle {
+          val a = Bits(4 bits) // Bits 0 1 2 3
+          skipTo(8)
+          val b = Bits(8 bits)
+        }
+
+        val io = new Bundle {
+          val a = in(Bits(4 bit))
+          val b = in(Bits(8 bit))
+          val packed = out(Bits(packedBundle.getPackedWidth bits))
+        }
+
+        io.packed := RegNext(packedBundle.packed)
+        packedBundle.a := io.a
+        packedBundle.b := io.b
+      })
+      .doSim(dut => {
+        dut.clockDomain.forkStimulus(10)
+
+        def pack(a: BigInt, b: BigInt): BigInt = {
+          var res = BigInt(0)
+          res += a
+          res += b << 8
+          res
+        }
+
+        for (i <- 0 to 15) {
+          val n = 1 << i
+          dut.io.a #= n & 0xF
+          dut.io.b #= (n >> 8) & 0xFF
+          dut.clockDomain.waitFallingEdge()
+          val packedCalc = pack(
+            dut.io.a.toBigInt,
+            dut.io.b.toBigInt
+          )
+
+          assert(
+            dut.io.packed.toBigInt == packedCalc,
+            s"Bit ${i}: 0x${dut.io.packed.toBigInt.toString(16)} =!= 0x${packedCalc.toString(16)}\n"
+          )
+        }
+      })
+  }
+
+  test("unpack with skipTo") {
+    SimConfig
+      .compile(new Component {
+        val packedBundle = new PackedBundle {
+          val a = Bits(4 bits) // Bits 0 1 2 3
+          skipTo(8)
+          val b = Bits(8 bits)
+        }
+
+        val io = new Bundle {
+          val a = out(Bits(4 bit))
+          val b = out(Bits(8 bit))
+          val packed = in(Bits(packedBundle.getPackedWidth bits))
+        }
+
+        packedBundle.unpack(RegNext(io.packed))
+        io.a := packedBundle.a
+        io.b := packedBundle.b
+      })
+      .doSim(dut => {
+        dut.clockDomain.forkStimulus(10)
+
+        def pack(a: BigInt, b: BigInt): BigInt = {
+          var res = BigInt(0)
+          res += a
+          res += b << 8
+          res
+        }
+
+        for (i <- 0 to 15) {
+          dut.io.packed #= 1 << i
+          dut.clockDomain.waitFallingEdge()
+          var packedCalc = pack(
+            dut.io.a.toBigInt,
+            dut.io.b.toBigInt
+          )
+          // Add the ignored bits back in
+          packedCalc |= (dut.io.packed.toBigInt & 0xF << 4)
+
+          assert(
+            dut.io.packed.toBigInt == packedCalc,
+            s"Bit ${i}: 0x${dut.io.packed.toBigInt.toString(16)} =!= 0x${packedCalc.toString(16)}\n"
+          )
+        }
+      })
+  }
 }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1337 

# Context, Motivation & Description

Adds the `skipOver` method to PackedBundle, which enables specification of gaps in packing without needing explicitly calculated bit positions (i.e., `packFrom` or `packTo`). 

# Impact on code generation

None

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
