### PR TITLE
Add convenience properties and overloads to CounterUpDown

### DIFF
--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -712,8 +712,9 @@ object MajorityVote {
 
 object CounterUpDown {
   def apply(stateCount: BigInt): CounterUpDown = new CounterUpDown(stateCount)
-  def apply(stateCount: BigInt, incWhen: Bool,decWhen : Bool): CounterUpDown = {
-    val counter = CounterUpDown(stateCount)
+  def apply(stateCount: BigInt, incWhen: Bool,decWhen : Bool): CounterUpDown = apply(stateCount, incWhen, decWhen, handleOverflow = true)
+  def apply(stateCount: BigInt, incWhen: Bool,decWhen : Bool, handleOverflow : Boolean): CounterUpDown = {
+    val counter = new CounterUpDown(stateCount, handleOverflow = handleOverflow)
     when(incWhen) {
       counter.increment()
     }
@@ -739,8 +740,14 @@ class CounterUpDown(val stateCount: BigInt, val handleOverflow : Boolean = true)
   val valueNext = UInt(log2Up(stateCount) bit)
   val value = RegNext(valueNext) init(0)
   val mayOverflow = value === stateCount - 1
+
+  val mayUnderflow = value === 0
+
   val willOverflowIfInc = mayOverflow && !decrementIt
   val willOverflow = willOverflowIfInc && incrementIt
+
+  val willUnderflowIfDec = mayUnderflow && !incrementIt
+  val willUnderflow = willUnderflowIfDec && decrementIt
 
   val finalIncrement = UInt(log2Up(stateCount) bit)
   when(incrementIt && !decrementIt){


### PR DESCRIPTION
Split from #1637 

- Adds underflow check properties to CounterUpDown in the same style of the overflow ones.
- Adds `apply` overload to allow for slightly less verbose instantiation when handleOverflow is false. 

# Impact on code generation

No impact on code generation

# Checklist

It seemed small enough to not need unit tests but I can add if wanted. 
