### PR TITLE
[RegIf] Fix the "BusInterface" and add a new function to change the default error state

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/BusInterface.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/BusInterface.scala
@@ -38,7 +38,7 @@ object BusInterface {
 
   def apply(bus: AxiLite4, sizeMap: SizeMapping)(implicit moduleName: ClassName): BusIf = AxiLite4BusInterface(bus, sizeMap)(moduleName)
   def apply(bus: AxiLite4, sizeMap: SizeMapping, regPre: String)(implicit moduleName: ClassName): BusIf = AxiLite4BusInterface(bus, sizeMap, regPre)(moduleName)
-  def apply(bus: AxiLite4, sizeMap: SizeMapping, regPre: String, withSecFireWall: Boolean)(implicit moduleName: ClassName): BusIf = AxiLite4BusInterface(bus, sizeMap, regPre)(moduleName)
+  def apply(bus: AxiLite4, sizeMap: SizeMapping, regPre: String, withSecFireWall: Boolean)(implicit moduleName: ClassName): BusIf = AxiLite4BusInterface(bus, sizeMap, regPre, withSecFireWall)(moduleName)
 
   def apply(bus: BRAM, sizeMap: SizeMapping)(implicit moduleName: ClassName): BusIf = BRAMBusInterface(bus, sizeMap)(moduleName)
   def apply(bus: BRAM, sizeMap: SizeMapping, regPre: String)(implicit moduleName: ClassName): BusIf = BRAMBusInterface(bus, sizeMap, regPre)(moduleName)

--- a/tester/src/test/scala/spinal/lib/bus/regif/RegIfBasicAccessTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/regif/RegIfBasicAccessTester.scala
@@ -30,4 +30,5 @@ class RegIfGenRtl extends SpinalAnyFunSuite{
   test("gen_regifgrptester"){RegIfGrpTesterMain.main(Array())}
   test("gen_regifsecure")   {playregifsec.main(Array())}
   test("gen_regifreuse")    {RegIfReuseBlockTesterMain.main(Array())}
+  test("gen_regifdefaulterr"){playregifDefaultError.main(Array())}
 }

--- a/tester/src/test/scala/spinal/lib/bus/regif/RegIfDefaultErrorStateTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/regif/RegIfDefaultErrorStateTester.scala
@@ -1,0 +1,29 @@
+package spinal.lib.bus.regif
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.amba4.axilite.{AxiLite4, AxiLite4Config}
+
+/*
+  Test the default error state
+ */
+class RegIfDefaultErrorStateTester(defaultError: Boolean) extends Component{
+  val io = new Bundle{
+    val axilite4 = slave(AxiLite4(AxiLite4Config(16,32)))
+    val wProtect = in Bool()
+    val rProtect = in Bool()
+  }
+  val busif = BusInterface(io.axilite4,(0x000,4 KiB), regPre = "TestBusif", withSecFireWall = true)
+  busif.setReservedAddressErrorState(defaultError)
+  val testGroup = busif.newGrp(64,"Test secure Group",Secure.CS(io.wProtect,io.rProtect))
+  val REG0 = testGroup.newReg("Reg0")
+  val reg0_field = REG0.field(Bits(32 bit), AccessType.RW, 0x00, doc = "test")
+  val REG1 = testGroup.newReg("Reg1")
+  val reg1_field = REG1.field(Bits(32 bit), AccessType.RW, 0x00, doc = "test")
+}
+
+object playregifDefaultError extends App {
+  val rde = SpinalConfig().copy(targetDirectory = "./out/regifEst", removePruned = true, headerWithDate = true)
+  rde.generateVerilog(new RegIfDefaultErrorStateTester(false).setDefinitionName("RIDES_false"))
+  rde.generateVerilog(new RegIfDefaultErrorStateTester(true).setDefinitionName("RIDES_true"))
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->
#1636 
# Context, Motivation & Description

**BugFix**:

The implementation of "BusInterface" associated with "AxiLite4BusInterface" is incomplete.

https://github.com/SpinalHDL/SpinalHDL/blob/04bb74bc81a540798621e9fbf4e56fe512f0a015/lib/src/main/scala/spinal/lib/bus/regif/BusInterface.scala#L41

**Add Function**:

The default error bits for accessing reserved addresses can be modified now.

You can use this function to change it.

https://github.com/HaroldZ32/SpinalHDL/blob/c483e9d508902ec92c9852677a68e37d9aceabf2/lib/src/main/scala/spinal/lib/bus/regif/BusIf.scala#L80

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

- BusInterface can now generate a AxiLite4Interface with SecFireWall.
- If the accessDefaultError has been set, the error signal when the master hit the reserved address would be set.

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented
