### PR TITLE
Fix the wrong directory when generating .lst of Verilog/SV

### DIFF
--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -145,7 +145,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
       }
 
       if(pc.config.printFilelist){
-        val fileListFile = new java.io.FileWriter(pc.config.targetDirectory + topLevel.definitionName + ".lst")
+        val fileListFile = new java.io.FileWriter(pc.config.targetDirectory + "/" + topLevel.definitionName + ".lst")
         fileList.foreach(file => fileListFile.write(file.replace("//", "/") + "\n"))
         fileListFile.flush()
         fileListFile.close()


### PR DESCRIPTION
A small fix. There's a missing "/" in the file path when generating .lst in Verilog/SystemVerilog mode. Everything works fine in VHDL mode.

For example. If "targetDirectory" in the config is "output/rtl", the full path of .lst should be "output/rtl/mytoplevel.lst", instead of "output/rtlmytoplevel.lst".