### PR TITLE
Allow user to swap out module dependencies when included as a git submodule

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -39,14 +39,14 @@ trait SpinalPublishModule extends PublishModule {
 }
 
 object idslpayload extends Cross[IdslPayload](Version.SpinalVersion.compilers)
-trait IdslPayload extends SpinalModule with SpinalPublishModule with CrossSbtModule {
+trait IdslPayload extends SpinalModule with SpinalPublishModule {
   def mainClass = Some("spinal.idslpayload")
   override def artifactName = "spinalhdl-idsl-payload"
   def ivyDeps = super.ivyDeps() ++ Agg(ivy"org.scala-lang:scala-reflect:${scalaVersion}")
 }
 
 object idslplugin extends Cross[IdslPlugin](Version.SpinalVersion.compilers)
-trait IdslPlugin extends SpinalModule with SpinalPublishModule with CrossSbtModule {
+trait IdslPlugin extends SpinalModule with SpinalPublishModule {
   def mainClass = Some("spinal.idslplugin")
   override def artifactName = "spinalhdl-idsl-plugin"
   def moduleDeps = Seq(idslpayload(crossScalaVersion))
@@ -57,7 +57,7 @@ trait IdslPlugin extends SpinalModule with SpinalPublishModule with CrossSbtModu
 object sim extends Cross[Sim](Version.SpinalVersion.compilers){
   def defaultCrossSegments = Seq(Version.SpinalVersion.compilers.head)
 }
-trait Sim extends SpinalModule with SpinalPublishModule with CrossSbtModule {
+trait Sim extends SpinalModule with SpinalPublishModule {
   def mainClass = Some("spinal.sim")
   def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"commons-io:commons-io:2.11.0",
@@ -71,7 +71,7 @@ trait Sim extends SpinalModule with SpinalPublishModule with CrossSbtModule {
 object lib extends Cross[Lib](Version.SpinalVersion.compilers){
   def defaultCrossSegments = Seq(Version.SpinalVersion.compilers.head)
 }
-trait Lib extends SpinalModule with SpinalPublishModule with CrossSbtModule {
+trait Lib extends SpinalModule with SpinalPublishModule {
   def mainClass = Some("spinal.lib")
   def moduleDeps = Seq(core(crossScalaVersion), sim(crossScalaVersion))
   def scalacOptions = super.scalacOptions() ++ idslplugin(crossScalaVersion).pluginOptions()
@@ -89,7 +89,7 @@ def gitHash(dir: os.Path) = (try {
 object core extends Cross[Core](Version.SpinalVersion.compilers){
   def defaultCrossSegments = Seq(Version.SpinalVersion.compilers.head)
 }
-trait Core extends SpinalModule with SpinalPublishModule with CrossSbtModule {
+trait Core extends SpinalModule with SpinalPublishModule {
   def mainClass = Some("spinal.core")
   def moduleDeps = Seq(idslplugin(crossScalaVersion), sim(crossScalaVersion))
 
@@ -118,7 +118,7 @@ trait Core extends SpinalModule with SpinalPublishModule with CrossSbtModule {
 object tester extends Cross[Tester](Version.SpinalVersion.compilers){
   def defaultCrossSegments = Seq(Version.SpinalVersion.compilers.head)
 }
-trait Tester extends SpinalModule with SpinalPublishModule with CrossSbtModule {
+trait Tester extends SpinalModule with SpinalPublishModule {
   override def millSourcePath = os.pwd / "tester"
   def mainClass = Some("spinal.tester")
   def moduleDeps = Seq(core(crossScalaVersion), sim(crossScalaVersion), lib(crossScalaVersion))

--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,6 @@
 // build.sc
 import mill._, scalalib._, publish._
+import mill.define.ModuleRef
 import $file.project.Version
 
 trait SpinalModule extends SbtModule with CrossSbtModule { outer =>
@@ -24,11 +25,11 @@ trait SpinalModule extends SbtModule with CrossSbtModule { outer =>
   // Default definitions for moduleDeps.  For projects that consume us as a
   // foreign module (with a git submodule), override these to avoid building
   // these modules multiple times
-  def coreMod = Some(core(crossScalaVersion))
-  def libMod = Some(lib(crossScalaVersion))
-  def simMod = Some(sim(crossScalaVersion))
-  def idslpayloadMod = Some(idslpayload(crossScalaVersion))
-  def idslpluginMod = Some(idslplugin(crossScalaVersion))
+  def coreMod = ModuleRef(core(crossScalaVersion))
+  def libMod = ModuleRef(lib(crossScalaVersion))
+  def simMod = ModuleRef(sim(crossScalaVersion))
+  def idslpayloadMod = ModuleRef(idslpayload(crossScalaVersion))
+  def idslpluginMod = ModuleRef(idslplugin(crossScalaVersion))
 }
 
 trait SpinalPublishModule extends PublishModule {
@@ -58,7 +59,7 @@ object idslplugin extends Cross[IdslPlugin](Version.SpinalVersion.compilers)
 trait IdslPlugin extends SpinalModule with SpinalPublishModule {
   def mainClass = Some("spinal.idslplugin")
   override def artifactName = "spinalhdl-idsl-plugin"
-  def moduleDeps = Seq(idslpayloadMod.get)
+  def moduleDeps = Seq(idslpayloadMod())
   def ivyDeps = super.ivyDeps() ++ Agg(ivy"org.scala-lang:scala-compiler:${scalaVersion}")
   def pluginOptions = T { Seq(s"-Xplugin:${assembly().path}") }
 }
@@ -82,8 +83,8 @@ object lib extends Cross[Lib](Version.SpinalVersion.compilers){
 }
 trait Lib extends SpinalModule with SpinalPublishModule {
   def mainClass = Some("spinal.lib")
-  def moduleDeps = Seq(coreMod.get, simMod.get)
-  def scalacOptions = super.scalacOptions() ++ idslpluginMod.get.pluginOptions()
+  def moduleDeps = Seq(coreMod(), simMod())
+  def scalacOptions = super.scalacOptions() ++ idslpluginMod().pluginOptions()
   def ivyDeps = super.ivyDeps() ++ Agg(ivy"commons-io:commons-io:2.11.0", ivy"org.scalatest::scalatest:${scalatestVersion}")
   def publishVersion = Version.SpinalVersion.lib
 }
@@ -100,9 +101,9 @@ object core extends Cross[Core](Version.SpinalVersion.compilers){
 }
 trait Core extends SpinalModule with SpinalPublishModule {
   def mainClass = Some("spinal.core")
-  def moduleDeps = Seq(idslpluginMod.get, simMod.get)
+  def moduleDeps = Seq(idslpluginMod(), simMod())
 
-  def scalacOptions = super.scalacOptions() ++ idslpluginMod.get.pluginOptions()
+  def scalacOptions = super.scalacOptions() ++ idslpluginMod().pluginOptions()
   def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"org.scala-lang:scala-reflect:${scalaVersion}",
     ivy"com.github.scopt::scopt:4.1.0",
@@ -130,8 +131,8 @@ object tester extends Cross[Tester](Version.SpinalVersion.compilers){
 trait Tester extends SpinalModule with SpinalPublishModule {
   override def millSourcePath = os.pwd / "tester"
   def mainClass = Some("spinal.tester")
-  def moduleDeps = Seq(coreMod.get, simMod.get, libMod.get)
-  def scalacOptions = super.scalacOptions() ++ idslpluginMod.get.pluginOptions()
+  def moduleDeps = Seq(coreMod(), simMod(), libMod())
+  def scalacOptions = super.scalacOptions() ++ idslpluginMod().pluginOptions()
   def ivyDeps = super.ivyDeps() ++ Agg(ivy"org.scalatest::scalatest:${scalatestVersion}")
   def publishVersion = Version.SpinalVersion.tester
 }


### PR DESCRIPTION
Due to the current way the `build.sc` file is written, when a user includes SpinalHDL as a submodule, the `lib`, `sim` and compiler plugin modules will be compiled multiple times since they depend on the instantiated module inside the build.sc and does not allow overriding.  This PR would allow the user to override these modules and supply their own instance:

https://github.com/KireinaHoro/enzian-pio-nic/blob/634ac4be382f57613339797f55ef3aed16dd0583/build.sc#L18-L39

Draft for now due to [a limitation](https://github.com/com-lihaoyi/mill/issues/3715) in Mill, leading to the ugly `Some(...)` hack.