### PR TITLE
Fix the issue that negative BigDecimal can not be assigned to AFix

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -1233,7 +1233,7 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
       (that * BigDecimal(BigInt(1) << shift)).toBigInt
     else
       (that / BigDecimal(BigInt(1) << -shift)).toBigInt
-    this.raw := value
+    this.raw := (if(value >= 0) value else (BigInt(1) << bitWidth) + value)
   }
 
   def init(that: BigDecimal): this.type = {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

Negative `BigDecimal` values cannot be assigned to `AFix`, as illustrated in the following examples:

```scala
object AFixAssignNegativeTest1 extends App {
  case class AFixAssignNegative() extends Component {
    val output = out(AFix.S(5 exp, 10 bits))
    output := -32.0

  }

  import spinal.core.sim._
  SimConfig.compile {
    val dut = AFixAssignNegative()
    dut
  }.doSim { dut =>
    sleep(10)
    println(s"${dut.output.toBigDecimal}") //expect -32
  }
}

object AFixAssignNegativeTest2 extends App {
  case class AFixAssignNegative() extends Component {
    val output = out(AFix.S(5 exp, 10 bits))
    val mem = Mem(output, 2) init Seq(AF(-32.0, output.Q), AF(-32.0, output.Q))
    val addr = U(1, 1 bits)
    output := mem.readSync(addr)

  }

  import spinal.core.sim._
  SimConfig.compile {
    val dut = AFixAssignNegative()
    dut
  }.doSim { dut =>
    val clock = dut.clockDomain
    clock.forkStimulus(10)
    clock.assertReset()
    clock.waitSampling()
    clock.deassertReset()
    clock.waitSampling(2)
    println(s"${dut.output.toBigDecimal}") //expect -32
  }
}
```

I made a simple fix for this.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
