### PR TITLE
Apb3.m2sPipe() test and fix

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba3/apb/APB3.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/apb/APB3.scala
@@ -86,15 +86,13 @@ case class Apb3(config: Apb3Config) extends Bundle with IMasterSlave {
 
   def m2sPipe(): Apb3 ={
     val that = Apb3(config)
-    // The first PENABLE of a transaction needs to be delayed by one clock cycle in any case.
-    val penableDelay = RegInit(True) clearWhen (this.PSEL.orR) setWhen (this.PENABLE && this.PREADY)
-    that.PADDR    := RegNext(this.PADDR  )
-    that.PWRITE   := RegNext(this.PWRITE )
-    that.PWDATA   := RegNext(this.PWDATA )
-    that.PSEL     := RegNext(this.PREADY ? B(0) | this.PSEL)
-    that.PENABLE  := RegNext(this.PENABLE && !this.PREADY && !penableDelay)
+    that.PADDR    := RegNext(this.PADDR)
+    that.PWRITE   := RegNext(this.PWRITE)
+    that.PWDATA   := RegNext(this.PWDATA)
+    that.PSEL     := RegNext(this.PSEL.andMask(!this.PREADY)).init(0)
+    that.PENABLE  := RegNext(this.PENABLE)
     this.PRDATA   := that.PRDATA
-    this.PREADY   := that.PREADY && that.PENABLE
+    this.PREADY   := that.PREADY && that.PENABLE && that.PSEL.orR
     if(PSLVERROR != null) { this.PSLVERROR := that.PSLVERROR }
     that
   }

--- a/lib/src/main/scala/spinal/lib/bus/amba3/apb/APB3.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/apb/APB3.scala
@@ -84,14 +84,15 @@ case class Apb3(config: Apb3Config) extends Bundle with IMasterSlave {
     }
   }
 
-  // !! no tested !!
   def m2sPipe(): Apb3 ={
     val that = Apb3(config)
+    // The first PENABLE of a transaction needs to be delayed by one clock cycle in any case.
+    val penableDelay = RegInit(True) clearWhen (this.PSEL.orR) setWhen (this.PENABLE && this.PREADY)
     that.PADDR    := RegNext(this.PADDR  )
     that.PWRITE   := RegNext(this.PWRITE )
     that.PWDATA   := RegNext(this.PWDATA )
     that.PSEL     := RegNext(this.PREADY ? B(0) | this.PSEL)
-    that.PENABLE  := RegNext(this.PENABLE && !this.PREADY)
+    that.PENABLE  := RegNext(this.PENABLE && !this.PREADY && !penableDelay)
     this.PRDATA   := that.PRDATA
     this.PREADY   := that.PREADY && that.PENABLE
     if(PSLVERROR != null) { this.PSLVERROR := that.PSLVERROR }

--- a/tester/src/test/scala/spinal/core/Apb3ConnectionTester.scala
+++ b/tester/src/test/scala/spinal/core/Apb3ConnectionTester.scala
@@ -1,0 +1,95 @@
+package spinal.core
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core.sim._
+import spinal.lib.bus.amba3.apb.Apb3
+import spinal.lib.{master, slave}
+
+class Apb3ConnectionTester extends AnyFunSuite {
+  class APB3Stage extends Component {
+    val input = slave(Apb3(12, 8))
+    val output = master(Apb3(12, 8))
+
+    input.m2sPipe() >> output
+  }
+
+  def readRequest(cd: ClockDomain, bus: Apb3, addr: Long): Long = {
+    bus.PSEL #= 1
+    bus.PENABLE #= false
+    bus.PADDR #= addr
+    bus.PWRITE #= false
+    cd.waitSampling()
+    do {
+      bus.PENABLE #= true
+      cd.waitSampling()
+    } while (!bus.PREADY.toBoolean)
+    bus.PSEL #= 0
+    bus.PRDATA.toLong
+  }
+
+  def serveRead(cd: ClockDomain, bus: Apb3, addr: Long, reply: Long): Unit = {
+    cd.waitSamplingWhere(bus.PSEL.toInt != 0)
+    assert(!bus.PENABLE.toBoolean)
+    bus.PRDATA #= reply
+    bus.PREADY #= true
+
+    cd.waitSampling()
+    assert(bus.PENABLE.toBoolean && bus.PSEL.toInt != 0)
+    assert(bus.PADDR.toLong == addr)
+  }
+
+  def doRead(dut: APB3Stage, addr: Long, reply: Long): Unit = {
+    fork {
+      serveRead(dut.clockDomain, dut.output, addr, reply)
+    }
+    assert(readRequest(dut.clockDomain, dut.input, addr) == reply)
+  }
+
+  test("apb3stage") {
+    val compiled = SpinalSimConfig().withWave.compile(new APB3Stage)
+    compiled.doSim("apb3stage") { dut =>
+      val cd = dut.clockDomain
+      cd.forkStimulus(10)
+      dut.input.PSEL #= 0
+      dut.output.PREADY #= false
+
+      cd.waitSampling()
+      doRead(dut, 0x100, 0xfe)
+
+      cd.waitSampling(10)
+      doRead(dut, 0x78, 0xff)
+      dut.input.PENABLE #= false
+      dut.output.PREADY #= true  // hold PREADY into next test case (this should be OK because all-hi PREADY is)
+
+      cd.waitSampling(10)
+      doRead(dut, 0x12, 0xac)
+      dut.output.PREADY #= false  // do not hold PREADY high any more
+      dut.output.PENABLE #= true  // but set PENABLE high (this should be valid outside of PSEL)
+
+      cd.waitSampling(10)
+      doRead(dut, 0x50, 0x13)
+      dut.output.PREADY #= true   // now hold both signals high
+      dut.output.PENABLE #= true  // this should also be allowed
+
+      // The following two waits are a regression test. With both PREADY and PENABLE high
+      // the output PENABLE starts oscillating at f/2. By trying both an even and an odd
+      // waiting time we are guaranteed to hit it both phases once.
+      cd.waitSampling(10)
+      doRead(dut, 0x25, 0x26)
+      dut.output.PREADY #= true   // now hold both signals high
+      dut.output.PENABLE #= true  // this should also be allowed
+
+      cd.waitSampling(11)
+      doRead(dut, 0x30, 0x3f)
+      dut.output.PREADY #= true   // now hold both signals high
+      dut.output.PENABLE #= true  // this should also be allowed
+
+      doRead(dut, 0x31, 0x41)
+      doRead(dut, 0x32, 0x42)
+
+      cd.waitSampling(10)
+
+      simSuccess()
+    }
+  }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

I noticed that `Apb3.m2sPipe()` would have an oscillating `PENABLE` signal at its output if the input `PREADY` and `PENABLE` signals are both asserted outside of a transaction. I believe the enable and ready signals may both always be asserted outside of PSEL. If an input transaction arrives at the time the output `PENABLE` is asserted, the bus transfer will be malformed as it has no setup phase on the output side.

I added a test that reproduces the issue. Then I added a fix to `Apb3.m2sPipe()`. I also took the liberty of removing the "not tested" comment there.

# Impact on code generation

None, change is in library code.

# Checklist

- [x] Unit tests were added