### PR TITLE
add newline to VpiBackend output

### DIFF
--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -94,8 +94,8 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
 
   class Logger extends ProcessLogger {
     val logs = new StringBuilder()
-    override def err(s: => String): Unit = { logs ++= (s) }
-    override def out(s: => String): Unit = { logs ++= (s) }
+    override def err(s: => String): Unit = { logs ++= (s ++ Properties.lineSeparator) }
+    override def out(s: => String): Unit = { logs ++= (s ++ Properties.lineSeparator) }
     override def buffer[T](f: => T) = f
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
The VCS Simulation backend printed the output in one continues line which made it hard to read. This merge request adds a line seperator to the `Logger` in the `VpiBackend`, similar to the `XSimBackend` and `VerilatorBackend`.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
None

# Checklist

- [x] Unit tests were added _(not required imo)_
- [x] API changes are or will be documented:
  - no API changes
