### PR TITLE
Add missing initialization of `portLowSpeed` in UsbLsFsPhy

### DIFF
--- a/lib/src/main/scala/spinal/lib/com/usb/phy/UsbHubPhy.scala
+++ b/lib/src/main/scala/spinal/lib/com/usb/phy/UsbHubPhy.scala
@@ -409,7 +409,7 @@ case class UsbLsFsPhy(portCount : Int, sim : Boolean = false) extends Component 
 
   val ports = for((usb, ctrl, management) <- (io.usb, io.ctrl.ports, io.management).zipped) yield new Area{
 //    val connected = Reg(Bool()) init(False) //TODO
-    val portLowSpeed = Reg(Bool())
+    val portLowSpeed = Reg(Bool()) init(False)
 //    val enable = Reg(Bool())
 
 //    ctrl.connected := connected
@@ -646,6 +646,9 @@ case class UsbLsFsPhy(portCount : Int, sim : Boolean = false) extends Component 
         when(timer.DISCONNECTED_EOI){
           ctrl.connect := True
           goto(DISABLED)
+        }
+        when(!ctrl.reset.valid && filter.io.filtred.dm =/= filter.io.filtred.dp) {
+          portLowSpeed := !filter.io.filtred.d
         }
       }
 


### PR DESCRIPTION
Add missing initialization of `portLowSpeed` in UsbLsFsPhy.

Currently `portLowSpeed` is assigned only in [this](https://github.com/SpinalHDL/SpinalHDL/blob/70750fc0e74703cd821cf3a31bcfea7eb38ddf79/lib/src/main/scala/spinal/lib/com/usb/phy/UsbHubPhy.scala#L624) line and happens only on reset of a already connected device, that seems to be bug.