### PR TITLE
Fix regression from #1506: allow mill to locate version config file

### DIFF
--- a/project/Version.sc
+++ b/project/Version.sc
@@ -3,7 +3,8 @@ import java.io.File
 import scala.collection.JavaConverters._
 
 object SpinalVersion {
-  val conf = ConfigFactory.parseFile(new File("project/version.conf")).resolve()
+  val projDescDir = os.Path(sourcecode.File()) / os.up / "version.conf"
+  val conf = ConfigFactory.parseFile(new File(projDescDir.toString)).resolve()
 
   val compilers = conf.getStringList("compilers").asScala.toList
   val compilerIsRC = conf.getBoolean("compilerIsRC")


### PR DESCRIPTION
PR #1506 introduced a `$PWD`-relative lookup to find the compiler version config file, which would break submodule setups.  Use ammonite's capability to locate the source file to find the right path.

Note that the same issue is also there for sbt, but I'm not using it and do not have an idea how to fix it there.