### PR TITLE
RFC: Add blackboxing for simple 1-port synchronous ROMs

### DIFF
--- a/core/src/main/scala/spinal/core/MemBlackBox.scala
+++ b/core/src/main/scala/spinal/core/MemBlackBox.scala
@@ -259,6 +259,32 @@ class Ram_1wrs(
   noIoPrefix()
 }
 
+/**
+ * Rom 1rs
+ */
+class Rom_1rs(
+                val wordWidth      : Int,
+                val wordCount      : Int,
+                val technology     : MemTechnologyKind
+              ) extends BlackBox {
+
+  addGenerics(
+    "wordCount"      -> Rom_1rs.this.wordCount,
+    "wordWidth"      -> Rom_1rs.this.wordWidth,
+    "technology"     -> Rom_1rs.this.technology.technologyKind
+  )
+
+  val io = new Bundle {
+    val clk    =  in Bool()
+    val en     =  in Bool()
+    val addr   =  in UInt(log2Up(wordCount) bit)
+    val data   = out Bits(wordWidth bit)
+  }
+
+  mapCurrentClockDomain(io.clk)
+  noIoPrefix()
+}
+
 
 /**
   * Ram 2wrs


### PR DESCRIPTION
# Context, Motivation & Description

The motivation for this is an issue I experienced in a recent tape-out. We added the AES extensions to a Vex configuration. The simulation tools indicated no problems with the `$readmemb` style ROM, but for complicated reasons this was a lie (the actual ROM was all-`X` but due to the way the compare loop ran in the test bench, it would not fail on `X`). 

In the end, the synthesis tool really either needed a black boxed ROM, or the ROM presented as a `case` statement in RTL.

This PR attempts to generate exactly that.

# Impact on code generation

In the case that no black boxing is requested, the generated code should be unaffected. However, a black box model of the ROM will be generated even if it is not used.

In the case that black boxing is requested, the ROM is replaced with a module that instantiates the black boxed ROM file, and a .v file that is an RTL model of the ROM. The name of the module and the ROM file I think is unique per ROM -- unlike the RAM black boxes where a single model can be re-used so long as the capacity is the same, identical capacity ROMs are still different models since they should have different contents.

Unfortunately, I could not figure out how to get `ComponentEmitterVerilog.scala`'s `emitMem()` routine to detect if the memory is a black box or not. I think the blackbox attribute is attached to a `Component` but `Mem` does not inherit `Component` properties, so I *think* it's not actually possible to tell between the two cases.

So, what ends up happening is you end up with both a `.bin` and a `.v` description of the ROM, and in the case that you are using a black box, there is still a dummy line that tries to `$readmemb` the `.bin` file, into a variable that isn't used. I ran this through verilator and it seemed harmless.

Note that in the case that a blackbox is requested, you actually do want both the `.v` blackbox and the `.bin` file, because the `.bin` file is used to generate the hard-macro for the ASIC, so both artifacts are in fact useful in that situation. The problem is more that the code is also generated to read in the .bin file to a useless variable, and when no black box is requested, you get this extra .v artifact that's not used by the design.

# Checklist

I'm happy to try and figure out how to add unit tests and API docs if the PR seems useful. However, I'm not even sure if this is the approach you'd really want to take to generate the black box model. I'm also happy to just keep this in my branch and pull it forward over time. Note that the block box model has at least been verified on the AES use case!

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
