### PR TITLE
VHDL basic assert message formatting

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -639,8 +639,8 @@ class ComponentEmitterVhdl(
               .map {
                 case m: String =>
                   "\"" +
-                    m.replace("\n", "\\n")
-                      .replace("\"", "\\\"") +
+                    m .replace("\"", "\"\"")
+                  .replace("\n", "\" & LF & \"")+
                   "\""
                 case m: SpinalEnumCraft[_] =>
                   require(
@@ -651,8 +651,8 @@ class ComponentEmitterVhdl(
                 case m @ (_: Bits | _: UInt | _: SInt) =>
                   s"pkg_toString(${emitExpression(m.asInstanceOf[Expression])})"
                 case m: Bool => s"std_logic'image(${emitExpression(m)})"
-                case m: Expression => s""""<Unknown Expression `$m`>""""
                 case `REPORT_TIME` => "time'image(now)"
+                case m: Data => s""""<Unknown Datatype `$m`>""""
                 case x =>
                   SpinalError(
                     s"""L\"\" can't manage the parameter '${x}' type for VHDL. Located at:\n${statement.getScalaLocationLong}"""

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -645,7 +645,7 @@ class ComponentEmitterVhdl(
                 case m: SpinalEnumCraft[_] =>
                   require(
                     m.getEncoding == native,
-                    s"VHDL emitter can format only natively encoded enums! Located at:\n${statement.getScalaLocationLong}",
+                    s"VHDL emitter can format only natively encoded enums! Located at:\n${statement.getScalaLocationLong}"
                   )
                   s"${emitEnumType(m)}'image(${emitExpression(m)})"
                 case m @ (_: Bits | _: UInt | _: SInt) =>

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -745,7 +745,6 @@ class ComponentEmitterVhdl(
             if (!spinalConfig.formalAsserts) {
               val cond = emitExpression(assertStatement.cond)
 
-              require(assertStatement.message.isEmpty || (assertStatement.message.size == 1 && assertStatement.message.head.isInstanceOf[String]))
               val message = assertStatement.message
                 .map {
                   case m: String =>

--- a/core/src/main/scala/spinal/core/internals/PhaseVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVhdl.scala
@@ -425,6 +425,10 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
     ret ++= "  function pkg_shiftLeft (that : signed; size : unsigned; w : integer) return signed;\n"
     ret ++= "\n"
     ret ++= "  function pkg_rotateLeft (that : std_logic_vector; size : unsigned) return std_logic_vector;\n"
+    ret ++= "\n"
+    ret ++= "  function pkg_toString (that : std_logic_vector) return string;\n"
+    ret ++= "  function pkg_toString (that : unsigned) return string;\n"
+    ret ++= "  function pkg_toString (that : signed) return string;\n"
     ret ++= s"end  $packageName;\n"
     ret ++= "\n"
     ret ++= s"package body $packageName is\n"
@@ -648,6 +652,44 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
         |    return ret;
         |  end pkg_resize;
         |""".stripMargin
+    ret ++= "\n"
+    ret ++= """|  function pkg_toString (that : std_logic_vector) return string is
+               |    variable ret : string((that'length-1)/4 downto 0);
+               |    constant chars : string := "0123456789abcdef";
+               |    variable left : natural;
+               |  begin
+               |    for i in ret'range loop
+               |      left := i*4+3;
+               |      if left > that'left then
+               |        left := that'left;
+               |      end if;
+               |      ret(i) := chars(to_integer(unsigned(that(left downto i*4)))+1);
+               |    end loop;
+               |    return "x" & '"' & ret & '"';
+               |  end pkg_toString;
+               |""".stripMargin
+    ret ++= """|  function pkg_toString (that : unsigned) return string is
+               |    constant chars : string := "0123456789";
+               |  begin
+               |    if that > 0 then
+               |      return pkg_toString(that / 10) & integer'image(to_integer(that mod 10));
+               |    else
+               |      return "";
+               |    end if;
+               |  end pkg_toString;
+               |""".stripMargin
+    ret ++= """|  function pkg_toString (that : signed) return string is
+               |    constant chars : string := "0123456789";
+               |  begin
+               |    if that < 0 then
+               |      return "-" & pkg_toString(0 - that);
+               |    elsif that > 0 then
+               |      return pkg_toString(that / 10) & integer'image(to_integer(that mod 10));
+               |    else
+               |      return "";
+               |    end if;
+               |  end pkg_toString;
+               |""".stripMargin
     ret ++= s"end $packageName;\n"
     ret ++= "\n"
     ret ++= "\n"

--- a/core/src/main/scala/spinal/core/internals/PhaseVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVhdl.scala
@@ -669,7 +669,6 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
                |  end pkg_toString;
                |""".stripMargin
     ret ++= """|  function pkg_toString (that : unsigned) return string is
-               |    constant chars : string := "0123456789";
                |  begin
                |    if that > 0 then
                |      return pkg_toString(that / 10) & integer'image(to_integer(that mod 10));
@@ -679,10 +678,9 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
                |  end pkg_toString;
                |""".stripMargin
     ret ++= """|  function pkg_toString (that : signed) return string is
-               |    constant chars : string := "0123456789";
                |  begin
                |    if that < 0 then
-               |      return "-" & pkg_toString(0 - that);
+               |      return "-" & pkg_toString(0 - pkg_resize(that, that'length + 1));
                |    elsif that > 0 then
                |      return pkg_toString(that / 10) & integer'image(to_integer(that mod 10));
                |    else

--- a/tester/src/test/scala/spinal/core/VhdlAssertTester.scala
+++ b/tester/src/test/scala/spinal/core/VhdlAssertTester.scala
@@ -33,6 +33,7 @@ class VhdlAssertTester extends SpinalAnyFunSuite {
             ("BITS", L"${B(0x123, 14 bits)}", """x"0123""""),
             ("UINT", L"${U(123, 14 bits)}", "123"),
             ("SINT", L"${S(-123, 14 bits)}", "-123"),
+            ("SINT", L"${S(-128, 8 bits)}", "-128"),
             ("ENUM", L"${TestEnum.First()} ${TestEnum.Third()}", "first third"),
             ("EXPRESSION", L"$testValue", "<Unknown Datatype `toplevel/testValue : TestBundle`>")
           )

--- a/tester/src/test/scala/spinal/core/VhdlAssertTester.scala
+++ b/tester/src/test/scala/spinal/core/VhdlAssertTester.scala
@@ -1,0 +1,60 @@
+package spinal.core
+
+import spinal.core.sim._
+import spinal.tester.scalatest.SpinalAnyFunSuite
+import java.io.OutputStream
+
+class VhdlAssertTester extends SpinalAnyFunSuite {
+  test("VHDL assert message formatting") {
+    var references: Seq[String] = null
+    val simOutput = new StringBuilder()
+    val realOut = Console.out
+
+    Console.withOut(new OutputStream {
+      override def write(i: Int) = {
+        realOut.write(i)
+        simOutput.+=(i.toChar)
+      }
+    }) {
+      SimConfig
+        .withGhdl()
+        .compile(new Component {
+          setDefinitionName("VhdlAssertTester")
+          object TestEnum extends SpinalEnum {
+            val First, Second, Third = newElement()
+          }
+          case class TestBundle() extends Bundle {}
+          val testValue = TestBundle()
+          val messages = Seq[(String, Seq[Any], String)](
+            ("REPORT_TIME", L"""$REPORT_TIME""", "210 fs"),
+            ("QUOTATION MARK", L""""""", """""""),
+            ("NEWLINE", Seq("First Line\nSecond Line\nThird Line"), "First Line\nSecond Line\nThird Line"),
+            ("BOOL", L"$True $False", "'1' '0'"),
+            ("BITS", L"${B(0x123, 14 bits)}", """x"0123""""),
+            ("UINT", L"${U(123, 14 bits)}", "123"),
+            ("SINT", L"${S(-123, 14 bits)}", "-123"),
+            ("ENUM", L"${TestEnum.First()} ${TestEnum.Third()}", "first third"),
+            ("EXPRESSION", L"$testValue", "<Unknown Datatype `toplevel/testValue : TestBundle`>")
+          )
+          references = for ((name, _, ref) <- messages) yield f"$name: $ref"
+
+          val counter = RegInit(U(0, 32 bits))
+          counter := counter + 1
+          for (((name, msg, _), i) <- messages.zipWithIndex) spinal.core.assert(counter =/= i, f"$name: " +: msg, NOTE)
+        })
+        .doSim { dut =>
+          val clk = dut.clockDomain
+          clk.forkStimulus(10, 0, 20)
+          clk.waitSampling(10)
+        }
+    }
+
+    val outputLines = simOutput.mkString.linesIterator
+    for {
+      message <- references
+      line <- message.linesIterator
+    }
+      while (!outputLines.next().endsWith(line))
+        assert(outputLines.hasNext, f"Message not found in simulation output:\n $message")
+  }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1532

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

Allow format strings as assert messages for VHDL, just like the Verilog emitter does.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

Formatted assert messages are emitted as VHDL. This shouldn't change anything for code that built previously.

The new `pkg_toString` function might lead to collisions.

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
