### PR TITLE
Add SimEquiv trait for using #= generically

### DIFF
--- a/lib/src/main/scala/spinal/lib/sim/Flow.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Flow.scala
@@ -38,6 +38,19 @@ object FlowDriver {
     }
     (driver, cmdQueue)
   }
+
+  def fromIterable[T <: Data, E](flow: Flow[T], clockDomain: ClockDomain, els: Iterable[E])
+    (implicit ev: T => SimEquiv { type SimEquivT = E }): FlowDriver[T] = {
+    val iter = els.iterator
+    FlowDriver(flow, clockDomain) { payload =>
+      if (!iter.isEmpty) {
+        payload #= iter.next
+        true
+      } else {
+        false
+      }
+    }
+  }
 }
 
 class FlowDriver[T <: Data](flow: Flow[T], clockDomain: ClockDomain, var driver: (T) => Boolean) {

--- a/lib/src/main/scala/spinal/lib/sim/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Stream.scala
@@ -67,6 +67,19 @@ object StreamDriver{
     }
     (driver, cmdQueue)
   }
+
+  def fromIterable[T <: Data, E](flow: Stream[T], clockDomain: ClockDomain, els: Iterable[E])
+    (implicit ev: T => SimEquiv { type SimEquivT = E }): StreamDriver[T] = {
+    val iter = els.iterator
+    StreamDriver(flow, clockDomain) { payload =>
+      if (!iter.isEmpty) {
+        payload #= iter.next
+        true
+      } else {
+        false
+      }
+    }
+  }
 }
 
 class StreamDriver[T <: Data](stream : Stream[T], clockDomain: ClockDomain, var driver : (T) => Boolean){


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

I often found myself dealing with a large amount of code repetition when writing testbenches. This adds the SimEquiv trait, which I consider a first step towards being able to write more reusable methods for my testbenches.

The SimEquiv trait represents the relationship where a scala type can correspond to a SpinalHDL type during simulation. This allows methods which assign or get simulation values to be written in terms of generics, thus possibly greatly reducing code repetition.

More concretely, one benefit is that it allows you to use #= between a SpinalHDL Vec and Scala List without the need to implement it for every type combination.

As a sample of the generic functions which are now possible, a new constructor for FlowDriver and StreamDriver was added which can drive a Stream or Flow directly from a list of Scala values.

# Impact on code generation

None.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?

Before I write the tests I would like some feedback on the changes here.