### PR TITLE
lib/bus/bmb/BmbDecoder: Fix missing wirings when invalidation is enabled

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/bmb/BmbDecoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bmb/BmbDecoder.scala
@@ -51,7 +51,10 @@ case class BmbDecoder(p : BmbParameter,
     input.ready := (hitsS1, io.outputs).zipped.map(_ && _.cmd.ready).orR || noHitS1
 
     val rspPendingCounter = Reg(UInt(log2Up(pendingMax + 1) bits)) init(0)
-    rspPendingCounter := rspPendingCounter + U(input.lastFire) - U(io.input.rsp.lastFire)
+    if (p.access.canSync)
+      rspPendingCounter := rspPendingCounter + U(input.lastFire) * 2 - U(io.input.rsp.lastFire) - U(io.input.sync.valid)
+    else
+      rspPendingCounter := rspPendingCounter + U(input.lastFire) - U(io.input.rsp.lastFire)
     val cmdWait = Bool()
     val rspHits = RegNextWhen(hitsS1, input.valid && !cmdWait)
     val rspPending = rspPendingCounter =/= 0

--- a/lib/src/main/scala/spinal/lib/bus/bmb/BmbDecoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bmb/BmbDecoder.scala
@@ -53,7 +53,7 @@ case class BmbDecoder(p : BmbParameter,
     val rspPendingCounter = Reg(UInt(log2Up(pendingMax + 1) bits)) init(0)
     if (p.access.canSync)
       rspPendingCounter := (rspPendingCounter + U(input.lastFire) - U(io.input.rsp.lastFire)
-                           + U(input.lastFire && input.isWrite) - U(io.input.sync.valid && input.isWrite))
+                           + U(input.lastFire && input.isWrite) - U(io.input.sync.fire))
     else
       rspPendingCounter := rspPendingCounter + U(input.lastFire) - U(io.input.rsp.lastFire)
     val cmdWait = Bool()
@@ -124,7 +124,7 @@ case class BmbDecoder(p : BmbParameter,
     for(output <- io.outputs) output.rsp.ready := io.input.rsp.ready
 
     cmdWait := ((rspPending && (hitsS1 =/= rspHits || rspNoHitValid))
-               || ((rspPendingCounter ^ pendingMax) & ~U(input.isWrite, log2Up(pendingMax + 1) bits)) === 0)
+               || (rspPendingCounter === pendingMax || rspPendingCounter === pendingMax - 1))
     when(cmdWait) {
       input.ready := False
       io.outputs.foreach(_.cmd.valid := False)


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
The current implementation of BmbDecoder ignores `canInvalidate` and `canSync` parameters found in the access parameters. This becomes an issue when instantiating multiple (or a single) VexRsicv cores with a stripped SRAM.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
Changes made in this PR simply wires `inv`, `ack`, and `sync` ports between input and outputs.

# Impact on code generation
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
