### PR TITLE
fix interface compiling on scala 2.11

### DIFF
--- a/tester/src/test/scala/spinal/core/InterfaceTester.scala
+++ b/tester/src/test/scala/spinal/core/InterfaceTester.scala
@@ -79,13 +79,13 @@ case class StreamIF[T <: Data](payloadType :  HardType[T]) extends Interface wit
 
   override def asMaster = mst
   @modport
-  def mst = {
+  def mst: Unit = {
     out(valid, payload)
     in(ready)
   }
 
   @modport
-  def slv = {
+  def slv: Unit = {
     in(valid, payload)
     out(ready)
   }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1507

# Context, Motivation & Description

The best practice might be define asMaster function and redirect it to mst and slv .

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
