### PR TITLE
Fix negation for AFix

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -667,9 +667,13 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
   override def <<(shift: UInt): AFix = ???
   override def >>(shift: UInt): AFix = this >> AFix(shift)
 
-  def unary_-(): AFix = negate(True)
+  def unary_-(): AFix = negate()
 
-  def negate(): AFix = negate(True)
+  def negate(): AFix = {
+    val ret = new AFix(-this.minRaw max this.maxRaw, -this.maxRaw min this.minRaw, this.exp)
+    ret.raw := (-S(this.raw).resize(ret.bitWidth)).asBits
+    ret
+  }
   def negate(enable : Bool, plusOneEnable : Bool = null): AFix = {
     val ret = new AFix(-this.minRaw max this.maxRaw, -this.maxRaw min this.minRaw, this.exp)
     ret.raw := U(this.raw).twoComplement(enable, plusOneEnable).asBits


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

The negation of signed `AFix` is producing incorrect results for negative numbers. The issue can be demonstrated with the following example:

``` scala
object AFixNegateBug extends App {
  case class AFNBug() extends Component {
    val input = in(AFix.S(3 bits))
    val output = out(-input)
    println(s"${input}")
    println(s"${output}")
  }

  import spinal.core.sim._
  SimConfig.compile {
    val dut = AFNBug()
    dut
  }.doSim { dut =>
    dut.input #= -1
    sleep(10)
    println(s"input: ${dut.input.toBigDecimal}") // expected -1, got -1
    println(s"output: ${dut.output.toBigDecimal}") //expected 1, got -7
  }
}
```

It appears that the `twoComplement` method of `UInt` in the `negate` implementation incorrectly adds an extra 1 to the msb, regardless of the sign of the `AFix`:

```scala
  def negate(enable : Bool, plusOneEnable : Bool = null): AFix = {
    val ret = new AFix(-this.minRaw max this.maxRaw, -this.maxRaw min this.minRaw, this.exp)
    ret.raw := U(this.raw).twoComplement(enable, plusOneEnable).asBits
    ret
  }
```

I found that using the negation of `SInt` works correctly:

```scala
  def unary_-(): AFix = negate()

  def negate(): AFix = {
    val ret = new AFix(-this.minRaw max this.maxRaw, -this.maxRaw min this.minRaw, this.exp)
    ret.raw := (-S(this.raw).resize(ret.bitWidth)).asBits
    ret
  }
```

I am not sure of the purpose of `def negate(enable : Bool, plusOneEnable : Bool = null): AFix`, so I have left it unchanged.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
