### PR TITLE
Add cross version test

### DIFF
--- a/.github/workflows/run-mill-tests.yml
+++ b/.github/workflows/run-mill-tests.yml
@@ -1,0 +1,140 @@
+name: Run mill tests
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+
+env:
+  SCALA_VERSION: "2.11.12"
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get submodules
+      shell: bash
+      run: git submodule update --init --recursive
+    - run: mill __.compile
+    - uses: actions/cache/save@v3
+      with:
+        path: |
+          **/
+        key: ${{ runner.os }}-compiled-${{ github.sha }}
+
+  idslplugin-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill idslplugin[$SCALA_VERSION].test
+
+  idslpayload-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill idslpayload[$SCALA_VERSION].test
+
+  core-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill core[$SCALA_VERSION].test
+
+  # core-formal:
+  #   needs: compile
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 90
+  #   container:
+  #     image: ghcr.io/spinalhdl/docker:latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: ./.github/actions/get-compiled
+  #   - run: sbt 'tester/testOnly spinal.core.* -- -n spinal.tester.formal'
+
+  sim-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill sim[$SCALA_VERSION].test
+
+  tester-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill tester[$SCALA_VERSION].test
+
+  # tester-formal:
+  #   needs: compile
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 90
+  #   container:
+  #     image: ghcr.io/spinalhdl/docker:latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: ./.github/actions/get-compiled
+  #   - run: sbt 'tester/testOnly spinal.tester.* -- -n spinal.tester.formal'
+
+  lib-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill lib[$SCALA_VERSION].test
+
+  # lib-formal:
+  #   needs: compile
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 90
+  #   container:
+  #     image: ghcr.io/spinalhdl/docker:latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: ./.github/actions/get-compiled
+  #   - run: sbt 'tester/testOnly spinal.lib.* -- -n spinal.tester.formal'
+
+  # scaladoc:
+  #   needs: compile
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   container:
+  #     image: ghcr.io/spinalhdl/docker:latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: ./.github/actions/get-compiled
+  #   - run: sbt unidoc

--- a/.github/workflows/run-tests-2_11.yml
+++ b/.github/workflows/run-tests-2_11.yml
@@ -1,4 +1,4 @@
-name: Run mill tests
+name: Run scala 2.11 tests
 
 on:
   push:
@@ -61,6 +61,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
     - run: mill core[$SCALA_VERSION].test
+    - run: mill tester[$SCALA_VERSION].testOnly spinal.core.*
 
   # core-formal:
   #   needs: compile
@@ -83,6 +84,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
     - run: mill sim[$SCALA_VERSION].test
+    - run: mill tester[$SCALA_VERSION].testOnly spinal.sim.*
 
   tester-test:
     needs: compile
@@ -93,7 +95,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
-    - run: mill tester[$SCALA_VERSION].test
+    - run: mill tester[$SCALA_VERSION].testOnly spinal.tester.*
 
   # tester-formal:
   #   needs: compile
@@ -116,6 +118,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
     - run: mill lib[$SCALA_VERSION].test
+    - run: mill tester[$SCALA_VERSION].testOnly spinal.lib.*
 
   # lib-formal:
   #   needs: compile

--- a/.github/workflows/run-tests-2_11.yml
+++ b/.github/workflows/run-tests-2_11.yml
@@ -1,12 +1,8 @@
 name: Run scala 2.11 tests
 
 on:
-  push:
-    branches:
-      - dev
-  pull_request:
-    branches:
-      - dev
+  schedule:
+    - cron: '0 0 * * 0'
 
 env:
   SCALA_VERSION: "2.11.12"

--- a/.github/workflows/run-tests-2_13.yml
+++ b/.github/workflows/run-tests-2_13.yml
@@ -1,0 +1,143 @@
+name: Run scala 2.13 tests
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+
+env:
+  SCALA_VERSION: "2.13.12"
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get submodules
+      shell: bash
+      run: git submodule update --init --recursive
+    - run: mill __.compile
+    - uses: actions/cache/save@v3
+      with:
+        path: |
+          **/
+        key: ${{ runner.os }}-compiled-${{ github.sha }}
+
+  idslplugin-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill idslplugin[$SCALA_VERSION].test
+
+  idslpayload-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill idslpayload[$SCALA_VERSION].test
+
+  core-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill core[$SCALA_VERSION].test
+    - run: mill tester[$SCALA_VERSION].testOnly spinal.core.*
+
+  # core-formal:
+  #   needs: compile
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 90
+  #   container:
+  #     image: ghcr.io/spinalhdl/docker:latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: ./.github/actions/get-compiled
+  #   - run: sbt 'tester/testOnly spinal.core.* -- -n spinal.tester.formal'
+
+  sim-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill sim[$SCALA_VERSION].test
+    - run: mill tester[$SCALA_VERSION].testOnly spinal.sim.*
+
+  tester-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill tester[$SCALA_VERSION].testOnly spinal.tester.*
+
+  # tester-formal:
+  #   needs: compile
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 90
+  #   container:
+  #     image: ghcr.io/spinalhdl/docker:latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: ./.github/actions/get-compiled
+  #   - run: sbt 'tester/testOnly spinal.tester.* -- -n spinal.tester.formal'
+
+  lib-test:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: mill lib[$SCALA_VERSION].test
+    - run: mill tester[$SCALA_VERSION].testOnly spinal.lib.*
+
+  # lib-formal:
+  #   needs: compile
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 90
+  #   container:
+  #     image: ghcr.io/spinalhdl/docker:latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: ./.github/actions/get-compiled
+  #   - run: sbt 'tester/testOnly spinal.lib.* -- -n spinal.tester.formal'
+
+  # scaladoc:
+  #   needs: compile
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   container:
+  #     image: ghcr.io/spinalhdl/docker:latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: ./.github/actions/get-compiled
+  #   - run: sbt unidoc

--- a/.github/workflows/run-tests-2_13.yml
+++ b/.github/workflows/run-tests-2_13.yml
@@ -1,12 +1,8 @@
 name: Run scala 2.13 tests
 
 on:
-  push:
-    branches:
-      - dev
-  pull_request:
-    branches:
-      - dev
+  schedule:
+    - cron: '0 0 * * 0'
 
 env:
   SCALA_VERSION: "2.13.12"

--- a/tester/src/test/scala/spinal/lib/SpinalSimStreamAccessibleFifoTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimStreamAccessibleFifoTester.scala
@@ -15,7 +15,7 @@ class SpinalSimStreamAccessibleFifoTester extends SpinalSimFunSuite {
         alwaysInput: Boolean = false,
         alwaysOutput: Boolean = false,
         inQueue: mutable.Queue[BigInt],
-        outQueue: mutable.Queue[BigInt],
+        outQueue: mutable.Queue[BigInt]
     ) {        
         val stateQueue    = mutable.Queue[BigInt]()
         stateQueue.clear()
@@ -78,7 +78,7 @@ class SpinalSimStreamAccessibleFifoTester extends SpinalSimFunSuite {
         val compiled = SimConfig.withFstWave.allOptimisation.compile {
             val dut = new StreamAccessibleFifo(
                 UInt(32 bits),
-                12,
+                12
             )
             dut
         }

--- a/tester/src/test/scala/spinal/lib/SpinalSimStreamShiftChainTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimStreamShiftChainTester.scala
@@ -8,13 +8,13 @@ import spinal.lib.sim._
 import spinal.core.sim._
 import spinal.tester.SpinalSimFunSuite
 
-class SpinalSimStreamShiftChainTester extends SpinalSimFunSuite {
+class SpinalSimStreamShiftChainTester() extends SpinalSimFunSuite {
     def prepare(
         dut: StreamShiftChain[UInt],
         alwaysInput: Boolean = false,
         alwaysOutput: Boolean = false,
         inQueue: mutable.Queue[BigInt],
-        outQueue: mutable.Queue[BigInt],
+        outQueue: mutable.Queue[BigInt]
     ) {
         dut.clockDomain.forkStimulus(period = 10)
         dut.io.push.valid #= false
@@ -62,7 +62,7 @@ class SpinalSimStreamShiftChainTester extends SpinalSimFunSuite {
         val compiled = SimConfig.allOptimisation.compile {
             val dut = new StreamShiftChain(
                 UInt(32 bits),
-                12,
+                12
             )
             dut
         }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

Add tester for scala version 2.11 and 2.13.

Still need to split formal test out after mill 0.12.0 release.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
