### PR TITLE
Fix timescale of the trace files generated by the Verilator backend

### DIFF
--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -293,6 +293,7 @@ ${    val signalInits = for((signal, id) <- config.signals.zipWithIndex) yield {
       #ifdef TRACE
       Verilated::traceEverOn(true);
       top->trace(&tfp, 99);
+      tfp.set_time_resolution(${if (useTimePrecision) "Verilated::threadContextp()->timeprecisionString()" else "VL_TIME_PRECISION_STR" });
       tfp.open((std::string(wavePath) + "wave" + ".${format.ext}").c_str());
       #endif
       this->name = name;


### PR DESCRIPTION
Explicitly set the time precision for trace files (.vcd and .fst) before opening the trace file.

Closes #1492

# Context, Motivation & Description

The Verilator Backend  seems to create the VerilatedContext instance via the default constructor of that class (I couldn't find any definition of that constructor in the Verilator repo, so I assume it sets all members to zero). Later on in the Verilator Backend the timeprecision is then set via a dedicated setter method. Nevertheless, at that point the "VerilatedVcd" is already created and the .vcd file opened with a default value of "1s" as timeprecision. The same issue is also seen for .fst files. For more details refer to #1492

# Impact on code generation

Timescale for .vcd and .fst files is set correctly. Correctly, means that the set values match the Scala simulation config. The change has been tested for .vcd and .fst files with different time specs set via the "withTimeSpec(...)" statement.

# Checklist

- [x] Unit tests were added
-> I did not find any unit tests which would check the resulting .vcd files (I guess most of the vcd generation is checked on the Verilator side)
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
