### PR TITLE
IVerilog and GHDL backends: put wave file in per-test paths

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -295,6 +295,7 @@ object SpinalGhdlBackend {
     }
     vconfig.runFlags = config.runFlags.mkString(" ")
     vconfig.logSimProcess = config.enableLogging
+    vconfig.testPath = config.testPath
 
     val signalsCollector = SpinalVpiBackend(config, vconfig)
 

--- a/sim/src/main/scala/spinal/sim/GhdlBackend.scala
+++ b/sim/src/main/scala/spinal/sim/GhdlBackend.scala
@@ -97,7 +97,7 @@ class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
     )
   }
 
-  def runSimulation(sharedMemIface: SharedMemIface): Thread = {
+  def runSimulation(sharedMemIface: SharedMemIface, testName: String): Thread = {
     val vpiModulePath =
       if (!isWindows) pluginsPath + "/" + vpiModuleName
       else (pluginsPath + "/" + vpiModuleName).replaceAll("/C", raw"C:").replaceAll(raw"/", raw"\\")

--- a/sim/src/main/scala/spinal/sim/SimVpi.scala
+++ b/sim/src/main/scala/spinal/sim/SimVpi.scala
@@ -8,11 +8,11 @@ import scala.sys._
 
 class VpiException(message: String) extends Exception(message)
 
-class SimVpi(backend: VpiBackend) extends SimRaw {
+class SimVpi(backend: VpiBackend, name: String) extends SimRaw {
 
   val filledByte = 255.toByte
   val zeroByte = 0.toByte
-  val (nativeIface, thread) = backend.instanciate()
+  val (nativeIface, thread) = backend.instanciate(name)
   val handleMap: HashMap[Int, Long] = new HashMap()
   val vectorInt8 = new VectorInt8()
 

--- a/sim/src/main/scala/spinal/sim/VCSBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VCSBackend.scala
@@ -353,7 +353,7 @@ class VCSBackend(config: VCSBackendConfig) extends VpiBackend(config) {
     override def buffer[T](f: => T) = f
   }
 
-  def runSimulation(sharedMemIface: SharedMemIface): Thread = {
+  def runSimulation(sharedMemIface: SharedMemIface, testName: String): Thread = {
     val thread = new Thread(new Runnable {
       val iface = sharedMemIface
       val logger = new LoggerPrintWithTerminationFilter()

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -33,7 +33,7 @@ case class VpiBackendConfig(
   var useCache: Boolean      = false,
   var logSimProcess: Boolean = false,
   var timePrecision: String  = null,
-  var testPath: String       = null,
+  var testPath: String       = null
 )
 
 abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {

--- a/sim/src/main/scala/spinal/sim/VpiBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VpiBackend.scala
@@ -32,7 +32,8 @@ case class VpiBackendConfig(
   var LDFLAGS: String        = "-lpthread ", 
   var useCache: Boolean      = false,
   var logSimProcess: Boolean = false,
-  var timePrecision: String  = null
+  var timePrecision: String  = null,
+  var testPath: String       = null,
 )
 
 abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
@@ -169,9 +170,9 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
 
   def compileVPI() : Unit   // Return the plugin name
   def analyzeRTL() : Unit
-  def runSimulation(sharedMemIface: SharedMemIface) : Thread
+  def runSimulation(sharedMemIface: SharedMemIface, testName: String) : Thread
 
-  def instanciate_() : (SharedMemIface, Thread) = {
+  def instanciate_(name: String) : (SharedMemIface, Thread) = {
     delayed_compilation
     val shmemKey = Seq("SpinalHDL",
       runIface.toString,
@@ -187,19 +188,19 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
     var shmemFile = new PrintWriter(new File(workspacePath + "/shmem_name"))
     shmemFile.write(shmemKey) 
     shmemFile.close
-    val thread = runSimulation(sharedMemIface)
+    val thread = runSimulation(sharedMemIface, name)
     sharedMemIface.check_ready 
     (sharedMemIface, thread)
   }
 
-  def instanciate(seed : Long) : (SharedMemIface, Thread) = {
+  def instanciate(name: String, seed : Long) : (SharedMemIface, Thread) = {
     val ret = if(useCache) {
       VpiBackend.synchronized {
-        instanciate_()
+        instanciate_(name)
       }
     } else {
       this.synchronized {
-        instanciate_()
+        instanciate_(name)
       }
     }
     ret._1.set_seed(seed)
@@ -207,7 +208,7 @@ abstract class VpiBackend(val config: VpiBackendConfig) extends Backend {
     ret
   }
 
-  def instanciate() : (SharedMemIface, Thread) = instanciate(0x5EED5EED)
+  def instanciate(name: String) : (SharedMemIface, Thread) = instanciate(name, 0x5EED5EED)
 }
 
 object VpiBackend {}

--- a/sim/src/test/scala/spinal/sim/Test2.scala
+++ b/sim/src/test/scala/spinal/sim/Test2.scala
@@ -67,7 +67,7 @@ object PlayGhdl extends App{
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
   println(ghdlbackend.print_signals())
   val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
   val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")

--- a/sim/src/test/scala/spinal/sim/TestGhdl.scala
+++ b/sim/src/test/scala/spinal/sim/TestGhdl.scala
@@ -21,7 +21,7 @@ object TestGhdl1 extends App{
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
   println(ghdlbackend.print_signals())
   val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
   val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
@@ -59,7 +59,7 @@ object TestGhdl2 extends App{
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
 
   for(i <- 0l to 2000000000l){
     ghdlbackend.eval
@@ -102,7 +102,7 @@ object TestGhdl3 extends App{
   config.waveFormat = WaveFormat.VCD
 
   val r = new Random()
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
   val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
   val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
   val sum = ghdlbackend.get_signal_handle("adder.sum")
@@ -145,7 +145,7 @@ object TestGhdl4 extends App{
   config.waveFormat = WaveFormat.VCD
 
   val r = new Random()
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
   val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
   val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
   val sum = ghdlbackend.get_signal_handle("adder.sum")
@@ -174,7 +174,7 @@ object TestGhdl5 extends App {
   config.waveFormat = WaveFormat.VCD
 
   val r = new Random()
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
   try {
     val sum = ghdlbackend.get_signal_handle("adder.yolo")
     println(ghdlbackend.read(sum))
@@ -199,7 +199,7 @@ object TestGhdl6 extends App{
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val simVpi = new SimVpi(new GhdlBackend(config))
+  val simVpi = new SimVpi(new GhdlBackend(config), "test")
   val nibble1 = new Signal(Seq("adder","nibble1"), new UIntDataType(4))
   val nibble2 = new Signal(Seq("adder","nibble2"), new UIntDataType(4))
   val sum = new Signal(Seq("adder","sum"), new UIntDataType(4))
@@ -230,7 +230,7 @@ object TestGhdl7 extends App{
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val simVpi = new SimVpi(new GhdlBackend(config))
+  val simVpi = new SimVpi(new GhdlBackend(config), "test")
   val nibble1 = new Signal(Seq("adder","nibble1"), new UIntDataType(4))
   val nibble2 = new Signal(Seq("adder","nibble2"), new UIntDataType(4))
   val sum = new Signal(Seq("adder","sum"), new UIntDataType(4))
@@ -260,7 +260,7 @@ object TestGhdl8 extends App{
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
   println(ghdlbackend.print_signals())
   ghdlbackend.eval
   ghdlbackend.close
@@ -277,7 +277,7 @@ object TestGhdl9 extends App{
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
   val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
   val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
   val sum = ghdlbackend.get_signal_handle("adder.sum")
@@ -302,7 +302,7 @@ object TestGhdl10 extends App {
   config.workspaceName = "yolo"
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.NONE
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
   val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
   val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
   val sum = ghdlbackend.get_signal_handle("adder.sum")
@@ -329,7 +329,7 @@ object TestGhdl11 extends App {
   config.waveFormat = WaveFormat.VCD
   config.useCache = true
 
-  val (ghdlbackend, _) = GhdlBackend.getGCC(config).instanciate()
+  val (ghdlbackend, _) = GhdlBackend.getGCC(config).instanciate("test")
    for(i <- 0l to 1000000l){
     ghdlbackend.randomize(i)
     ghdlbackend.sleep(1)
@@ -349,7 +349,7 @@ object TestGhdl12 extends App {
   config.waveFormat = WaveFormat.VCD
   config.useCache = true
 
-  val (ghdlbackend, _) = GhdlBackend.getLLVM(config).instanciate()
+  val (ghdlbackend, _) = GhdlBackend.getLLVM(config).instanciate("test")
    for(i <- 0l to 1000000l){
     ghdlbackend.randomize(i)
     ghdlbackend.sleep(1)
@@ -370,7 +370,7 @@ object TestGhdl13 extends App {
   config.waveFormat = WaveFormat.VCD
   config.useCache = true
 
-  val (ghdlbackend, _) = GhdlBackend.getMCODE(config).instanciate()
+  val (ghdlbackend, _) = GhdlBackend.getMCODE(config).instanciate("test")
    for(i <- 0l to 1000000l){
     ghdlbackend.randomize(i)
     ghdlbackend.sleep(1)
@@ -390,7 +390,7 @@ object TestGhdl14 extends App{
   config.waveFormat = WaveFormat.VCD
 
   val backendFactory = new GhdlBackend(config)
-  var (ghdlbackend, _) = backendFactory.instanciate()
+  var (ghdlbackend, _) = backendFactory.instanciate("test")
   var nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
   var nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
   var sum = ghdlbackend.get_signal_handle("adder.sum")
@@ -401,7 +401,7 @@ object TestGhdl14 extends App{
   ghdlbackend.close
 
   config.wavePath = "test2.vcd"
-  val (ghdlbackend2, _) = backendFactory.instanciate()
+  val (ghdlbackend2, _) = backendFactory.instanciate("test")
   nibble1 = ghdlbackend2.get_signal_handle("adder.nibble1")
   nibble2 = ghdlbackend2.get_signal_handle("adder.nibble2")
   sum = ghdlbackend2.get_signal_handle("adder.sum")
@@ -412,7 +412,7 @@ object TestGhdl14 extends App{
   ghdlbackend2.close
 
   config.wavePath = "test3.vcd"
-  val (ghdlbackend3, _) = backendFactory.instanciate()
+  val (ghdlbackend3, _) = backendFactory.instanciate("test")
   nibble1 = ghdlbackend3.get_signal_handle("adder.nibble1")
   nibble2 = ghdlbackend3.get_signal_handle("adder.nibble2")
   sum = ghdlbackend3.get_signal_handle("adder.sum")
@@ -439,7 +439,7 @@ object TestGhdl15 extends App{
   val backendFactory = new GhdlBackend(config)
   val runningSims = (0 to 7).map { i =>
     Future {
-    val (ghdlbackend, _) = backendFactory.instanciate()
+    val (ghdlbackend, _) = backendFactory.instanciate("test")
       val nibble1 = ghdlbackend.get_signal_handle("adder.nibble1")
       val nibble2 = ghdlbackend.get_signal_handle("adder.nibble2")
       val sum = ghdlbackend.get_signal_handle("adder.sum")
@@ -474,7 +474,7 @@ object TestGhdl16 extends App{
   val backendFactory = new GhdlBackend(config)
  
   val ghdlbackends = (0 to 7).map { i =>
-    val (ghdlbend, _) = backendFactory.instanciate()
+    val (ghdlbend, _) = backendFactory.instanciate("test")
     ghdlbend
   }.toArray
 
@@ -524,7 +524,7 @@ object TestGhdl17 extends App{
   val backendFactory = new GhdlBackend(config)
 
   val ghdlbackends = (0 to 7).map { i =>
-    val (ghdlbend, _) = backendFactory.instanciate()
+    val (ghdlbend, _) = backendFactory.instanciate("test")
     ghdlbend
   }.toArray
  
@@ -569,7 +569,7 @@ object TestGhdl18 extends App{
   config.wavePath = "test3.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val (ghdlbackend, _) = new GhdlBackend(config).instanciate()
+  val (ghdlbackend, _) = new GhdlBackend(config).instanciate("test")
   val native_in = ghdlbackend.get_signal_handle("SpinalSimVerilatorIoTestTop.nativeEncoding_stateInput")
   val native_out = ghdlbackend.get_signal_handle("SpinalSimVerilatorIoTestTop.nativeEncoding_stateOutput")
   val native_decoded = ghdlbackend.get_signal_handle("SpinalSimVerilatorIoTestTop.nativeEncoding_stateDecoded")

--- a/sim/src/test/scala/spinal/sim/TestIVerilog.scala
+++ b/sim/src/test/scala/spinal/sim/TestIVerilog.scala
@@ -21,7 +21,7 @@ object TestIVerilog1 extends App{
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val (iverilogbackend, _) = new IVerilogBackend(config).instanciate()
+  val (iverilogbackend, _) = new IVerilogBackend(config).instanciate("test")
   val clk = iverilogbackend.get_signal_handle("TestMemIVerilog.clk")
   val reset = iverilogbackend.get_signal_handle("TestMemIVerilog.reset")
   val addr = iverilogbackend.get_signal_handle("TestMemIVerilog.io_addr")
@@ -62,7 +62,7 @@ object TestIVerilog2 extends App{
   config.wavePath = "test.vcd"
   config.waveFormat = WaveFormat.VCD
 
-  val (iverilogbackend, _) = new IVerilogBackend(config).instanciate()
+  val (iverilogbackend, _) = new IVerilogBackend(config).instanciate("test")
   val clk = iverilogbackend.get_signal_handle("TestMemIVerilog.clk")
   val reset = iverilogbackend.get_signal_handle("TestMemIVerilog.reset")
   val addr = iverilogbackend.get_signal_handle("TestMemIVerilog.io_addr")

--- a/sim/src/test/scala/spinal/sim/TestVCS.scala
+++ b/sim/src/test/scala/spinal/sim/TestVCS.scala
@@ -26,7 +26,7 @@ object TestVCS1 extends App{
 //  config.vcsCC = Some("gcc-4.4")
 //  config.vcsLd = Some("g++-4.4")
 
-  val (vcsBackend, _) = new VCSBackend(config).instanciate()
+  val (vcsBackend, _) = new VCSBackend(config).instanciate("test")
   println(vcsBackend.print_signals())
   val nibble1 = vcsBackend.get_signal_handle("adder.nibble1")
   val nibble2 = vcsBackend.get_signal_handle("adder.nibble2")

--- a/tester/src/test/scala/spinal/core/SpinalSimWaveLocationTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimWaveLocationTester.scala
@@ -1,0 +1,41 @@
+package spinal.core
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core.sim._
+import spinal.tester.SpinalSimTester
+
+import java.io.File
+import java.nio.file.Paths
+
+// Checks whether the simulators included in SpinalSimTester (at time
+// of this writing, December 2024: GHDL, IVerilog, Verilator) all
+// put their wave files in the per-test location expected.
+class SpinalSimWaveLocationTester extends AnyFunSuite {
+  class Comp extends Component {
+    val input = in(UInt(6 bits))
+    val output = out(UInt(6 bits)).setAsReg()
+    output := output + input
+  }
+
+  SpinalSimTester { env =>
+    println(f"env: ${env}")
+    val compiled = env.SimConfig.withVcdWave.compile(new Comp())
+
+    for (testName <- Seq("test1", "test2")) {
+      var testPath: String = null
+
+      compiled.doSim(testName) { dut =>
+        testPath = currentTestPath()
+        dut.clockDomain.forkStimulus(10)
+        dut.input #= 5
+        dut.clockDomain.waitSampling(10)
+        simSuccess()
+      }
+
+      val expWavePath = Paths.get(testPath, "wave.vcd").toString
+      if (!new File(expWavePath).isFile) {
+        fail(f"expected wave file to be at '${expWavePath}' but did not find it")
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Partial resolution to #1605, at least for IVerilog and GHDL backends.

# Context, Motivation & Description

Verilator backed simulation runs put their wavefiles into a per-test directory. This PR adapts the IVerilog and GHDL backends to follow this pattern as well.

This is my first SpinalHDL PR, so please bear with me :upside_down_face: I'm happy to incorporate feedback.

For instance, I'm unsure whether the route chosen is OK. Also I've modified some tests along the way (e.g. `TestIVerlilog.scala`) - I discovered these through compile errors (maybe on some test command?) but I can't figure out how to run those.

Also I lack the means to to extend this implementation to e.g. the VCS backend as I can't test it.

# Impact on code generation

None on the RTL code, a small impact (reading the wave file name from a $plus arg in the IVerilog simulation file) on simulation.

# Checklist

- [x] Unit tests were added (check that The Big Three Simulators put wavefiles in expected location)

