### PR TITLE
Enhance pipeline payload propagation logic in propagateDown and propagateUp functions

### DIFF
--- a/lib/src/main/scala/spinal/lib/misc/pipeline/Builder.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/Builder.scala
@@ -20,7 +20,7 @@ object Builder {
           e.propagateDown()
           for (d <- e.downs) {
             solved += d
-            if (d.down != null && d.down.ups.forall(u => solved.contains(u))) {
+            if (d.down != null && d.down.ups.forall(u => solved.contains(u) || u.up == null)) {
               seeds += d.down
             }
           }
@@ -40,7 +40,7 @@ object Builder {
           e.propagateUp()
           for (d <- e.ups) {
             solved += d
-            if (d.up != null && d.up.downs.forall(u => solved.contains(u))) {
+            if (d.up != null && d.up.downs.forall(u => solved.contains(u) || u.down == null)) {
               seeds += d.up
             }
           }


### PR DESCRIPTION
Hi, 

When implementing a pipeline that employs fork and join to work with an external stream, I encountered an error indicating that `sorterNode`'s payload has no driver: **"NO DRIVER ON (toplevel/sorterNode_PRESENT: Bool), defined at ..."**.

```scala
// Define pipeline stages
val decoderNode                         = Node()
val memoryIssueNode, memoryResponseNode = Node()
val memoryNode, memorySyncNode          = Node()
val sorterNode                          = Node()

val l1 = ForkLink(decoderNode, Seq(memoryIssueNode, memoryNode))
val l2 = StageLink(memoryNode, memorySyncNode)
val l3 = JoinLink(Seq(memorySyncNode, memoryResponseNode), sorterNode)
/*
decoderNode
|\
| \
memoryNode
|   |
|   memoryIssueNode
|   |
memorySyncNode
|   |
|   streamMemory(external)
|   |
|   memoryResponseNode
|  /
| /
|/
sorterNode
*/

// Define pipeline payload
val PRESENT = Payload(Bool())

val decoder = new decoderNode.Area {
  arbitrateFrom(insertCommand)

  PRESENT := some_data
}

val memory = new memoryNode.Area {
}

val memoryIssuer = new memoryIssueNode.Area {
  arbitrateTo(dataMemory.io.cmd)
}

val memoryResponder = new memoryResponseNode.Area {
  arbitrateFrom(dataMemory.io.rsp)
}

val sorter = new sorterNode.Area {
  arbitrateTo(io.down)

  io.down.toSort     := PRESENT
}

Builder(l1, l2, l3)
```

After inspecting the pipeline API source code, I found that the error is caused by incorrect payload propagation logic.

```scala
def propagateDown(): Unit = {
  val solved = mutable.ArrayBuffer[Node]()
  val seeds = mutable.ArrayBuffer[Link]()
  seeds ++= connectors.filter(c => c.ups.isEmpty || c.ups.forall(_.up == null))
  while (seeds.nonEmpty) {
    val tmp = seeds.toArray
    seeds.clear()
    for (e <- tmp) {
      e.propagateDown()
      for (d <- e.downs) {
        solved += d
        if (d.down != null && d.down.ups.forall(u => solved.contains(u))) {
          seeds += d.down
        }
      }
    }
  }
}
```

The issues I identified are as follows:

- The condition `c.ups.forall(_.up == null)` prevents the link `l3` from being selected as a seed. In my case, `l3` connects `memorySyncNode` (which has a non-null `up`) and `memoryResponseNode` (which has a `null` `up`).
- The condition `d.down.ups.forall(u => solved.contains(u))` prevents `l3` from being selected as a seed, as `memoryResponseNode` will never be added to `solved` because it has a `null` `up`.

To address this issue, I believe that a link should be considered ready for propagation if either it is already solved or its `up` is `null` (indicating that it won't be solved by any other node).

To fix this, I modified the code as follows:

```scala
-       if (d.down != null && d.down.ups.forall(u => solved.contains(u))) {
+       if (d.down != null && d.down.ups.forall(u => solved.contains(u) || u.up == null)) {
```

To address similar issues, the same change can be applied to the `propagateUp` function as well.