### PR TITLE
Watch unassigned inputs

### DIFF
--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -187,7 +187,7 @@ package object sim {
   def addWatchedSignals(signals : Seq[BaseType]){
     val manager = SimManagerContext.current.manager
     val simSignals = signals.map{ btToSignal(manager, _) }
-    manager.addWatchedSignals(simSignals)
+    manager.addWatchedSignals(simSignals.toSeq)
   }
 
   def checkWatchedSignalAssigned(): Seq[String] = {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
@@ -221,6 +221,28 @@ class SpinalSimMiscTester extends SpinalAnyFunSuite {
       }
     }
 
+    test(prefix + "testInputWatch") {
+      compiled.doSim(dut => {
+        addInputsAssignmentWatch(dut)
+        dut.clockDomain.forkStimulus(10)
+
+        checkInputsAssignmentAfterReset(dut.clockDomain)
+        var counterModel = 0
+        var counter = 0
+        while (true) {
+          // dut.io.enable.randomize()
+          dut.clockDomain.waitSampling();
+          sleep(0)
+          if (dut.io.enable.toBoolean) {
+            counterModel = (counterModel + 1) & 0xFF
+          }
+          // assert(dut.io.value.toInt == counterModel)
+          counter += 1
+          if (counter == 1000) simSuccess()
+        }
+      })
+    }
+
     test(prefix + "testRecompile1") {
       SimConfig.doSim(new SpinalSimMiscTester.SpinalSimMiscTesterCounter)(dut => {
         dut.clockDomain.forkStimulus(10)


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1006 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
