### PR TITLE
Fix some issues in WidthAdapter of TileLink

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/tilelink/WidthAdapter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/WidthAdapter.scala
@@ -41,9 +41,9 @@ class WidthAdapter(ip : BusParameter,
       val valid   = RegInit(False)
       val first   = RegInit(True)
       val args    = Reg(ChannelA(ip.copy(withDataA = false)))
-      val data    = Vec.fill(ratio)(Reg(src.data))
+      val data    = src.withData generate Vec.fill(ratio)(Reg(src.data))
       val mask    = src.withMask generate Vec.fill(ratio)(Reg(src.maskNull))
-      val corrupt = Reg(Bool())
+      val corrupt = src.withData generate Reg(Bool())
       val denied  = src.withDenied generate Reg(Bool())
       val sink  = src.withSink generate Reg(op.sink)
     }
@@ -51,8 +51,10 @@ class WidthAdapter(ip : BusParameter,
     dst.valid := buffer.valid
     dst.payload.assignSomeByName(buffer.args)
     if(dst.withMask) dst.maskNull := Cat(buffer.mask)
-    dst.data    := Cat(buffer.data)
-    dst.corrupt := buffer.corrupt
+    if(dst.withData) {
+      dst.data := Cat(buffer.data)
+      dst.corrupt := buffer.corrupt
+    }
     if(src.withDenied) dst.deniedNull := buffer.denied
     if(src.withSink) dst.sinkNull := buffer.sink
 
@@ -64,25 +66,31 @@ class WidthAdapter(ip : BusParameter,
       buffer.first := wordLast
       when(buffer.first) {
         buffer.args.assignSomeByName(src.payload)
-        buffer.corrupt := False
+        if(src.withData) buffer.corrupt := False
         if(src.withDenied) buffer.denied := False
         if(src.withMask) buffer.mask.foreach(_ := 0)
         if(src.withSink) buffer.sink := src.sinkNull
       }
 
-      if(src.withMask) {
-        buffer.data(sel) := src.data
-        buffer.mask(sel) := src.maskNull
-      } else {
-        val maskRange = log2Up(src.p.dataBytes)+1 to log2Up(dst.p.dataBytes)
-        val mask = maskRange.map(src.size >= _).asBits().asUInt
-        for(i <- 0 until ratio){
-          when(((sel ^ i) & mask) === 0){
-            buffer.data(i) := src.data
+      if(src.withData) {
+        if(src.withMask) {
+          buffer.data(sel) := src.data
+          buffer.mask(sel) := src.maskNull
+        } else {
+          if(src.size.maxValue > log2Up(src.p.dataBytes)) {
+            val maskRange = log2Up(src.p.dataBytes)+1 to log2Up(dst.p.dataBytes).min(src.size.maxValue.toInt)
+            val mask = maskRange.map(src.size >= _).asBits().asUInt
+            for(i <- 0 until ratio){
+              when(((sel ^ i) & mask) === 0){
+                buffer.data(i) := src.data
+              }
+            }
+          } else {
+            buffer.data.foreach(_ := src.data)
           }
         }
+        buffer.corrupt setWhen(src.corrupt)
       }
-      buffer.corrupt setWhen(src.corrupt)
       if(src.withDenied) buffer.denied setWhen(src.deniedNull)
     }
   }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->


# Context, Motivation & Description

## Issue 1: The `WidthAdapter` fails when upsizing a channel with no data

This issue can be demonstrated with the following example:

``` scala
object TileLinkWidthAdapterBug1 extends App {
  SpinalVerilog {
    new Component {
      val axiConfig = Axi4Config(
        addressWidth = 64,
        dataWidth = 64,
        idWidth = 4
      )
      val axi = slave(Axi4(axiConfig))
      val bridge = new Axi4ToTilelinkFiber(64, 4)
      bridge.up load axi

      // success with dataWidth >= 64, fail with dataWidth < 64 because downWrite in Axi4ToTilelinkFiber uses ChannelUpSizer on ChannelD with no data
      val dataWidth = 32 
      val up = tilelink.fabric.Node.up()
      val upLogic = Fiber build new Area {
        up.forceDataWidth(dataWidth)
        up.m2s.supported load up.m2s.proposed
        up.s2m.none()

        val dummy = Bits(dataWidth bits)
        val factory = new tilelink.SlaveFactory(up.bus, allowBurst = false)
        factory.drive(dummy, 0)
      }
      up at 0 of bridge.down
    }
  }
}
```

The failure occurs because the `ChannelUpSizer` in the `WidthAdapter` does not handle the case where the channel contains no data.

## Issue 2: The `WidthAdapter` fails when `src.size.maxValue = log2Up(src.p.dataBytes)`

This issue can be demonstrated with the following example:

``` scala
object TileLinkWidthAdapterBug2 extends App {
  SpinalVerilog {
    new Component {
      val axiConfig = Axi4Config(
        addressWidth = 32,
        dataWidth = 64,
        idWidth = 4
      )
      val axi = slave(Axi4(axiConfig))
      val bridge = new Axi4ToTilelinkFiber(64, 4)
      bridge.up load axi

      // fail with dataWidth = 16 because src.size.maxValue = log2Up(src.p.dataBytes) = 1
      val dataWidth = 16 
      val up = tilelink.fabric.Node.up()
      val upLogic = Fiber build new Area {
        up.forceDataWidth(dataWidth)
        up.m2s.supported load tilelink.M2sSupport(
          addressWidth = 12,
          dataWidth = dataWidth,
          transfers = tilelink.M2sTransfers(
            get = tilelink.SizeRange(dataWidth / 8),
            putPartial = tilelink.SizeRange(dataWidth / 8)
          )
        )
        up.s2m.none()

        val dummy = Bits(dataWidth bits)
        val factory = new tilelink.SlaveFactory(up.bus, allowBurst = false)
        factory.drive(dummy, 0)
        Fiber.awaitCheck()
        println(s"parameter ${up.m2s.parameters}")
      }
      up at 0 of bridge.down
    }
  }
}
```
The failure occurs because the `ChannelUpSizer` in the `WidthAdapter` does not handle the case correctly where `src.size.maxValue = log2Up(src.p.dataBytes)`.

I made a simple fix to address these issues.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
