### PR TITLE
fix missing ipxact lib problem while runing with 2.11 & 2.13.

### DIFF
--- a/.github/workflows/run-tests-2_11.yml
+++ b/.github/workflows/run-tests-2_11.yml
@@ -3,6 +3,12 @@ name: Run scala 2.11 tests
 on:
   schedule:
     - cron: '0 0 * * 0'
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
 
 env:
   SCALA_VERSION: "2.11.12"

--- a/.github/workflows/run-tests-2_13.yml
+++ b/.github/workflows/run-tests-2_13.yml
@@ -3,6 +3,12 @@ name: Run scala 2.13 tests
 on:
   schedule:
     - cron: '0 0 * * 0'
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
 
 env:
   SCALA_VERSION: "2.13.12"

--- a/build.sc
+++ b/build.sc
@@ -85,7 +85,8 @@ trait Lib extends SpinalModule with SpinalPublishModule {
   def mainClass = Some("spinal.lib")
   def moduleDeps = Seq(coreMod(), simMod())
   def scalacOptions = super.scalacOptions() ++ idslpluginMod().pluginOptions()
-  def ivyDeps = super.ivyDeps() ++ Agg(ivy"commons-io:commons-io:2.11.0", ivy"org.scalatest::scalatest:${scalatestVersion}")
+  def ivyDeps = super.ivyDeps() ++ Agg(ivy"commons-io:commons-io:2.11.0", ivy"org.scalatest::scalatest:${scalatestVersion}",
+    ivy"io.github.zhaokunhu::ipxactscalacases:0.0.1")
   def publishVersion = Version.SpinalVersion.lib
 }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
