### PR TITLE
Fix incorrect interconnect addressWidth generation

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/bmb/Bmb.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bmb/Bmb.scala
@@ -403,7 +403,7 @@ case class BmbCmd(p : BmbParameter) extends Bundle{
     def s = this
     WeakConnector(m, s, m.source,  s.source,  defaultValue = null, allowUpSize = true , allowDownSize = false, allowDrop = false)
     WeakConnector(m, s, m.opcode,  s.opcode,  defaultValue = null, allowUpSize = false, allowDownSize = false, allowDrop = false)
-    WeakConnector(m, s, m.address, s.address, defaultValue = null, allowUpSize = false, allowDownSize = true , allowDrop = false)
+    WeakConnector(m, s, m.address, s.address, defaultValue = null, allowUpSize = true, allowDownSize = true , allowDrop = false)
     WeakConnector(m, s, m.length,  s.length,  defaultValue = null, allowUpSize = true, allowDownSize = false , allowDrop = false)
     WeakConnector(m, s, m.data,    s.data,    defaultValue = () => Bits(m.p.access.dataWidth bits).assignDontCare() , allowUpSize = false, allowDownSize = false, allowDrop = true )
     WeakConnector(m, s, m.mask,    s.mask,    defaultValue = () => Bits(m.p.access.maskWidth bits).assignDontCare() , allowUpSize = false, allowDownSize = false, allowDrop = true)
@@ -456,7 +456,7 @@ case class BmbInv(p: BmbParameter) extends Bundle{
   def weakAssignFrom(m : BmbInv): Unit ={
     def s = this
     WeakConnector(m, s, m.source , s.source , defaultValue = null, allowUpSize = false, allowDownSize = false, allowDrop = false)
-    WeakConnector(m, s, m.address, s.address, defaultValue = null, allowUpSize = false, allowDownSize = false, allowDrop = false)
+    WeakConnector(m, s, m.address, s.address, defaultValue = null, allowUpSize = true, allowDownSize = false, allowDrop = false)
     WeakConnector(m, s, m.length , s.length , defaultValue = null, allowUpSize = false, allowDownSize = false, allowDrop = false)
     WeakConnector(m, s, m.all    , s.all    , defaultValue = null, allowUpSize = false, allowDownSize = false, allowDrop = false)
   }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
When the master of a connection uses `SizeMapping` to describe its address mapping, the current Bmb interconnect generator assigns the minimal number of bits that describe the range of the mapping to be the address width of that connection (i.e., `log2Up(sizeMapping.size)`). However, this doesn't make sense as the hit function used by `SizeMapping` implies that the address used by it is a true address instead of an offset. This is because the given address (parameter used by the hit function) is compared with `base + size`. I didn't fully walk myself through how the hit function interacts with the address parameter in the interconnect, so I am not sure if I missed anything. If so, please let me know, thanks!


<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
I simply removed the spacial case for `SizeMapping` and use the addressWidth parameter described in the master's `accessRequirements` instead.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
