### PR TITLE
add fp-interpolator to avoid errors in 2.13

### DIFF
--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -599,4 +599,19 @@ package object core extends BaseTypeFactory with BaseTypeCast {
   object LITTLE extends Endianness
   /** Big-Endian */
   object BIG    extends Endianness
+
+  implicit class PhysicalNumberPimper(val sc: StringContext) extends AnyVal {
+    def fp(args: Any*): String = {
+      val strings = sc.parts.iterator
+      val expressions = args.iterator
+
+      var formatted = Seq(strings.next())
+      formatted ++= strings.map { part =>
+        val fmt = if (part.length == 0) "%s" else part
+        val obj = expressions.next()
+        String.format(fmt, obj.asInstanceOf[AnyRef])
+      }
+      formatted.mkString
+    }
+  }
 }

--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -601,7 +601,7 @@ package object core extends BaseTypeFactory with BaseTypeCast {
   object BIG    extends Endianness
 
   implicit class PhysicalNumberPimper(val sc: StringContext) extends AnyVal {
-    def fp(args: Any*): String = {
+    def sf(args: Any*): String = {
       val strings = sc.parts.iterator
       val expressions = args.iterator
 

--- a/tester/src/test/scala/spinal/core/PhysicalNumbers.scala
+++ b/tester/src/test/scala/spinal/core/PhysicalNumbers.scala
@@ -35,12 +35,12 @@ class PhysicalNumbers extends AnyFunSuite {
   }
 
   test("formatting") {
-    assert(fp"${HertzNumber(5123000)}" == "5.123 MHz")
-    assert(fp"${HertzNumber(5123000)}%s" == "5.123 MHz")
-    assert(fp"${HertzNumber(5123000)}%S" == "5.123MHz")
-    assert(fp"${HertzNumber(5123000)}%#s" == "5.123")
-    assert(fp"${HertzNumber(5123000)}%.5s" == "5.12300 MHz")
-    assert(fp"${HertzNumber(5123000)}%15.5s" == "    5.12300 MHz")
-    assert(fp"${HertzNumber(5123000)}%-15.5s" == "5.12300 MHz    ")
+    assert(sf"${HertzNumber(5123000)}" == "5.123 MHz")
+    assert(sf"${HertzNumber(5123000)}%s" == "5.123 MHz")
+    assert(sf"${HertzNumber(5123000)}%S" == "5.123MHz")
+    assert(sf"${HertzNumber(5123000)}%#s" == "5.123")
+    assert(sf"${HertzNumber(5123000)}%.5s" == "5.12300 MHz")
+    assert(sf"${HertzNumber(5123000)}%15.5s" == "    5.12300 MHz")
+    assert(sf"${HertzNumber(5123000)}%-15.5s" == "5.12300 MHz    ")
   }
 }

--- a/tester/src/test/scala/spinal/core/PhysicalNumbers.scala
+++ b/tester/src/test/scala/spinal/core/PhysicalNumbers.scala
@@ -35,12 +35,12 @@ class PhysicalNumbers extends AnyFunSuite {
   }
 
   test("formatting") {
-    assert(f"${HertzNumber(5123000)}" == "5.123 MHz")
-    assert(f"${HertzNumber(5123000)}%s" == "5.123 MHz")
-    assert(f"${HertzNumber(5123000)}%S" == "5.123MHz")
-    assert(f"${HertzNumber(5123000)}%#s" == "5.123")
-    assert(f"${HertzNumber(5123000)}%.5s" == "5.12300 MHz")
-    assert(f"${HertzNumber(5123000)}%15.5s" == "    5.12300 MHz")
-    assert(f"${HertzNumber(5123000)}%-15.5s" == "5.12300 MHz    ")
+    assert(fp"${HertzNumber(5123000)}" == "5.123 MHz")
+    assert(fp"${HertzNumber(5123000)}%s" == "5.123 MHz")
+    assert(fp"${HertzNumber(5123000)}%S" == "5.123MHz")
+    assert(fp"${HertzNumber(5123000)}%#s" == "5.123")
+    assert(fp"${HertzNumber(5123000)}%.5s" == "5.12300 MHz")
+    assert(fp"${HertzNumber(5123000)}%15.5s" == "    5.12300 MHz")
+    assert(fp"${HertzNumber(5123000)}%-15.5s" == "5.12300 MHz    ")
   }
 }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1559 

# Context, Motivation & Description

avoid use official f-interpolator, use fp"xxxxx". 
This will change API.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
