### PR TITLE
Run psl test individually to reduce test time, based on test name.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
-    - run: sbt 'tester/testOnly spinal.core.* -- -l spinal.tester.formal'
+    - run: sbt 'tester/testOnly spinal.core.* -- -l spinal.tester.formal -l spinal.tester.psl'
 
   core-formal:
     needs: compile
@@ -70,6 +70,17 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
     - run: sbt 'tester/testOnly spinal.core.* -- -n spinal.tester.formal'
+
+  core-psl:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: sbt 'tester/testOnly spinal.core.* -- -n spinal.tester.psl'
 
   sim-test:
     needs: compile
@@ -91,7 +102,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
-    - run: sbt 'tester/testOnly spinal.tester.* -- -l spinal.tester.formal'
+    - run: sbt 'tester/testOnly spinal.tester.* -- -l spinal.tester.formal -l spinal.tester.psl'
 
   tester-formal:
     needs: compile
@@ -104,6 +115,17 @@ jobs:
     - uses: ./.github/actions/get-compiled
     - run: sbt 'tester/testOnly spinal.tester.* -- -n spinal.tester.formal'
 
+  tester-psl:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: sbt 'tester/testOnly spinal.tester.* -- -n spinal.tester.psl'
+
   lib-test:
     needs: compile
     runs-on: ubuntu-latest
@@ -113,7 +135,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
-    - run: sbt 'tester/testOnly spinal.lib.* -- -l spinal.tester.formal'
+    - run: sbt 'tester/testOnly spinal.lib.* -- -l spinal.tester.formal -l spinal.tester.psl'
 
   lib-formal:
     needs: compile
@@ -125,6 +147,17 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
     - run: sbt 'tester/testOnly spinal.lib.* -- -n spinal.tester.formal'
+
+  lib-psl:
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/spinalhdl/docker:latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/get-compiled
+    - run: sbt 'tester/testOnly spinal.lib.* -- -n spinal.tester.psl'
 
   scaladoc:
     needs: compile

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches:
       - dev
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
 
 jobs:
   compile:

--- a/tester/src/main/scala/spinal/lib/formal/SpinalFormalFunSuite.scala
+++ b/tester/src/main/scala/spinal/lib/formal/SpinalFormalFunSuite.scala
@@ -7,6 +7,7 @@ import spinal.core.formal._
 import spinal.idslplugin.Location
 
 object SpinalFormal extends Tag("spinal.tester.formal")
+object SpinalFormalPSL extends Tag("spinal.tester.psl")
 
 class SpinalFormalFunSuite extends AnyFunSuite{
   implicit val className: String = getClass.getSimpleName()
@@ -19,8 +20,14 @@ class SpinalFormalFunSuite extends AnyFunSuite{
   }
 
   def test(testName: String)(testFun: => Unit): Unit = {
-    super.test("formal_" + testName, SpinalFormal) {
-      testFun
+    if (testName.contains("ghdl")) {
+      super.test("formalpsl_" + testName, SpinalFormalPSL) {
+        testFun
+      }
+    } else {
+      super.test("formal_" + testName, SpinalFormal) {
+        testFun
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
This is not a perfect solution, but it works now.
The API is that if formal verification by GHDL should include "ghdl" inside the test name.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
