### PR TITLE
StreamCCByToggle Altera attributes

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -259,45 +259,7 @@ class PhaseDeviceSpecifics(pc : PhaseContext) extends PhaseNetlist{
 //        if(hit) mem.addAttribute("ram_style", "distributed") //Vivado stupid ganbling workaround Synth 8-6430
 //      case _ =>
 //    }
-    def seekRegDriver(that : BaseType): Iterable[BaseType] ={
-      var buffer = ArrayBuffer[BaseType]()
-        that.foreachStatements{ s =>
-          def forExp(e : Expression) : Unit = e match {
-            case s : Statement => s match {
-              case s : BaseType if !s.isReg => {buffer ++= seekRegDriver(s) }
-              case s : BaseType if s.isReg => buffer += s
-              case s =>
-            }
-            case e: MemReadSync =>
-            case e: MemReadWrite =>
-            case e : Expression => e.foreachDrivingExpression(forExp)
-          }
-          s.walkParentTreeStatementsUntilRootScope{sParent =>
-            sParent.foreachDrivingExpression(forExp)
-          }
-          s.foreachDrivingExpression(forExp)
-        }
-        buffer
-      }
-    walkComponentsExceptBlackbox{component =>
-      var statements = ArrayBuffer[DataAssignmentStatement]()
-      component.dslBody.walkStatements {
-        case da: DataAssignmentStatement if da.target.isInstanceOf[SpinalTagReady] && da.target
-          .asInstanceOf[SpinalTagReady]
-          .hasTag(classOf[crossClockMaxDelay]) =>
-          statements += da
-        case _ =>
-      }
-      for (statement <- statements) {
-        val sources = seekRegDriver(statement.source.asInstanceOf[BaseType])
-          
-        val target = statement.target.asInstanceOf[BaseType]
-        val regAttribute = new AttributeString("altera_attribute", "-name ADV_NETLIST_OPT_ALLOWED NEVER_ALLOW")
 
-        sources.foreach(_.addAttribute(regAttribute))
-        target.addAttribute(regAttribute)
-      }
-    }
   }
 }
 
@@ -1434,6 +1396,7 @@ trait PhaseDeviceHandler{
   def onMemReadAsync(config : SpinalConfig, mem : Mem[_]) : Unit = {}
   def onMemDontCareOrdering(config : SpinalConfig, mem : Mem[_]) : Unit = {}
   def onCrossClockBuffer(config : SpinalConfig, that : BaseType) : Unit = {} // To help inferring low metastability
+  def onCrossClockMaxDelay(config: SpinalConfig, sources: Iterable[BaseType], target: BaseType) : Unit = {}
 }
 
 object PhaseDeviceDefault extends PhaseDeviceDefault
@@ -1457,6 +1420,14 @@ class PhaseDeviceDefault extends PhaseDeviceHandler{
   override def onMemDontCareOrdering(config : SpinalConfig, mem: Mem[_]) = {
     if(config.device.vendor == Device.ALTERA.vendor){
       mem.addAttribute("ramstyle", "no_rw_check")
+    }
+  }
+  override def onCrossClockMaxDelay(config: SpinalConfig, sources: Iterable[BaseType], target: BaseType) = {
+    if(config.device.vendor == Device.ALTERA.vendor){
+      val regAttribute = new AttributeString("altera_attribute", "-name ADV_NETLIST_OPT_ALLOWED NEVER_ALLOW")
+
+        sources.foreach(_.addAttribute(regAttribute))
+        target.addAttribute(regAttribute)
     }
   }
 }
@@ -1494,6 +1465,46 @@ class PhaseDevice(pc : PhaseContext) extends PhaseMisc{
         }
       }
       case _ =>
+    }
+    def seekRegDriver(that : BaseType): Iterable[BaseType] = {
+      var buffer = ArrayBuffer[BaseType]()
+      that.foreachStatements{ s =>
+        def forExp(e : Expression) : Unit = e match {
+          case s: Statement => s match {
+            case s: BaseType if !s.isReg => {buffer ++= seekRegDriver(s) }
+            case s: BaseType if s.isReg => buffer += s
+            case s =>
+          }
+          case e: MemReadSync =>
+          case e: MemReadWrite =>
+          case e: Expression => e.foreachDrivingExpression(forExp)
+        }
+        s.walkParentTreeStatementsUntilRootScope{sParent =>
+          sParent.foreachDrivingExpression(forExp)
+        }
+        s.foreachDrivingExpression(forExp)
+      }
+      buffer
+    }
+    pc.walkComponentsExceptBlackbox{component =>
+      var statements = ArrayBuffer[DataAssignmentStatement]()
+      component.dslBody.walkStatements {
+        case da: DataAssignmentStatement if da.target.isInstanceOf[SpinalTagReady] && da.target
+          .asInstanceOf[SpinalTagReady]
+          .hasTag(classOf[crossClockMaxDelay]) =>
+          statements += da
+        case _ =>
+      }
+      for (statement <- statements) {
+        val sources = seekRegDriver(statement.source.asInstanceOf[BaseType])
+
+        val target = statement.target.asInstanceOf[BaseType]
+        val regAttribute = new AttributeString("altera_attribute", "-name ADV_NETLIST_OPT_ALLOWED NEVER_ALLOW")
+
+        sources.foreach(_.addAttribute(regAttribute))
+        target.addAttribute(regAttribute)
+        cb.onCrossClockMaxDelay(pc.config, sources, target)
+      }
     }
   }
 }

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -1496,14 +1496,12 @@ class PhaseDevice(pc : PhaseContext) extends PhaseMisc{
         case _ =>
       }
       for (statement <- statements) {
-        val sources = seekRegDriver(statement.source.asInstanceOf[BaseType])
-
-        val target = statement.target.asInstanceOf[BaseType]
-        val regAttribute = new AttributeString("altera_attribute", "-name ADV_NETLIST_OPT_ALLOWED NEVER_ALLOW")
-
-        sources.foreach(_.addAttribute(regAttribute))
-        target.addAttribute(regAttribute)
-        cb.onCrossClockMaxDelay(pc.config, sources, target)
+        (statement.source, statement.target) match {
+          case (source: BaseType, target: BaseType) =>
+            val sources = seekRegDriver(source)
+            cb.onCrossClockMaxDelay(pc.config, sources, target)
+            case _ =>
+        }
       }
     }
   }

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -1423,7 +1423,7 @@ class PhaseDeviceDefault extends PhaseDeviceHandler{
     }
   }
   override def onCrossClockMaxDelay(config: SpinalConfig, sources: Iterable[BaseType], target: BaseType) = {
-    if(config.device.vendor == Device.ALTERA.vendor){
+    if(config.device.isVendorDefault || config.device.vendor == Device.ALTERA.vendor){
       val regAttribute = new AttributeString("altera_attribute", "-name ADV_NETLIST_OPT_ALLOWED NEVER_ALLOW")
 
         sources.foreach(_.addAttribute(regAttribute))

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1744,7 +1744,7 @@ class StreamCCByToggle[T <: Data](dataType: HardType[T],
   val outHitSignal = Bool()
 
   val pushArea = inputClock on new Area {
-    val hit = BufferCC(outHitSignal, False, inputAttributes = Seq(crossClockFalsePath()))
+    val hit = BufferCC(outHitSignal, False, inputAttributes = Seq(crossClockMaxDelay(1, useTargetClock = true)))
     val accept = Bool()
     val target = RegInit(False) toggleWhen(accept)
     val data = RegNextWhen(io.input.payload, accept)
@@ -1763,7 +1763,7 @@ class StreamCCByToggle[T <: Data](dataType: HardType[T],
   val popArea = finalOutputClock on new Area {
     val stream = cloneOf(io.input)
 
-    val target = BufferCC(pushArea.target, False, inputAttributes = Seq(crossClockFalsePath()))
+    val target = BufferCC(pushArea.target, False, inputAttributes = Seq(crossClockMaxDelay(1, useTargetClock = true)))
     val hit = RegNextWhen(target, stream.fire) init(False)
     outHitSignal := hit
 

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -359,12 +359,12 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
   def stage() : Stream[T] = this.m2sPipe()
 
   //! if collapsBubble is enable then ready is not "don't care" during valid low !
-  def m2sPipe(collapsBubble : Boolean = true, crossClockData: Boolean = false, flush : Bool = null, holdPayload : Boolean = false, dataTags: Seq[SpinalTag] = Seq()): Stream[T] = new Composite(this) {
+  def m2sPipe(collapsBubble : Boolean = true, crossClockData: Boolean = false, flush : Bool = null, holdPayload : Boolean = false): Stream[T] = new Composite(this) {
     val m2sPipe = Stream(payloadType)
 
     val rValid = RegNextWhen(self.valid, self.ready) init(False)
     val rData = RegNextWhen(self.payload, if(holdPayload) self.fire else self.ready)
-    dataTags.foreach(rData.addTag)
+
     if (crossClockData) {
       rData.addTag(crossClockDomain)
       rData.addTag(crossClockMaxDelay(1, useTargetClock = true))
@@ -1742,14 +1742,12 @@ class StreamCCByToggle[T <: Data](dataType: HardType[T],
   }
 
   val outHitSignal = Bool()
-  // Make sure Quartus does not optimize the registers to make the timing constraints valid
-  val regAttribute = new AttributeString("altera_attribute", "-name ADV_NETLIST_OPT_ALLOWED NEVER_ALLOW")
 
   val pushArea = inputClock on new Area {
-    val hit = BufferCC(outHitSignal, False, inputAttributes = Seq(crossClockFalsePath()))
+    val hit = BufferCC(outHitSignal, False)
     val accept = Bool()
     val target = RegInit(False) toggleWhen(accept)
-    val data = RegNextWhen(io.input.payload, accept) addAttribute(regAttribute)
+    val data = RegNextWhen(io.input.payload, accept)
 
     if (!withInputWait) {
       accept := io.input.fire
@@ -1765,14 +1763,14 @@ class StreamCCByToggle[T <: Data](dataType: HardType[T],
   val popArea = finalOutputClock on new Area {
     val stream = cloneOf(io.input)
 
-    val target = BufferCC(pushArea.target, False, inputAttributes = Seq(crossClockFalsePath()))
+    val target = BufferCC(pushArea.target, False)
     val hit = RegNextWhen(target, stream.fire) init(False)
     outHitSignal := hit
 
     stream.valid := (target =/= hit)
     stream.payload := pushArea.data
 
-    io.output << (if(withOutputBuffer) stream.m2sPipe(holdPayload = true, crossClockData = true, dataTags = Seq(regAttribute)) else stream)
+    io.output << (if(withOutputBuffer) stream.m2sPipe(holdPayload = true, crossClockData = true) else stream)
   }
 }
 

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1744,7 +1744,7 @@ class StreamCCByToggle[T <: Data](dataType: HardType[T],
   val outHitSignal = Bool()
 
   val pushArea = inputClock on new Area {
-    val hit = BufferCC(outHitSignal, False)
+    val hit = BufferCC(outHitSignal, False, inputAttributes = Seq(crossClockFalsePath()))
     val accept = Bool()
     val target = RegInit(False) toggleWhen(accept)
     val data = RegNextWhen(io.input.payload, accept)
@@ -1763,7 +1763,7 @@ class StreamCCByToggle[T <: Data](dataType: HardType[T],
   val popArea = finalOutputClock on new Area {
     val stream = cloneOf(io.input)
 
-    val target = BufferCC(pushArea.target, False)
+    val target = BufferCC(pushArea.target, False, inputAttributes = Seq(crossClockFalsePath()))
     val hit = RegNextWhen(target, stream.fire) init(False)
     outHitSignal := hit
 

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1742,7 +1742,7 @@ class StreamCCByToggle[T <: Data](dataType: HardType[T],
   }
 
   val outHitSignal = Bool()
-  // Make sure Quartus does not optimize the registers to make 
+  // Make sure Quartus does not optimize the registers to make the timing constraints valid
   val regAttribute = new AttributeString("altera_attribute", "-name ADV_NETLIST_OPT_ALLOWED NEVER_ALLOW")
 
   val pushArea = inputClock on new Area {

--- a/tester/src/test/scala/spinal/core/PhaseDeviceSpecificsTester.scala
+++ b/tester/src/test/scala/spinal/core/PhaseDeviceSpecificsTester.scala
@@ -1,0 +1,28 @@
+package spinal.core
+
+import spinal.tester.SpinalAnyFunSuite
+import spinal.lib._
+import spinal.core._
+import scala.util.matching.Regex
+
+class PhaseDeviceSpecificsTester extends SpinalAnyFunSuite {
+  test("Test ") {
+    val report = SpinalVerilog(new Component {
+      val io = new Bundle {
+        val i = slave port Stream(Bits(8 bit))
+        val o = master port Stream(Bits(8 bit))
+      }
+      val cd1 = ClockDomain.external("cd1")
+      val cd2 = ClockDomain.external("cd2")
+      setDefinitionName("PhaseDeviceSpecificsTester")
+      cd2 {
+        io.o << io.i.ccToggle(cd1, cd2)
+      }
+    })
+    val string = report.getRtlString
+    println(report.toplevel)
+    assert("-name ADV_NETLIST_OPT_ALLOWED NEVER_ALLOW.*pushArea_data;".r.findFirstIn(string).isDefined)
+    assert("-name ADV_NETLIST_OPT_ALLOWED NEVER_ALLOW.*popArea_stream_rData;".r.findFirstIn(string).isDefined)
+  }
+
+}

--- a/tester/src/test/scala/spinal/core/PhaseDeviceSpecificsTester.scala
+++ b/tester/src/test/scala/spinal/core/PhaseDeviceSpecificsTester.scala
@@ -7,7 +7,7 @@ import scala.util.matching.Regex
 
 class PhaseDeviceSpecificsTester extends SpinalAnyFunSuite {
   test("Test ") {
-    val report = SpinalVerilog(new Component {
+    val report = SpinalVerilog(SpinalConfig(device=Device.ALTERA))(new Component {
       val io = new Bundle {
         val i = slave port Stream(Bits(8 bit))
         val o = master port Stream(Bits(8 bit))


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description
StreamCCByToggle: Add `altera_attribute` Attributes to the registers that get max_skew requirement to disable optimization. Otherwise Quartus sometimes moves comb logic between the registers making them illegit targets for most timing constraints. 

Also add crossClockFalsePath to the relevant BufferCC registers. (analog to PulseCCByToggle)

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
