### PR TITLE
fix incorrect right-shift of signed AFix

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -586,13 +586,13 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
     ret
   }
 
-  // Shift bits and decimal point right, adding padding bits left
+  // Shift bits and decimal point right, truncating bits on the right
   def >>|(shift: Int): AFix = {
     val shiftBig = BigInt(2).pow(shift)
     val ret = new AFix(this.maxRaw / shiftBig, this.minRaw / shiftBig, this.exp)
 
     if (this.signed)
-      ret.raw := (this.raw.asSInt >> shift).asBits
+      ret.raw := this.raw.dropLow(shift)
     else
       ret.raw := this.raw.dropLow(shift)
 

--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -592,7 +592,7 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
     val ret = new AFix(this.maxRaw / shiftBig, this.minRaw / shiftBig, this.exp)
 
     if (this.signed)
-      ret.raw := this.raw.dropLow(shift)
+      ret.raw := (this.raw.asSInt >> shift).asBits
     else
       ret.raw := this.raw.dropLow(shift)
 
@@ -608,7 +608,10 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
       (this.exp - shift.maxRaw.toInt)
     )
 
-    ret.raw := (this.raw << shift.maxRaw.toInt) >> U(shift)
+    if (this.signed)
+      ret.raw := ((this.raw << shift.maxRaw.toInt).asSInt >> U(shift)).asBits
+    else
+      ret.raw := (this.raw << shift.maxRaw.toInt) >> U(shift)
 
     ret
   }
@@ -619,7 +622,10 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
     assert(shift.minRaw == 0)
     val ret = cloneOf(this)
 
-    ret.raw := this.raw >> U(shift)
+    if (this.signed)
+      ret.raw := (this.raw.asSInt >> U(shift)).asBits
+    else
+      ret.raw := this.raw >> U(shift)
 
     ret
   }

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -109,6 +109,30 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
     }
   }
 
+  test("arithmetic_shift") {
+    // there is nothing special to the values used for testing here; i just picked some
+    SimConfig.compile(new Component {
+      val shiftConst: Int = 1
+      val io = new Bundle {
+        val inFix = in(AFix.S(7 exp, 0 exp))
+        val shiftVariable = in(AFix.U(3 bits))
+        val outFixKeepLsbVariable = out(AFix.S(7 exp, -7 exp))
+        val outFixLoseLsbVariable = out(AFix.S(7 exp, 0 exp))
+        val outFixLoseLsbConst = out(AFix.S(6 exp, 0 exp))
+      }
+      io.outFixKeepLsbVariable := io.inFix >> io.shiftVariable
+      io.outFixLoseLsbVariable := io.inFix >>| io.shiftVariable
+      io.outFixLoseLsbConst := io.inFix >>| shiftConst
+    }).doSim(seed = 0) { dut =>
+      dut.io.inFix #= -22.0
+      dut.io.shiftVariable #= 1.0
+      sleep(1)
+      assert(dut.io.outFixKeepLsbVariable.toDouble == -11.0)
+      assert(dut.io.outFixLoseLsbVariable.toDouble == -11.0)
+      assert(dut.io.outFixLoseLsbConst.toDouble == -11.0)
+    }
+  }
+
   def dutStateString(dut: AFixTester): String = {
     val model = AFixTesterModel(dut)
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1490

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

As mentioned in the issue, using `>>` between two `AFix`es, or using `>>|` between an `AFix` and an `AFix` or an `AFix` and an `Int`, does not behave as expected when the left `AFix` is signed. It can change a negative `AFix` into a positive one. This PR adds a check to each of the three relevant functions and sign-extends if the left `AFix` is signed.

# Impact on code generation

Right-shifting signed `AFix`es will now sign-extend.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - none needed