### PR TITLE
remove always false logic for Mem.streamReadSync

### DIFF
--- a/lib/src/main/scala/spinal/lib/Mem.scala
+++ b/lib/src/main/scala/spinal/lib/Mem.scala
@@ -48,9 +48,6 @@ class MemPimped[T <: Data](mem: Mem[T]) {
     val retValid = RegInit(False)
     val retData = mem.readSync(cmd.payload, cmd.fire, clockCrossing = crossClock)
 
-    when(ret.ready) {
-      retValid := Bool(false)
-    }
     when(cmd.ready) {
       retValid := cmd.valid
     }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->



# Context, Motivation & Description
Condition ret.ready of retValid for Mem.streamReadSync is redundant.
<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
Generated RTL code will remove always false logic for retValid, which could avoids uncovered branch issue.
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

None
