### PR TITLE
Add another auxiliary constructor for StreamDemux

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -980,6 +980,10 @@ object StreamDemux{
     (demux(0).combStage(), demux(1).combStage())
   }
   def two[T <: Data](input: Stream[T], select : Bool) : (Stream[T], Stream[T]) = two(input, select.asUInt)
+  def two[T <: Data](input: Stream[T], select : Stream[UInt]) : (Stream[T], Stream[T]) = {
+    val demux = joinSel(input, select, 2)
+    (demux(0).combStage(), demux(1).combStage())
+  }
 }
 
 class StreamDemux[T <: Data](dataType: T, portCount: Int) extends Component {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->


# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

Add one more method `two` for StreamDemux, which could demux input stream by another input stream. 

# Impact on code generation
None
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

