### PR TITLE
validate component and declaration naming

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2481,6 +2481,40 @@ class PhaseAllocateNames(pc: PhaseContext) extends PhaseMisc{
     for (c <- sortedComponents.reverse) {
       c.allocateNames(pc.globalScope)
     }
+
+    val invalidVhdlIdentifier = List (
+      ("[^\\w]".r, "contains non-alphanumeric characters"),
+      ("_$".r, "ends with an underscore"),
+      ("__".r, "contains a double underscore"),
+      ("^[^a-zA-Z]".r, "doesn't start with a letter")
+    )
+    val invalidVerilogIdentifier = List (
+      ("[^\\w$]".r, "contains non-alphanumeric or dollar characters"),
+      ("^[^a-zA-Z_]".r, "doesn't start with a letter or underscore")
+    )
+    def checkName(namedObj: Nameable): Unit = {
+      var name = namedObj.getName()
+      if (!name.startsWith(pc.globalData.anonymSignalPrefix)) {
+        for ((regex, reason) <- invalidVhdlIdentifier) {
+          if (regex.findFirstIn(name).exists(_ => true)) {
+            val msg = s"Name of $namedObj is invalid in VHDL because it $reason."
+            if (pc.config.mode == VHDL) SpinalError(msg)
+            else SpinalWarning(msg)
+          }
+        }
+        for ((regex, reason) <- invalidVerilogIdentifier) {
+          if (regex.findFirstIn(name).exists(_ => true)) {
+            val msg = s"Name of $namedObj is invalid in (System)Verilog bacause it $reason."
+            if (pc.config.mode != VHDL) SpinalError(msg)
+            else SpinalWarning(msg)
+          }
+        }
+      }
+    }
+    pc.walkComponents( c => {
+      checkName(c)
+      c.dslBody.walkDeclarations( d => checkName(d) )
+    })
   }
 }
 

--- a/tester/src/test/scala/spinal/core/NameableTester.scala
+++ b/tester/src/test/scala/spinal/core/NameableTester.scala
@@ -1,0 +1,72 @@
+package spinal.core
+
+import org.scalatest.funsuite.AnyFunSuite
+
+object NameableTester {
+  class NameableTester(nameToSet: String) extends Component {
+    val signal = Bool().setName(nameToSet)
+  }
+}
+
+class NameableTester extends AnyFunSuite {
+  def genVhdl(nameToSet: String): Unit = {
+    SpinalConfig(mode = VHDL).generate(new NameableTester.NameableTester(nameToSet))
+  }
+  def genVhdlShouldFail(nameToSet: String): Unit = {
+    try {
+      genVhdl(nameToSet)
+    } catch {
+      case e: Throwable => {
+        return
+      }
+    }
+    assert(false, s"VHDL generation for name '$nameToSet' was expected to fail, but did not :(")
+  }
+
+  def genVerilog(nameToSet: String): Unit = {
+    SpinalConfig(mode = Verilog).generate(new NameableTester.NameableTester(nameToSet))
+  }
+  def genVerilogShouldFail(nameToSet: String): Unit = {
+    try {
+      genVerilog(nameToSet)
+    } catch {
+      case e: Throwable => {
+        return
+      }
+    }
+    assert(false, s"Verilog generation for name '$nameToSet' was expected to fail, but did not :(")
+  }
+
+  test("vhdl - invalid formats") {
+    genVhdlShouldFail("_test_abc")
+    genVhdlShouldFail("1test_abc")
+    genVhdlShouldFail("test_abc_")
+    genVhdlShouldFail("test__abc")
+    genVhdlShouldFail("test abc")
+    genVhdlShouldFail("test@abc")
+  }
+
+  test("vhdl - valid formats") {
+    genVhdl("test_abc")
+    genVhdl("test_abc1")
+    genVhdl("t1est_abc")
+    genVhdl("t_e_s_t_a_b_c")
+  }
+
+  test("verilog - invalid formats") {
+    genVerilogShouldFail("1test_abc")
+    genVerilogShouldFail("test abc")
+    genVerilogShouldFail("test@abc")
+    genVerilogShouldFail("$test_abc")
+  }
+
+  test("verilog - valid formats") {
+    genVerilog("test_abc")
+    genVerilog("test_abc1")
+    genVerilog("t1est_abc")
+    genVerilog("t_e_s_t_a_b_c")
+    genVerilog("test_abc$")
+    genVerilog("_test_abc")
+    genVerilog("t$est_abc")
+  }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

related #1463

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
Spinal now checks the names of components and declarations for validity in the currently active language.
If an invalid name is found, it fails the generation.
If an invalid name in another than the currently active language is found, it reports a warning.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
Spinal will now refuse to generate code that has invalid identifiers. Previously Spinal did just generate it and at a later step the user had to find out (through GHDL, Quartus, etc.) that the generated code was invalid.

# Checklist

- [x] Unit tests were added
- [x] ~API changes are or will be documented:~ -> no changes to API
