### PR TITLE
add replaceFragmentLast method for fragment

### DIFF
--- a/lib/src/main/scala/spinal/lib/Fragment.scala
+++ b/lib/src/main/scala/spinal/lib/Fragment.scala
@@ -56,6 +56,8 @@ class StreamFragmentPimped[T <: Data](pimped: Stream[Fragment[T]]) {
 
   def toStreamOfFragment : Stream[T] = pimped.translateWith(pimped.fragment)
 
+  def replaceFragmentLast(last: Bool) : Stream[Fragment[T]] = toStreamOfFragment.addFragmentLast(last)
+
 /**
  * Stepwise reduction of all fragments into a single value. With this, you can calculate
  * the (check)sum of every n elements or parity bits.


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->


# Context, Motivation & Description

add method `replaceFragmentLast(last)` to simplify  `stream.toStreamOfFragment.addFragmentLast(last)` usage.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
No impact on code generation since the mathod is a simplified usage for existing methods.
# Checklist

- [ ] Unit tests were added
- [ ] API changes will be documented using Scaladoc comments: `/** */`