### PR TITLE
fix xsim backend improperly converting signed values to bigint

### DIFF
--- a/sim/src/main/resources/XSIIface.cpp
+++ b/sim/src/main/resources/XSIIface.cpp
@@ -130,7 +130,11 @@ int64_t XSIIface::read64(int32_t handle) {
 
 std::vector<int8_t> XSIIface::read(int32_t handle, int32_t width) {
     std::vector<int8_t> vec_bytes = read_vlog(handle);
-    vec_bytes.resize(width, 0);
+    int32_t byteCount = width / 8;
+    if(width % 8){
+        byteCount++;
+    }
+    vec_bytes.resize(byteCount, 0);
     std::reverse(vec_bytes.begin(), vec_bytes.end());
     return vec_bytes;
 }

--- a/sim/src/main/scala/spinal/sim/SimXSim.scala
+++ b/sim/src/main/scala/spinal/sim/SimXSim.scala
@@ -38,10 +38,22 @@ class SimXSim(backend: XSimBackend) extends SimRaw {
     instance.write64(id, value)
   }
 
+
+  def SignExtendByte(byte: Byte, width : Int) : Byte =  {
+    val bitOffset = (width -1) % 8
+    val signMask = 1 << bitOffset
+    ((byte ^ signMask) - signMask).toByte
+  }
+
   override def getBigInt(signal: Signal) = {
     val id = getSignalId(signal)
     val value = instance.read(id, signal.width)
-    if(!signal.dataType.isInstanceOf[SIntDataType]) value.add(0, zeroByte)
+    if(signal.dataType.isInstanceOf[SIntDataType]) {
+      val extended = SignExtendByte(value.get(0), signal.width)
+      value.set(0, extended)
+    } else {
+      value.add(0, zeroByte)
+    }
     BigInt(value.asScala.toArray.map{x => x.toByte})
   }
 


### PR DESCRIPTION

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
I noticed that I was never getting negative numbers back from simulation when using the xsim backend, regardless of type.
One reason was that non-32 or 64 bit types were having vectors returned with one byte per bit, and then the last byte wasn't being sign extended. 

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
no codegen changes, this just fixes how xsim retrieves signed numbers from simulation 



