### PR TITLE
add preliminary CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: SpinalHDL
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Charles
+    family-names: Papon
+    email: charles.papon.90@gmail.com
+repository-code: 'https://github.com/SpinalHDL/SpinalHDL'
+license: LGPL-3.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,5 +11,8 @@ authors:
   - given-names: Charles
     family-names: Papon
     email: charles.papon.90@gmail.com
+  - given-names: Yindong
+    family-names: Xiao
+    orcid: "https://orcid.org/0000-0003-1214-6077"
 repository-code: 'https://github.com/SpinalHDL/SpinalHDL'
 license: LGPL-3.0


### PR DESCRIPTION
# Context, Motivation & Description

Citing the GitHub repository is a bit tedious in papers at times. Adding a CITATION.cff allows more smooth citation that also results in more 'consistent' citations by academicians (otherwise everyone would write names differently or link to something different).

If you compare with https://github.com/agra-uni-bremen/microrv32 I added a CITATION.cff to my repository, which allows pressing 'Cite this repository' on the sidebar of the Github repository. Which allows to basically export APA or BibTeX formatted versions of citing the repository. BibTeX actually uses the `@software` tag, which is also neat.
This is handy for SpinalHDL as there is no publication (even on arXiv?) yet? If there is then it can also be combined nicely with the DOI of the publication.

## Discussion
@Dolu1990 It would require you to fill out a version of the CITATION.cff more faithfully than I did here right now. At [https://citation-file-format.github.io/cff-initializer-javascript/](https://citation-file-format.github.io/cff-initializer-javascript/) you can do that. More information on CITATION.cff is at [https://citation-file-format.github.io/](https://citation-file-format.github.io/). 
I preliminarily created one for the ease of integration, with very basic information I found. There are some 'unclear' things like the licensing as the CITATION.cff doesnt officially allow two licenses to appear in the file. 
Would like to hear your opinion on this.

## Example https://github.com/agra-uni-bremen/microrv32

Old version:
```
@misc{
    title = {{MicroRV32}},
    howpublished = {{https://github.com/agra-uni-bremen/microrv32}},
    note = {Accessed: 23-10-2024}
}

i.e. 
MicroRV32 - https://github.com/agra-uni-bremen/microrv32, Accessed: 23-10-2024
```

With CITATION.cff
```
@software{Ahmadi-Pour_MicroRV32,
author = {Ahmadi-Pour, Sallar and Drechsler, Rolf},
license = {MIT},
title = {{MicroRV32}},
url = {https://github.com/agra-uni-bremen/microrv32/}
}

i.e.

Ahmadi-Pour, S., & Drechsler, R. - MicroRV32 [Computer software]. https://github.com/agra-uni-bremen/microrv32/
```


# Impact on code generation

None
