### PR TITLE
Adding waitInactiveEdge and waitInactiveEdgeWhere

### DIFF
--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -929,6 +929,23 @@ package object sim {
       }
     }
 
+    def waitInactiveEdge(): Unit = waitInactiveEdge(1)
+    def waitInactiveEdge(count: Int = 1): Unit = {
+      if (cd.config.clockEdge == spinal.core.RISING) {
+        waitFallingEdge(count)
+      }else{
+        waitRisingEdge(count)
+      }
+    }
+
+    def waitInactiveEdgeWhere(condAnd: => Boolean): Unit = {
+      if(cd.config.clockEdge == spinal.core.RISING) {
+        waitFallingEdgeWhere(condAnd)
+      }else {
+        waitRisingEdgeWhere(condAnd)
+      }
+    }
+
     def doStimulus(period: Long, resetCycles : Int = 16): Unit = {
       assert(period >= 2)
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
  - Let me know if you want a unit test for this small change 
- [X ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
I pushed up a small change to the SpinalDoc with these additions
