### PR TITLE
Fix unconnected port comma issue

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -416,7 +416,7 @@ class ComponentEmitterVerilog(
 
       logics ++= s"${child.getName()} (\n"
 
-      val ios = child.getOrdredNodeIo.filterNot(_.isSuffix)
+      val ios = child.getOrdredNodeIo.filterNot(_.isSuffix).filter(data => !data.isInOut || analogDrivers.isDefinedAt(data))
       val connectedIF = mutable.HashSet[Data]()
       val prepareInstports = ios.flatMap { data =>
         if (spinalConfig.mode == SystemVerilog && spinalConfig.svInterface && data.hasTag(IsInterface)) {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->
Closes #1537 
<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->


# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

Fix a bug in emitted verilog
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [X] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
