### PR TITLE
Set Name for asyncAssertSyncDeassert

### DIFF
--- a/lib/src/main/scala/spinal/lib/CrossClock.scala
+++ b/lib/src/main/scala/spinal/lib/CrossClock.scala
@@ -120,7 +120,7 @@ object ResetCtrl{
    * @param outputPolarity (HIGH/LOW)
    * @param bufferDepth Number of register stages used to avoid metastability (default=2)
    * @param inputSync Active high, will set reset high in a sync way
-   * @return Filtred Bool which is asynchronously asserted synchronously deaserted
+   * @return Filtered Bool which is asynchronously asserted synchronously deasserted
    */
   def asyncAssertSyncDeassert(input : Bool,
                               clockDomain : ClockDomain,
@@ -139,7 +139,7 @@ object ResetCtrl{
     val solvedOutputPolarity = if(outputPolarity == null) clockDomain.config.resetActiveLevel else outputPolarity
     val falsePathAttrs = List(crossClockFalsePath(Some(input), destType = TimingEndpointType.RESET))
     samplerCD(BufferCC(
-      input       = (if(solvedOutputPolarity == HIGH) False else True) ^ inputSync,
+      input       = ((if(solvedOutputPolarity == HIGH) False else True) ^ inputSync).setCompositeName(input, "asyncAssertSyncDeassert", true),
       init        = if(solvedOutputPolarity == HIGH) True  else False,
       bufferDepth = bufferDepth,
       allBufAttributes = falsePathAttrs)


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
When you have multiple clock domains and reset synchronizers debugging becomes super confusing.
Setting the name on the input to bufferCC gives a chance to give a name to the bufferCC which gives a hint on the purpose

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

Improved names
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
