### PR TITLE
Mem read buffer bb

### DIFF
--- a/core/src/main/scala/spinal/core/Mem.scala
+++ b/core/src/main/scala/spinal/core/Mem.scala
@@ -113,7 +113,7 @@ class MemWritePayload[T <: Data](dataType: T, addressWidth: Int) extends Bundle 
 
 object AllowPartialyAssignedTag extends SpinalTag
 object AllowMixedWidth extends SpinalTag
-trait MemPortStatement extends LeafStatement with StatementDoubleLinkedContainerElement[Mem[_], MemPortStatement] with Nameable {
+trait MemPortStatement extends LeafStatement with StatementDoubleLinkedContainerElement[Mem[_], MemPortStatement] with Nameable with SpinalTagReady {
   var isVital = false
   var mem: Mem[_] = null
 }
@@ -528,7 +528,7 @@ object MemReadAsync{
 }
 
 
-class MemReadAsync extends MemPortStatement with WidthProvider with SpinalTagReady with ContextUser with Expression{
+class MemReadAsync extends MemPortStatement with WidthProvider  with ContextUser with Expression{
 
   override def getWidth: Int = width
 
@@ -601,7 +601,7 @@ object MemReadSync{
 }
 
 
-class MemReadSync() extends MemPortStatement with WidthProvider with SpinalTagReady with ContextUser with Expression {
+class MemReadSync() extends MemPortStatement with WidthProvider with ContextUser with Expression {
 
   var width          : Int = -1
   var address        : Expression with WidthProvider = null
@@ -686,7 +686,7 @@ object MemWrite{
   }
 }
 
-class MemWrite() extends MemPortStatement with WidthProvider with SpinalTagReady {
+class MemWrite() extends MemPortStatement with WidthProvider{
   var width       : Int = -1
   var address     : Expression with WidthProvider = null
   var data        : Expression with WidthProvider = null
@@ -785,7 +785,7 @@ object MemReadWrite {
 }
 
 
-class MemReadWrite() extends MemPortStatement with WidthProvider with SpinalTagReady  with ContextUser with Expression{
+class MemReadWrite() extends MemPortStatement with WidthProvider with ContextUser with Expression{
   var width        : Int = -1
   var address      : Expression with WidthProvider = null
   var data         : Expression with WidthProvider = null

--- a/core/src/main/scala/spinal/core/MemBlackBox.scala
+++ b/core/src/main/scala/spinal/core/MemBlackBox.scala
@@ -92,7 +92,8 @@ class Ram_1w_1rs(
 
   val rdClock        : ClockDomain,
   val rdAddressWidth : Int,
-  val rdDataWidth    : Int
+  val rdDataWidth    : Int,
+  val rdLatency      : Int = 1
 ) extends BlackBox {
 
   addGenerics(
@@ -106,7 +107,8 @@ class Ram_1w_1rs(
     "wrMaskWidth"    -> Ram_1w_1rs.this.wrMaskWidth,
     "wrMaskEnable"   -> Ram_1w_1rs.this.wrMaskEnable,
     "rdAddressWidth" -> Ram_1w_1rs.this.rdAddressWidth,
-    "rdDataWidth"    -> Ram_1w_1rs.this.rdDataWidth
+    "rdDataWidth"    -> Ram_1w_1rs.this.rdDataWidth,
+    "rdLatency"      -> Ram_1w_1rs.this.rdLatency
   )
 
 
@@ -120,10 +122,11 @@ class Ram_1w_1rs(
     }
 
     val rd = new Bundle {
-      val clk  = in Bool()
-      val en   = in Bool()
-      val addr = in  UInt(rdAddressWidth bit)
-      val data = out Bits(rdDataWidth bit)
+      val clk    = in Bool()
+      val en     = in Bool()
+      val addr   = in  UInt(rdAddressWidth bit)
+      val dataEn = in Bool() default(True) //Only used if rdLatency > 1
+      val data   = out Bits(rdDataWidth bit)
     }
   }
 

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -943,7 +943,15 @@ class MemReadBufferPhase extends PhaseNetlist {
           val tags = port.getTags().collect { case e: MemReadBufferTag => e }
           if (tags.nonEmpty) {
             val enableScope = tags.head.enableScope
-            if (tags.exists(_.enableScope != enableScope)) {
+            val ok = tags.forall { self =>
+              if(self.enableScope == enableScope) true
+              else (enableScope.parentStatement, self.enableScope.parentStatement) match {
+                case (refWhen : WhenStatement, selfWhen : WhenStatement) =>
+                  refWhen.cond == selfWhen.cond
+                case _ => false
+              }
+            }
+            if (!ok) {
               clean(port)
             }
           }

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -906,7 +906,7 @@ class MemReadBufferPhase extends PhaseNetlist {
           case e: Cast => walkExp(e.input, e :: through)
           case e: BitsRangedAccessFixed => walkExp(e.source, e :: through)
           case bt: BaseType if bt.isComb && bt.hasOnlyOneStatement => walkStm(bt.head, bt :: through)
-          case rs: MemReadSync if reg.component == rs.component => {
+          case rs: MemReadSync if reg.component == rs.component && reg.clockDomain == rs.clockDomain => {
 //            println(s"hit $rs through ${through.map(e => "- " + e).mkString("\n")}")
             val hitId = portsHits.size
             portsHits += rs

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -878,6 +878,82 @@ abstract class PhaseMemBlackBoxingWithPolicy(policy: MemBlackboxingPolicy) exten
   def doBlackboxing(memTopology: MemTopology) : String
 }
 
+case class MemReadBufferTag(reg: BaseType, rs: MemPortStatement, through: List[BaseNode]) extends SpinalTag{
+  val enableScope = reg.head.parentScope
+  def enableCraft = {
+    reg.head.parentScope.on{
+      ConditionalContext.isTrue(reg.parentScope)
+    }
+  }
+}
+
+class MemReadBufferPhase extends PhaseNetlist {
+  override def impl(pc: PhaseContext): Unit = {
+    val algo = pc.globalData.allocateAlgoIncrementale()
+    val portsHits = ArrayBuffer[MemPortStatement]()
+    pc.walkDeclarations {
+      case reg: BaseType if reg.isReg && !reg.hasInit && reg.hasOnlyOneStatement && reg.isDirectionLess => {
+        def walkStm(s: LeafStatement, through: List[BaseNode]): Unit = s match {
+          case s: DataAssignmentStatement if s.target.isInstanceOf[BaseType] =>
+            val target = s.target.asInstanceOf[BaseType]
+            if (through == Nil || s.parentScope == target.parentScope) {
+              walkExp(s.source, s :: through)
+            }
+          case _ =>
+        }
+
+        def walkExp(e: Expression, through: List[BaseNode]): Unit = e match {
+          case e: Cast => walkExp(e.input, e :: through)
+          case e: BitsRangedAccessFixed => walkExp(e.source, e :: through)
+          case bt: BaseType if bt.isComb && bt.hasOnlyOneStatement => walkStm(bt.head, bt :: through)
+          case rs: MemReadSync if reg.component == rs.component => {
+//            println(s"hit $rs through ${through.map(e => "- " + e).mkString("\n")}")
+            val hitId = portsHits.size
+            portsHits += rs
+            rs.addTag(new MemReadBufferTag(reg, rs, through))
+            through.foreach { bn =>
+              bn.algoIncrementale = algo
+              bn.algoInt = hitId
+            }
+          }
+          case _ =>
+        }
+
+        walkStm(reg.head.asInstanceOf[DataAssignmentStatement], Nil)
+      }
+      case _ =>
+    }
+
+    def clean(port: MemPortStatement): Unit = {
+      port.removeTags(port.getTags().filter(_.isInstanceOf[MemReadBufferTag]))
+    }
+
+    pc.walkStatements { s =>
+      if (s.algoIncrementale != algo) {
+        s.walkDrivingExpressions { e =>
+          if (e.algoIncrementale == algo) {
+//            println("Remove it")
+            val port = portsHits(e.algoInt)
+            clean(port)
+          }
+        }
+      }
+      s match {
+        case port: MemPortStatement => {
+          val tags = port.getTags().collect { case e: MemReadBufferTag => e }
+          if (tags.nonEmpty) {
+            val enableScope = tags.head.enableScope
+            if (tags.exists(_.enableScope != enableScope)) {
+              clean(port)
+            }
+          }
+        }
+        case _ =>
+      }
+    }
+  }
+}
+
 class MemBlackboxOf(val mem : Mem[Data]) extends SpinalTag
 class PhaseMemBlackBoxingDefault(policy: MemBlackboxingPolicy) extends PhaseMemBlackBoxingWithPolicy(policy){
   def doBlackboxing(topo: MemTopology): String = {
@@ -940,6 +1016,7 @@ class PhaseMemBlackBoxingDefault(policy: MemBlackboxingPolicy) extends PhaseMemB
         }
 
         for (rd <- topo.readsSync) {
+          val twoLatTags = rd.getTags().collect{case e : MemReadBufferTag => e }
           val ram = new Ram_1w_1rs(
             wordWidth = mem.getWidth,
             wordCount = mem.wordCount,
@@ -949,6 +1026,7 @@ class PhaseMemBlackBoxingDefault(policy: MemBlackboxingPolicy) extends PhaseMemB
             wrDataWidth = wr.data.getWidth,
             rdAddressWidth = rd.getAddressWidth,
             rdDataWidth = rd.getWidth,
+            rdLatency = twoLatTags.nonEmpty.mux(2, 1),
             wrMaskWidth = if (wr.mask != null) wr.mask.getWidth else 1,
             wrMaskEnable = wr.mask != null,
             readUnderWrite = rd.readUnderWrite,
@@ -967,7 +1045,38 @@ class PhaseMemBlackBoxingDefault(policy: MemBlackboxingPolicy) extends PhaseMemB
 
           ram.io.rd.en := wrapBool(rd.readEnable) && rd.clockDomain.isClockEnableActive
           ram.io.rd.addr.assignFrom(rd.address)
-          wrapConsumers(rd, ram.io.rd.data)
+          if(twoLatTags.isEmpty) {
+            wrapConsumers(rd, ram.io.rd.data)
+          } else {
+            ram.io.rd.dataEn := twoLatTags.head.enableCraft
+            for(t <- twoLatTags){
+              t.through.foreach{
+                case bt: BaseType if bt.parentScope != null => {
+                  bt.removeAssignments()
+                  bt.removeStatement()
+                }
+                case _ =>
+              }
+              t.reg.removeAssignments()
+              t.reg.setAsComb()
+//              t.reg.clearAll()
+              var ptrOld : Expression = rd
+              var ptrNew : Expression  = ram.io.rd.data
+              t.through.foreach{
+                case e : BaseType => ptrOld = e
+                case e : Expression => {
+                  e.remapDrivingExpressions{
+                    case x if x == ptrOld => ptrNew
+                    case x => x
+                  }
+                  ptrOld = e
+                  ptrNew = e
+                }
+                case _ =>
+              }
+              t.reg.assignFrom(ptrNew)
+            }
+          }
 
           ram.setName(mem.getName())
         }

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -892,7 +892,7 @@ class MemReadBufferPhase extends PhaseNetlist {
     val algo = pc.globalData.allocateAlgoIncrementale()
     val portsHits = ArrayBuffer[MemPortStatement]()
     pc.walkDeclarations {
-      case reg: BaseType if reg.isReg && !reg.hasInit && reg.hasOnlyOneStatement && reg.isDirectionLess => {
+      case reg: BaseType if reg.isReg && !reg.hasInit && reg.hasOnlyOneStatement => {
         def walkStm(s: LeafStatement, through: List[BaseNode]): Unit = s match {
           case s: DataAssignmentStatement if s.target.isInstanceOf[BaseType] =>
             val target = s.target.asInstanceOf[BaseType]

--- a/core/src/main/scala/spinal/core/internals/Statement.scala
+++ b/core/src/main/scala/spinal/core/internals/Statement.scala
@@ -61,10 +61,11 @@ class ScopeStatement(var parentStatement: TreeStatement) {
 
   def push() = DslScopeStack.set(this)
 
-  def on(body : => Unit): Unit = {
+  def on[T](body : => T): T = {
     val ctx = push()
-    body
+    val ret = body
     ctx.restore()
+    ret
   }
 
   //Execute body on the head of the ScopeStatement list


### PR DESCRIPTION
Allows RegNext(mem.readSync(xxx)) to be infered as a blackbox with 2 cycle latency ram read : 

For instance : 
```
object PlayMemSync3 extends App{
  val config = SpinalConfig()
  config.addTransformationPhase(new MemReadBufferPhase)
  config.addStandardMemBlackboxing(blackboxAllWhatsYouCan)
  config.generateVerilog(new Component{
    val dataType = HardType(Rgb(5,6,5))
    val ram = Mem.fill(256)(dataType)
    val write = ram.writePort().asSlave
    val addr = in(ram.addressType)
    val readed = ram.readSync(addr)
    val miaou = dataType()
    miaou := readed
    val condA = in Bool()
    val buffer = RegNextWhen(miaou, condA)
    val result = out(CombInit(buffer))
  })
}
```