### PR TITLE
Allow randomizing TKEEP/TSTRB for Axi4StreamMaster

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axis/sim/Axi4StreamMaster.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axis/sim/Axi4StreamMaster.scala
@@ -59,7 +59,7 @@ case class Axi4StreamMaster(axis: Axi4Stream, clockDomain: ClockDomain, nullSegm
     val beats = (data.flatMap { byte =>
       val numNullBytes = if (maxNullSegment == 0) 0 else
         (Random.nextFloat() < nullSegmentProb).toInt * Random.nextInt(maxNullSegment)
-      Seq((byte, 1)) ++ Seq.fill(numNullBytes)((0.toByte, 0))
+      Seq.fill(numNullBytes)((0.toByte, 0)) ++ Seq((byte, 1))
     } padTo(fullLength, (0.toByte, 0)) grouped busConfig.dataWidth).toList
     log(s"initiating send, ${beats.length} beats in total")
     beats.zipWithIndex.foreach { case (dataWithStrb, idx) =>


### PR DESCRIPTION
A nice-to-have for the `Axi4StreamMaster` simulation agent.  Randomizing TKEEP is useful to test if an AXIS component is standard-compliant and correctly discards the null bytes in the stream (TSTRB = 0 && TKEEP = 0).

Note that this does not support randomizing TSTRB as well (it's tied to TKEEP) since I don't have a use for it (yet); it can be implemented at a later date.