### PR TITLE
fix elaboration hang-up while bit count of field is negative.

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/package.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/package.scala
@@ -6,6 +6,7 @@ import scala.collection.mutable.ListBuffer
 
 package object regif {
   def formatResetValue(value: BigInt, bitCount: Int): String = {
+    if (bitCount < 0) return "-"
     val hexCount = scala.math.ceil(bitCount / 4.0).toInt
     val unsignedValue = if (value >= 0) value else ((BigInt(1) << bitCount) + value)
     s"${bitCount}'h%${hexCount}s".format(unsignedValue.toString(16)).replace(' ', '0')


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

run getRegIfExample class with RegIfExample2 would fail.
this is caused by bit count is -1.

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
