### PR TITLE
Fix isUnnamed for NameableByComponent

### DIFF
--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -386,7 +386,7 @@ trait Nameable extends OwnableRef with ContextUser{
     case OWNER_PREFIXED        => refOwner == null || refOwner.asInstanceOf[Nameable].isUnnamed
   }
 
-  def isNamed: Boolean = !isUnnamed
+  final def isNamed: Boolean = !isUnnamed
 
   def getName(): String = getName("")
   def getPartialName() : String = name

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -260,13 +260,13 @@ trait NameableByComponent extends Nameable with GlobalDataUser {
   }
 
 
-  override def isNamed: Boolean = {
+  override def isUnnamed: Boolean = {
     (getMode, nameableRef) match{
       case (NAMEABLE_REF_PREFIXED, other : NameableByComponent) if other.component != null && this.component != null && this.component != other.component =>
-        nameableRef.isNamed && getPath(this.component, other.component).tail.forall(_.isNamed)
+        nameableRef.isUnnamed || getPath(this.component, other.component).tail.exists(_.isUnnamed)
       case (NAMEABLE_REF, other : NameableByComponent) if other.component != null && this.component != null && this.component != other.component =>
-        nameableRef.isNamed && getPath(this.component, other.component).tail.forall(_.isNamed)
-      case _ => super.isNamed
+        nameableRef.isUnnamed || getPath(this.component, other.component).tail.exists(_.isUnnamed)
+      case _ => super.isUnnamed
     }
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1551

# Context, Motivation & Description
I seem to have found the problem for issue #1551:
`NameableByComponent` extends `Nameable`.
`Nameeable` defines `isUnnamed` and defines `isNamed` as the opposite, but `NameableByComponent` defines isNamed, without overwriting `isUnnamed` therefore `isUnnamed` has some wrong content.
This does funky stuff in `Component.allocateNames` (`child.isUnnamed` is checked there)
I reversed the definition in NameableByComponent.

Sadly, it takes some complicated combination to trigger this edge case which I was not able to destille a unit test from.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
