### PR TITLE
Fix SpinalSim segfault on Verilator 5.026

### DIFF
--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -267,10 +267,12 @@ public:
       //contextp = new VerilatedContext;
       Verilated::randReset(2);
       Verilated::randSeed(seed);
-      top = new V${config.toplevelName}();
-
+      // Verilator v5.026+ calls time() inside Vtop::Vtop()
+      // initialize the simHandle before we call Vtop
       simHandle${uniqueId} = this;
       time = 0;
+      top = new V${config.toplevelName}();
+
       timeCheck = 0;
       lastFlushAt = high_resolution_clock::now();
       waveEnabled = true;


### PR DESCRIPTION
Latest Verilator (5.026) introduced a [commit](https://github.com/verilator/verilator/commit/fd1e4d9e45646eaddd01937423d10fab267fe71a#diff-1c0f1298e2ed5505c79d957359eb3bdfee1dfa2ca6efdb67c2f9a28126639804R2670) that would call `time()` during initialization of the verilated model (inside `Vtop::Vtop()`).  This results in `sc_time_stamp` getting called, before we set `simHandle`, thus resulting in a segfault:

```console
$ mill gen.runMain pionic.SimAsynchronousExample                                                                                                                        
[429/429] gen.runMain                                                                                                                                                      
[Runtime] SpinalHDL dev    git head : ab29614c7c2ee387ce49ef8c57abe322d88224c2                                                                                             
[Runtime] JVM max memory : 15864.0MiB                                                                                                                                      
[Runtime] Current date : 2024.07.24 16:15:39                                                                                                                               
[Progress] at 0.000 : Elaborate components                                                                                                                                 
[Progress] at 0.124 : Checks and transforms                                                                                                                                
[Progress] at 0.161 : Generate Verilog to tmp/job_1                                                                                                                        
[Done] at 0.183                                                                                                                                                            
[Progress] Simulation workspace in /local/home/pengxu/work/enzian-pio-nic/./simWorkspace/Dut                                                                               
[Progress] Verilator compilation started                                                                                                                                   
[Progress] Verilator compilation done in 1486.897 ms                                                                                                                       
#                                                                                                                                                                          
# A fatal error has been detected by the Java Runtime Environment:                                                                                                         
#                                                                                                                                                                          
#  SIGSEGV (0xb) at pc=0x00007f9245a962bd, pid=1742331, tid=1742332                                                                                                        
#                                                                                                                                                                          
# JRE version: OpenJDK Runtime Environment (18.0.2+9) (build 18.0.2-ea+9-Ubuntu-222.04)                                                                                    
# Java VM: OpenJDK 64-Bit Server VM (18.0.2-ea+9-Ubuntu-222.04, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)                   
# Problematic frame:                                                                                                                                                       
# C  [verilator_6290821037268796068.so+0x362bd]  sc_time_stamp()+0x14                                                                                                      
#                                                                                                                                                                          
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again                                
#                                                                                                                                                                          
# An error report file with more information is saved as:                                                                                                                  
# /local/home/pengxu/work/enzian-pio-nic/hs_err_pid1742331.log                                                                                                             
#                                                                                                                                                                          
# If you would like to submit a bug report, please visit:                                                                                                                  
#   Unknown                                                                                                                                                                
# The crash happened outside the Java Virtual Machine in native code.                                                                                                      
# See problematic frame for where to report the bug.                                                                                                                       
#                                                                                                                                                                          
1 targets failed                                                                                                                                                           
gen.runMain Subprocess failed
```

Fix by making sure that `simHandle` is initialized before calling `Vtop::Vtop()`.