### PR TITLE
Fix FSM bug

### DIFF
--- a/lib/src/main/scala/spinal/lib/fsm/State.scala
+++ b/lib/src/main/scala/spinal/lib/fsm/State.scala
@@ -126,6 +126,8 @@ class StateFsm[T <: StateMachineAccessor](val fsm:  T)(implicit stateMachineAcce
 
   onEntry{
     fsm.startFsm()
+    fsm.getEntry().onEntryTasks.foreach(_())
+    fsm.getEntry().whenIsNextTasks.foreach(_())
   }
 
   whenIsActiveWithPriority(1){
@@ -171,7 +173,11 @@ class StateParallelFsm(val _fsms: StateMachineAccessor*)(implicit stateMachineAc
   val fsms = _fsms
   
   onEntry{
-    fsms.foreach(_.startFsm())
+    fsms.foreach { fsm =>
+      fsm.startFsm()
+      fsm.getEntry().onEntryTasks.foreach(_())
+      fsm.getEntry().whenIsNextTasks.foreach(_())
+    }
   }
 
   whenIsActiveWithPriority(1){

--- a/tester/src/test/scala/spinal/lib/SpinalFsmTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalFsmTester.scala
@@ -1,0 +1,68 @@
+package spinal.lib
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib.fsm._
+import spinal.tester.SpinalAnyFunSuite
+
+class SpinalFsmTester extends SpinalAnyFunSuite {
+  test("nested fsm onEntry") {
+    SimConfig
+      .compile(new Component {
+        val io = new Bundle {
+          val go = in Bool()
+          val a = out Bool()
+          val b = out Bool()
+          val aReg = out(Reg(Bool()) init(False))
+          val bReg = out(Reg(Bool()) init(False))
+        }
+
+        io.a := False
+        io.b := False
+        io.aReg := False
+        io.bReg := False
+
+        val fsm = new StateMachine() {
+          val idle: State = new State with EntryPoint() {
+            whenIsActive {
+              io.b := False
+              io.bReg := False
+              when (io.go) { goto(par) }
+            }
+          }
+          val par = new StateFsm(
+            new StateMachine {
+              val nested = new State() with EntryPoint {
+                onEntry {
+                  io.a := True
+                  io.b := True
+                  io.aReg := True
+                  io.bReg := True
+                }
+                whenIsActive { exit() }
+              }
+            }
+          ) {
+            whenCompleted { goto(idle) }
+          }
+        }
+      })
+      .doSim(dut => {
+        dut.clockDomain.forkStimulus(10)
+        dut.clockDomain.waitSampling()
+        fork {
+          while (true) {
+            sleep(1)
+            assert(dut.io.a.toBoolean == dut.io.b.toBoolean)
+          }
+        }
+        sleep(5)
+        dut.io.go #= true
+        dut.clockDomain.waitSampling()
+        sleep(5)
+        dut.io.go #= false
+        dut.clockDomain.waitSampling(5)
+        simSuccess()
+      })
+  }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1528

# Context, Motivation & Description

See issue for details.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

`StateFsm` and `StateParallelFsm` now generate `onEntry` statements duplicating the `onEntry` blocks of the entry points of their nested state machines.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [-] API changes are or will be documented (bugfix - none needed)