### PR TITLE
Add areas list to component and populate it as areas are created.

### DIFF
--- a/core/src/main/scala/spinal/core/Area.scala
+++ b/core/src/main/scala/spinal/core/Area.scala
@@ -67,6 +67,13 @@ trait Area extends NameableByComponent with ContextUser with OwnableRef with Sca
     oldContext.restore()
     b
   }
+
+  /** Get the parent component (null if there is no parent)*/
+  private[core] def parentComponent: Component = if(parentScope != null) parentScope.component else null
+  if (parentComponent != null) {
+    parentComponent.areas += this
+  }
+
   override private[core] def getComponent() = component
 
   override def valCallbackRec(obj: Any, name: String): Unit = {

--- a/core/src/main/scala/spinal/core/Component.scala
+++ b/core/src/main/scala/spinal/core/Component.scala
@@ -138,6 +138,10 @@ abstract class Component extends NameableByComponent with ContextUser with Scala
   }
 
   val areas = ArrayBuffer[Area]()
+  def walkAreas(body : Area => Unit) : Unit = {
+    areas.foreach(_.walkAreas(body))
+    children.foreach(_.walkAreas(body))
+  }
 
   var traceEnabled = true
 

--- a/core/src/main/scala/spinal/core/Component.scala
+++ b/core/src/main/scala/spinal/core/Component.scala
@@ -137,6 +137,8 @@ abstract class Component extends NameableByComponent with ContextUser with Scala
     children.foreach(_.walkComponents(body))
   }
 
+  val areas = ArrayBuffer[Area]()
+
   var traceEnabled = true
 
   def traceDisable(recursive : Boolean = true) : this.type = {


### PR DESCRIPTION
Related to #1637 

It'd be useful in some scenarios such as the related PR to be able to iterate over a components areas even if the handle for them isn't immediately available in the owning component; much in the same way that this is done for components. This adds that feature.

# Impact on code generation

None

# Checklist

- [ ] Unit tests were added - No new tests -- unclear if any are needed for this
- [ ] API changes are or will be documented -- I can annotate the areas field if wanted but it seems self explanatory in the context where it lives. 
