### PR TITLE
Improved scala doc

### DIFF
--- a/core/src/main/scala/spinal/core/Area.scala
+++ b/core/src/main/scala/spinal/core/Area.scala
@@ -25,22 +25,6 @@ import spinal.core.internals.Misc
 import spinal.idslplugin.PostInitCallback
 
 
-
-
-
-/**
-  * Sometime, creating a Component to define some logic is overkill.
-  * For this kind of cases you can use Area to define a group of signals/logic.
-  *
-  * @example {{{
-  *     val tickConter = new Area{
-  *       val tick = Reg(UInt(8 bits) init(0)
-  *       tick := tick + 1
-  *     }
-  * }}}
-  *  @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/area/ Area Documentation]]
-  */
-
 class Composite[T <: Nameable](val self : T, postfix : String = null, weak : Boolean = true) extends Area{
   override def childNamePriority = Nameable.USER_WEAK
   if(postfix == null) {
@@ -50,6 +34,18 @@ class Composite[T <: Nameable](val self : T, postfix : String = null, weak : Boo
   }
 }
 
+
+/** Sometime, creating a `Component` to define some logic is overkill.
+  * For this kind of cases you can use `Area` to define a group of signals/logic.
+  *
+  * @example {{{
+  *     val tickConter = new Area{
+  *       val tick = Reg(UInt(8 bits) init(0)
+  *       tick := tick + 1
+  *     }
+  * }}}
+  *  @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/area.html `Area` Documentation]]
+  */
 trait Area extends NameableByComponent with ContextUser with OwnableRef with ScalaLocated with ValCallbackRec with OverridedEqualsHashCode  {
   if(OnCreateStack.nonEmpty){
     OnCreateStack.get match {
@@ -120,11 +116,10 @@ object ImplicitArea{
 }
 
 
-/**
-  * Clock domains could be applied to some area of the design and then all synchronous elements instantiated into
+/** Clock domains could be applied to some area of the design and then all synchronous elements instantiated into
   * this area will then implicitly use this clock domain.
   *
-  *  @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/clock_domain/ ClockDomain Documentation]]
+  *  @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/clock_domain.html Clock domains documentation]]
   */
 class ClockingArea(val clockDomain: ClockDomain) extends Area with PostInitCallback {
   val ctx = ClockDomainStack.set(clockDomain)
@@ -136,8 +131,8 @@ class ClockingArea(val clockDomain: ClockDomain) extends Area with PostInitCallb
 }
 
 
-/**
-  * Clock Area with a special clock enable
+/** Clock Area with a special clock enable.
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/clock_domain.html#clockenablearea `ClockEnableArea` documentation]]
   */
 class ClockEnableArea(clockEnable: Bool) extends Area with PostInitCallback {
 
@@ -158,8 +153,8 @@ class ClockEnableArea(clockEnable: Bool) extends Area with PostInitCallback {
 }
 
 
-/**
-  * Define a clock domain which is x time slower than the current clock
+/** Define a clock domain which is x time slower than the current clock.
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/clock_domain.html#slow-area `SlowArea` documentation]]
   */
 class SlowArea(val factor: BigInt, allowRounding : Boolean) extends ClockingArea(ClockDomain.current.newClockDomainSlowedBy(factor)){
   def this(factor: BigInt) = {
@@ -181,8 +176,8 @@ class SlowArea(val factor: BigInt, allowRounding : Boolean) extends ClockingArea
 }
 
 
-/**
-  * ResetArea allow to reset an area with a special reset combining with the current reset (cumulative)
+/** `ResetArea` allow to reset an area with a special reset combining with the current reset (cumulative).
+  *  @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/clock_domain.html#resetarea `ResetArea` documentation]]
   */
 class ResetArea(reset: Bool, cumulative: Boolean) extends Area with PostInitCallback {
 
@@ -202,10 +197,10 @@ class ResetArea(reset: Bool, cumulative: Boolean) extends Area with PostInitCall
 }
 
 
-trait AreaObject extends Area{
+trait AreaObject extends Area {
   setName(this.getClass.getSimpleName.replace("$",""))
 }
 
-trait AreaRoot extends Area{
+trait AreaRoot extends Area {
   setName("")
 }

--- a/core/src/main/scala/spinal/core/BaseType.scala
+++ b/core/src/main/scala/spinal/core/BaseType.scala
@@ -347,22 +347,42 @@ abstract class BaseType extends Data with DeclarationStatement with StatementDou
   /** Create a new instance of the same datatype without any configuration (width, direction) */
   private[core] def weakClone: this.type
 
+  /** Use a `scala.Seq` of SpinalHDL data as mux inputs.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#bitwise-selection Bitwise selection Documentation]]
+    */
   def muxList[T2 <: Data](mappings: Seq[(Any, T2)]): T2 = {
     SpinalMap.list(this,mappings)
   }
 
+  /** Use a `scala.Seq` of SpinalHDL data as mux inputs.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#bitwise-selection Bitwise selection Documentation]]
+    */
   def muxList[T2 <: Data](defaultValue: T2, mappings: Seq[(Any, T2)]): T2 = {
     SpinalMap.list(this, mappings :+ (spinal.core.default , defaultValue) )
   }
 
+  /** Version of SpinalHDL `muxList` that allows Don't Care.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#bitwise-selection Bitwise selection Documentation]]
+    */
   def muxListDc[T2 <: Data](mappings: Seq[(Any, T2)]): T2 = {
     SpinalMap.listDc(this, mappings)
   }
 
+  /** Use a SpinalHDL data as a selector for a mux.
+   * 
+   * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#bitwise-selection Bitwise selection Documentation]]
+   */  
   def mux[T2 <: Data](mappings: (Any, T2)*): T2 = {
     SpinalMap.list(this,mappings)
   }
 
+  /** Version of SpinalHDL `mux` that allows Don't Care.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#bitwise-selection Bitwise selection Documentation]]
+    */
   def muxDc[T2 <: Data](mappings: (Any, T2)*): T2 = {
     SpinalMap.listDc(this,mappings)
   }

--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -26,14 +26,13 @@ import spinal.idslplugin.Location
 import scala.collection.mutable.ArrayBuffer
 
 
-/**
-  * BitVector is a family of types for storing multiple bits of information in a single value.
-  * This type has three subtypes that can be used to model different behaviours:
-  *     - Bits
-  *     - UInt (unsigned integer)
-  *     - SInt (signed integer)
+/** `BitVector` is a family of types for storing multiple bits of information in a single value.
+  * This type has three subtypes that can be used to model different behaviors:
+  *     - `Bits`
+  *     - `UInt` (unsigned integer)
+  *     - `SInt` (signed integer)
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/TypeIntroduction BitVector Documentation]]
+  * @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Developers%20area/types.html#the-bitvector-family-bits-uint-sint `BitVector` family Documentation]]
   */
 abstract class BitVector extends BaseType with Widthable {
 
@@ -230,7 +229,7 @@ abstract class BitVector extends BaseType with Widthable {
   }
 
   /**
-    * Take lowerst n bits
+    * Take lowest n bits
     * @example {{{ val res = data10bits.take(4) }}}
     * @return data10bits(3 downto 0)
     */
@@ -242,7 +241,7 @@ abstract class BitVector extends BaseType with Widthable {
   def takeLow(n: Int): Bits = take(n)
 
   /**
-    * Drop lowerst n bits
+    * Drop lowest n bits
     * @example {{{ val res = data10bits.drop(4) }}}
     * @return data10bits(9 downto 4)
     */

--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -56,8 +56,10 @@ abstract class BitVector extends BaseType with Widthable {
 
   def reversed : this.type
 
-  /** Logical OR of all bits */
-//  def orR: Bool = this.asBits =/= 0
+  /** Hardware logical OR of all bits
+    * 
+    * Equivalent to `this.asBits =/= 0`.
+    */
   def orR: Bool = {
     if(GlobalData.get.config.mode == VHDL) {
       this.asBits =/= 0
@@ -65,8 +67,11 @@ abstract class BitVector extends BaseType with Widthable {
       wrapUnaryWithBool(new Operator.BitVector.orR)
     }
   }
-  /** Logical AND of all bits */
-//  def andR: Bool = this.asBits === ((BigInt(1) << getWidth) - 1)
+
+  /** Hardware logical AND of all bits
+    * 
+    * Equivalent to `this.asBits === ((BigInt(1) << getWidth) - 1)`.
+    */  
   def andR: Bool = {
     if(GlobalData.get.config.mode == VHDL) {
       this.asBits === ((BigInt(1) << getWidth) - 1)
@@ -74,8 +79,11 @@ abstract class BitVector extends BaseType with Widthable {
       wrapUnaryWithBool(new Operator.BitVector.andR)
     }
   }
-  /** Logical XOR of all bits */
-//  def xorR: Bool = this.asBools.reduce(_ ^ _)
+ 
+  /** Hardware logical XOR of all bits    
+    * 
+    * Equivalent to `this.asBools.reduce(_ ^ _)`.
+    */   
   def xorR: Bool = {
     if(GlobalData.get.config.mode == VHDL) {
       this.asBools.reduce(_ ^ _)
@@ -84,8 +92,13 @@ abstract class BitVector extends BaseType with Widthable {
     }
   }
 
+  /** Hardware logical NOR of all bits */
   def norR : Bool = !orR
+  
+  /** Hardware logical NAND of all bits */
   def nandR : Bool = !andR
+
+  /** Hardware logical NXOR of all bits */
   def nxorR : Bool = !xorR
 
   /**
@@ -202,9 +215,7 @@ abstract class BitVector extends BaseType with Widthable {
     w
   }
 
-  /**
-    * Cast the BitVector into a Vector of Bool
-    * @return a vector of Bool
+  /** Cast the `BitVector` into a vector of `Bool`
     */
   def asBools: Vec[Bool] = signalCache(this, "asBools") {
     val vec = ArrayBuffer[Bool]()
@@ -214,6 +225,7 @@ abstract class BitVector extends BaseType with Widthable {
     Vec(vec)
   }
 
+  /** Return `this.lsb` */
   def asBool : Bool = {
     val ret = Bool()
     ret := lsb
@@ -228,8 +240,7 @@ abstract class BitVector extends BaseType with Widthable {
     }
   }
 
-  /**
-    * Take lowest n bits
+  /** Take lowest n bits
     * @example {{{ val res = data10bits.take(4) }}}
     * @return data10bits(3 downto 0)
     */

--- a/core/src/main/scala/spinal/core/Bits.scala
+++ b/core/src/main/scala/spinal/core/Bits.scala
@@ -187,6 +187,10 @@ class Bits extends BitVector with DataPrimitives[Bits] with BaseTypePrimitives[B
     0 to (1 << getWidth)-1
   }
 
+  /** Return a resized representation of x.
+   * 
+   *  If enlarged, it is extended with zero padding at MSB as necessary.
+   */
   override def resize(width: Int): Bits = wrapWithWeakClone({
     val node   = new ResizeBits
     node.input = this
@@ -194,6 +198,10 @@ class Bits extends BitVector with DataPrimitives[Bits] with BaseTypePrimitives[B
     node
   })
 
+  /** Return a resized representation of x.
+   * 
+   *  If enlarged, it is extended with zero padding at MSB as necessary.
+   */
   override def resize(width: BitCount) : Bits = resize(width.value)
 
   override def resizeFactory: Resize = new ResizeBits

--- a/core/src/main/scala/spinal/core/Bits.scala
+++ b/core/src/main/scala/spinal/core/Bits.scala
@@ -35,7 +35,7 @@ trait BitsFactory {
 
 
 /**
-  * The Bits type corresponds to a vector of bits that does not convey any arithmetic meaning.
+  * The `Bits` type corresponds to a vector of bits that does not convey any arithmetic meaning.
   *
   * @example {{{
   *     val myBits1 = Bits(32 bits)
@@ -44,7 +44,7 @@ trait BitsFactory {
   *     val myBits4 = B"1001_0011
   * }}}
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/Bits Bits Documentation]]
+  * @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html `Bits` Documentation]]
   */
 class Bits extends BitVector with DataPrimitives[Bits] with BaseTypePrimitives[Bits] with BitwiseOp[Bits]{
 

--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -24,20 +24,20 @@ import spinal.core.internals.Operator.Formal
 import spinal.core.internals._
 import spinal.idslplugin.Location
 
-/** Bool factory used for instance by the IODirection to create a in/out Bool() */
+/** `Bool` factory used for instance by the IODirection to create a in/out Bool() */
 trait BoolFactory {
   @deprecated("Use `Bool()` (with braces) instead")
   def Bool: Bool = Bool()
 
-  /** Create a new Bool */
+  /** Create a new `Bool` */
   def Bool(u: Unit = ()): Bool = new Bool
 
-  /** Create a new Bool with a value */
+  /** Create a new `Bool` with a value */
   def Bool(value: Boolean)(implicit loc: Location): Bool = BoolLiteral(value, Bool().setAsTypeNode())
 }
 
 /**
-  * The Bool type corresponds to a boolean value (True or False)
+  * The `Bool` type corresponds to a SpinalHDL boolean value (`True` or `False`)
   *
   * @example {{{
   *     val myBool = Bool()
@@ -45,7 +45,7 @@ trait BoolFactory {
   *     myBool := Bool(false)
   * }}}
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/Bool Bool Documentation]]
+  * @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bool.html Bool Documentation]]
   */
 class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[Bool]  with BitwiseOp[Bool]{
 
@@ -58,7 +58,7 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
   private[spinal] override def _data: Bool = this
 
   /**
-    * Logical AND
+    * SpinalHDL logical AND
     * @example{{{ val result = myBool1 && myBool2 }}}
     * @return a Bool assign with the AND result
     */
@@ -66,7 +66,7 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
   override def &(b: Bool): Bool = this && b
 
   /**
-    * Logical OR
+    * SpinalHDL logical OR
     * @example{{{ val result = myBool1 || myBool2 }}}
     * @return a Bool assign with the OR result
     */
@@ -76,7 +76,7 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
   override def ^(b: Bool): Bool  = wrapLogicalOperator(b, new Operator.Bool.Xor)
 
   /**
-    * Logical NOT
+    * SpinalHDL logical NOT
     * @example{{{ val result = !myBool1 }}}
     * @return a Bool assign with the NOT result
     */
@@ -95,9 +95,9 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
     result
   }
 
-  /** this is assigned to True */
+  /** this is assigned to `True` */
   def set(): Unit = this := True
-  /** this is assigned to False */
+  /** this is assigned to `False` */
   def clear(): Unit = this := False
 
   /** Set to True.

--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -37,7 +37,7 @@ trait BoolFactory {
 }
 
 /**
-  * The `Bool` type corresponds to a SpinalHDL boolean value (`True` or `False`)
+  * The `Bool` type corresponds to a hardware boolean value (`True` or `False`)
   *
   * @example {{{
   *     val myBool = Bool()
@@ -58,25 +58,32 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
   private[spinal] override def _data: Bool = this
 
   /**
-    * SpinalHDL logical AND
+    * Hardware logical AND
     * @example{{{ val result = myBool1 && myBool2 }}}
     * @return a Bool assign with the AND result
     */
   def &&(b: Bool): Bool = wrapLogicalOperator(b, new Operator.Bool.And)
   override def &(b: Bool): Bool = this && b
 
-  /**
-    * SpinalHDL logical OR
+  /** Hardware logical OR
     * @example{{{ val result = myBool1 || myBool2 }}}
     * @return a Bool assign with the OR result
     */
   def ||(b: Bool): Bool = wrapLogicalOperator(b, new Operator.Bool.Or)
+
+  /** Hardware alternative to logical OR
+    * @example{{{ val result = myBool1 | myBool2 }}}
+    * @return a Bool assign with the OR result
+    */
   override def |(b: Bool): Bool = this || b
 
+  /** Hardware logical XOR
+    * @example{{{ val result = myBool1 ^ myBool2 }}}
+    * @return a Bool assign with the XOR result
+    */
   override def ^(b: Bool): Bool  = wrapLogicalOperator(b, new Operator.Bool.Xor)
 
-  /**
-    * SpinalHDL logical NOT
+  /** Hardware logical NOT
     * @example{{{ val result = !myBool1 }}}
     * @return a Bool assign with the NOT result
     */
@@ -84,8 +91,17 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
 
   def isUnknown: Bool = wrapUnaryOperator(new Operator.BitVector.IsUnknown)
 
+  /** Hardware alternative to logical NOT
+    * @example{{{ val result = ~myBool1 }}}
+    * @return a Bool assign with the NOT result
+    */
   override def unary_~ : Bool = ! this
 
+  /** Hardware repeat `count` time a `Bool`
+    * 
+    * @param count
+    * @return `Bits(count bits)`
+    */
   override def #* (count : Int) : Bits = {
     val node = new Operator.Bool.Repeat(count)
     node.source = this.asInstanceOf[node.T]

--- a/core/src/main/scala/spinal/core/Bundle.scala
+++ b/core/src/main/scala/spinal/core/Bundle.scala
@@ -27,24 +27,7 @@ import spinal.idslplugin.{Location, ValCallback}
 import scala.collection.mutable
 
 
-/**
-  * The Bundle is a composite type that defines a group of named signals (of any SpinalHDL basic type) under a single name.
-  * The Bundle can be used to model data structures, buses and interfaces.
-  *
-  * @example {{{
-  *     val cmd = new Bundle{
-  *       val init   = in Bool()
-  *       val start  = in Bool()
-  *       val result = out Bits(32 bits)
-  *     }
-  * }}}
-  *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/Bundle Bundle Documentation]]
-  */
-
-
-
-trait ValCallbackRec extends ValCallback{
+trait ValCallbackRec extends ValCallback {
 
 //  final override def valCallback(fieldRef: Any, name: String): Unit = {
 //    val refs = mutable.Set[Any]()
@@ -105,6 +88,21 @@ trait ValCallbackRec extends ValCallback{
   }
 }
 
+
+/**
+  * A `Bundle` is a composite type that defines a group of named signals (of any SpinalHDL basic type) under a single name.
+  * A `Bundle` can be used to model data structures, buses and interfaces.
+  *
+  * @example {{{
+  *     val cmd = new Bundle{
+  *       val init   = in Bool()
+  *       val start  = in Bool()
+  *       val result = out Bits(32 bits)
+  *     }
+  * }}}
+  *
+  * @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bundle.html `Bundle` Documentation]]
+  */
 class Bundle extends MultiData with Nameable with ValCallbackRec {
 
   var hardtype: HardType[_] = null

--- a/core/src/main/scala/spinal/core/ClockDomain.scala
+++ b/core/src/main/scala/spinal/core/ClockDomain.scala
@@ -313,13 +313,13 @@ object Clock{
   }
 }
 
-/**
-  * clock and reset signals can be combined to create a clock domain.
+/** Clock and reset signals can be combined to create a clock domain.
+  * 
   * Clock domains could be applied to some area of the design and then all synchronous elements instantiated into this
   * area will then implicitly use this clock domain.
   * Clock domain application work like a stack, which mean, if you are in a given clock domain, you can still apply another clock domain locally
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/clock_domain ClockDomain Documentation]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/clock_domain.html clock domains documentation]]
   */
 case class ClockDomain(clock       : Bool,
                        reset       : Bool = null,

--- a/core/src/main/scala/spinal/core/Component.scala
+++ b/core/src/main/scala/spinal/core/Component.scala
@@ -55,7 +55,7 @@ object Component {
 
 
 /**
-  * Abstract class used to create a new Component
+  * Abstract class used to create a new `Component`
   *
   * @example {{{
   *         class MyAndGate extends Component {
@@ -67,7 +67,7 @@ object Component {
   *         }
   * }}}
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/components_hierarchy Component Documentation]]
+  * @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/components_hierarchy.html Component Documentation]]
   */
 abstract class Component extends NameableByComponent with ContextUser with ScalaLocated with PostInitCallback with Stackable with OwnableRef with SpinalTagReady with OverridedEqualsHashCode with ValCallbackRec {
   if(parentScope == null) {

--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -33,15 +33,16 @@ class VarAssignementTag(val from : Data) extends SpinalTag{
   var id = 0
 }
 
-trait DataPrimitives[T <: Data]{
+trait DataPrimitives[T <: Data] {
 
   private[spinal] def _data : T
 
-  /** Comparison between two data */
+  /** `isEqualTo` comparison between two SpinalHDL data. */
   def ===(that: T): Bool = _data isEqualTo that
+  /** `isNotEqualTo` comparison between two SpinalHDL data. */
   def =/=(that: T): Bool = _data isNotEqualTo that
 
-  /** Assign a data to this */
+  /** Standard SpinalHDL assignment, equivalent to `<=` in VHDL/Verilog. */
   def := (that: T)(implicit loc: Location): Unit = _data assignFrom that
 
   /** Use as \= to have the same behavioral as VHDL variable */
@@ -87,7 +88,10 @@ trait DataPrimitives[T <: Data]{
     _data.copyDirectionOfImpl(that)
   }
 
-  /** Auto connection between two data */
+  /** Automatic connection between two SpinalHDL signals or two bundles of the same type.
+   * 
+   * Direction is inferred by using signal direction (`in`/`out`). (Similar behavior to `:=`) 
+   */
   def <>(that: T)(implicit loc: Location): Unit = _data autoConnect that
 
   /** Set initial value to a data */
@@ -479,7 +483,9 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
   private[core] def isEqualTo(that: Any): Bool
   private[core] def isNotEqualTo(that: Any): Bool
 
-  /** Resized data regarding target */
+  /** Allow SpinalHDL assignment with the size inferred from the assigned data.
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/assignments.html#width-checking Width checking Documentation]]
+    */
   def resized: this.type = {
     val ret = cloneOf(this)
     ret.assignFrom(this)
@@ -487,17 +493,17 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
     return ret.asInstanceOf[this.type]
   }
 
-  /** Allow a Data to be overriden
+  /** Allow a Data to be overridden.
     *
-    * See https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/assignment_overlap.html
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/assignment_overlap.html Assignment overlap Error Documentation]]
     */
   def allowOverride(): this.type = {
     addTag(allowAssignmentOverride)
   }
 
-  /** Allow a Data of an io Bundle to be directionless
+  /** Allow a Data of an io `Bundle` to be directionless.
     *
-    * See https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/iobundle.html
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/iobundle.html IO Bundle Error Documentation]]
     */
   def allowDirectionLessIo(): this.type = {
     addTag(allowDirectionLessIoTag)
@@ -510,7 +516,7 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
 
   /** Allow a register to have only an init (no assignments)
     *
-    * See https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/unassigned_register.html#register-with-only-init
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/unassigned_register.html#register-with-only-init "Register with only init" Error Documentation ]]
     */
   def allowUnsetRegToAvoidLatch(): this.type = {
     addTag(unsetRegIfNoAssignementTag)
@@ -518,7 +524,7 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
 
   /** Disable combinatorial loop checking for this Data
     *
-    * See https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/combinatorial_loop.html
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/combinatorial_loop.html Combinatorial loop Error Documentation]]
     */
   def noCombLoopCheck(): this.type = {
     addTag(spinal.core.noCombinatorialLoopCheck)

--- a/core/src/main/scala/spinal/core/Enum.scala
+++ b/core/src/main/scala/spinal/core/Enum.scala
@@ -71,22 +71,20 @@ class SpinalEnumElement[T <: SpinalEnum](val spinalEnum: T, val position: Int) e
 }
 
 
-/**
- * Base class for creating enumeration
- *
- * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/Enum Enumeration Documentation]]
- *
- * @example {{{
- *         object MyEnum extends SpinalEnum(binarySequential){
- *           val s1, s2, s3, s4 = newElement()
- *         }
- *         }}}
- *
- * SpinalEnum contains a list of SpinalEnumElement that is the definition of an element. SpinalEnumCraft is the
- * hardware representation of the the element.
- *
- * @param defaultEncoding encoding of the senum
- */
+/** Base class for creating enumeration
+  *
+  * @example {{{
+  *         object MyEnum extends SpinalEnum(binarySequential){
+  *           val s1, s2, s3, s4 = newElement()
+  *         }
+  *         }}}
+  *
+  * `SpinalEnum` contains a list of `SpinalEnumElement` that is the definition of an element. `SpinalEnumCraft` is the
+  * hardware representation of the the element.
+  *
+  * @param defaultEncoding encoding of the enum
+  * @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/enum.html Enumeration Documentation]]
+  */
 class SpinalEnum(var defaultEncoding: SpinalEnumEncoding = native) extends Nameable with ScalaLocated {
 
   assert(defaultEncoding != inferred, "Enum definition should not have 'inferred' as default encoding")

--- a/core/src/main/scala/spinal/core/FixedPoint.scala
+++ b/core/src/main/scala/spinal/core/FixedPoint.scala
@@ -305,10 +305,9 @@ abstract class XFix[T <: XFix[T, R], R <: BitVector with Num[R]](val maxExp: Int
 }
 
 //TODO Fix autoconnect
-/**
-  * Signed fix point
+/** Signed fix point
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/Fix SFix Documentation]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Fix.html `UFix`/`SFix` Documentation]]
   */
 class SFix(maxExp: Int, bitCount: Int) extends XFix[SFix, SInt](maxExp, bitCount) {
   override def rawFactory(maxExp: Int, bitCount: Int): SInt = SInt(bitCount bit)
@@ -453,10 +452,10 @@ class SFix2D(val maxExp: Int, val bitCount: Int) extends Bundle {
   override def clone: this.type = new SFix2D(maxExp, bitCount).asInstanceOf[this.type]
 }
 
-/**
-  * Unsigned fix point
+
+/** Unsigned fix point
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/Fix UFix Documentation]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Fix.html `UFix`/`SFix` Documentation]]
   */
 class UFix(maxExp: Int, bitCount: Int) extends XFix[UFix, UInt](maxExp, bitCount) {
 
@@ -528,7 +527,7 @@ class UFix(maxExp: Int, bitCount: Int) extends XFix[UFix, UInt](maxExp, bitCount
     this
   }
 
-  //Rounded down
+  // Rounded down
   def toUInt: UInt = {
     if (maxExp < 0)
       U(0)
@@ -579,7 +578,7 @@ class UFix2D(val maxExp: Int, val bitCount: Int) extends Bundle {
 
 
 /**
-  * Two-dimensional SFix
+  * Two-dimensional `SFix`
   */
 object SFix2D {
   def apply(maxExp: ExpNumber, bitCount: BitCount): SFix2D = new SFix2D(maxExp.value, bitCount.value)
@@ -589,7 +588,7 @@ object SFix2D {
 
 
 /**
-  * Two-dimensional UFix
+  * Two-dimensional `UFix`
   */
 object UFix2D {
   def apply(maxExp: ExpNumber, bitCount: BitCount): UFix2D = new UFix2D(maxExp.value, bitCount.value)

--- a/core/src/main/scala/spinal/core/IODirection.scala
+++ b/core/src/main/scala/spinal/core/IODirection.scala
@@ -28,7 +28,7 @@ package spinal.core
   *   - `SInt`
   *   - `Vec`
   *
-  * The "spaceful" syntax is generic and beatiful, but more verbose.
+  * The "spaceful" syntax is generic and beautiful, but more verbose.
   *
   * The "variadic" syntax can be used with any number of ports, but can be used
   * only if the ports types are already declared.

--- a/core/src/main/scala/spinal/core/Literal.scala
+++ b/core/src/main/scala/spinal/core/Literal.scala
@@ -30,12 +30,55 @@ abstract class BitVectorLiteralFactory[T <: BitVector] {
 
   def apply(): T
 
+  /** Create an hardware literal from a Scala `Int`
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html#declaration `UInt`/`SInt` declaration]]
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+    */
   def apply(value: Int): T = this(BigInt(value))
+  
+  /** Create an hardware literal from a Scala `Int` with a given `width`
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html#declaration `UInt`/`SInt` declaration]]
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+    */
   def apply(value: Int, width: BitCount): T = this(BigInt(value),width)
+  
+  /** Create an hardware literal from a Scala `Long`
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html#declaration `UInt`/`SInt` declaration]]
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+    */
   def apply(value: Long): T = this(BigInt(value))
+  
+  /** Create an hardware literal from a Scala `Long` with a given `width`
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html#declaration `UInt`/`SInt` declaration]]
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+    */
   def apply(value: Long, width: BitCount): T = this(BigInt(value),width)
+  
+  /** Create an hardware literal from a Scala `BigInt`
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html#declaration `UInt`/`SInt` declaration]]
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+    */
   def apply(value: BigInt): T = getFactory(value, -1, this().setAsTypeNode())
+  
+  /** Create an hardware literal from a Scala `BigInt` with a given `width`
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html#declaration `UInt`/`SInt` declaration]]
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+    */
   def apply(value: BigInt, width: BitCount): T = getFactory(value, width.value, this().setWidth(width.value).setAsTypeNode())
+  
+  /** Create an hardware literal from string literal definition.
+    *  @example{{{
+    *  myUInt := U"0000_0101"  // Base per default is binary => 5
+    *  myUInt := U"h1A"        // Base could be x (base 16)
+    *                          //               h (base 16)
+    *                          //               d (base 10)
+    *                          //               o (base 8)
+    *                          //               b (base 2)
+    *  myUInt := U"8'h1A"
+    * }}} 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html#declaration `UInt`/`SInt` declaration]]
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+    */
   def apply(value: String): T = bitVectorStringParser(this, value,  isSigned)
 
   def apply(bitCount: BitCount, rangesValue: (Any, Any), _rangesValues: (Any, Any)*): T = this.aggregate(bitCount, rangesValue +: _rangesValues)
@@ -103,18 +146,26 @@ abstract class BitVectorLiteralFactory[T <: BitVector] {
   }
 }
 
-
 /**
   * Used to create a new Bits or cast to Bits
   */
 object B extends BitVectorLiteralFactory[Bits] {
-  def apply(): Bits = new Bits()
+  /** Create an `Bits` hardware literal.
+    *
+    *  Bit count is inferred from the widest assignment statement after construction.
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+    */
+  def apply(): Bits = new Bits()  
   def apply(that: Data): Bits = that.asBits
   def apply(that: Data, width : BitCount): Bits = that.asBits.resize(width)
   def apply(head: Data, tail: Data*) : Bits = Cat((head +: tail).reverse)
   def apply(value: Data, times: Int) : Bits = value #* times
   def apply(value : Seq[Data]) : Bits = Cat(value)
   def apply[T <: Data](value : Vec[T]) : Bits = B(value.asInstanceOf[Data])
+
+  /** Create a `Bits` hardware literal, from a string de
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+    */
   def apply(value : MaskedLiteral, filling : Boolean = false): Bits = value.asBits(filling)
 
   override private[core] def newInstance(bitCount: BitCount): Bits = Bits(bitCount)

--- a/core/src/main/scala/spinal/core/MaskedLiteral.scala
+++ b/core/src/main/scala/spinal/core/MaskedLiteral.scala
@@ -44,12 +44,12 @@ object MaskedLiteral{
   *
   */
 
-class MaskedBoolean(value : Boolean, careAbout : Boolean){
+class MaskedBoolean(value : Boolean, careAbout : Boolean) {
   def ===(that : Bool) : Bool = if(careAbout) that === Bool(value) else True
   def =/=(that : Bool) : Bool = if(careAbout) that =/= Bool(value) else False
 }
 
-class MaskedLiteral(val value: BigInt, val careAbout: BigInt, val width: Int){
+class MaskedLiteral(val value: BigInt, val careAbout: BigInt, val width: Int) {
   override def hashCode() = value.hashCode() + careAbout.hashCode() + width
   override def equals(o: scala.Any) = o match {
     case o : MaskedLiteral => this.value == o.value && this.careAbout == o.careAbout && this.width == o.width
@@ -59,7 +59,7 @@ class MaskedLiteral(val value: BigInt, val careAbout: BigInt, val width: Int){
   def withDontCare = careAbout != (BigInt(1) << width)-1
 
   def getWidth() = width
-  def apply(index : Int): MaskedBoolean ={
+  def apply(index : Int): MaskedBoolean = {
     if(index >= width){
       SpinalError(s"Accessing MaskedLiteral at $index is outside its range ($width bits)")
     }

--- a/core/src/main/scala/spinal/core/MemBlackBox.scala
+++ b/core/src/main/scala/spinal/core/MemBlackBox.scala
@@ -202,7 +202,7 @@ class Ram_1w_1rs(
     val rd = new Bundle {
       val clk    = in Bool()
       val en     = in Bool()
-      val addr   = in  UInt(rdAddressWidth bit)
+      val addr   = in UInt(rdAddressWidth bit)
       val dataEn = in Bool() default(True) //Only used if rdLatency > 1
       val data   = out Bits(rdDataWidth bit)
     }

--- a/core/src/main/scala/spinal/core/Misc.scala
+++ b/core/src/main/scala/spinal/core/Misc.scala
@@ -196,9 +196,12 @@ object Cat {
 }
 
 
-/**
- * Mux operation 
- */
+/** SpinalHDL standalone mux with `Bool` selector
+  * 
+  * Types like `Enum`/`Bool`/`Bits`/`UInt`/`SInt` can also be used as selector with the method
+  * `mux()` of their parent `BaseType`.
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#mux `Mux` documentation]]
+  */
 object Mux {
   def apply[T <: Data](sel: Bool, whenTrue: T, whenFalse: T): T = {
     Multiplex.complexData(sel, whenTrue, whenFalse)
@@ -558,10 +561,11 @@ object AnnotationUtils{
 }
 
 
-/**
- * Create a new signal, assigned by the given parameter.
- * Useful to provide a "copy" of something that you can then modify with more conditional assignments.
- */
+/** Create a new signal, assigned by the given parameter.
+  * 
+  * Useful to provide a "copy" of something that you can then modify with more conditional assignments.
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/assignments.html#combinit `CombInit` Documentation]]
+  */
 object CombInit {
   def apply[T <: Data](init: T): T = {
     val ret = cloneOf(init)

--- a/core/src/main/scala/spinal/core/SInt.scala
+++ b/core/src/main/scala/spinal/core/SInt.scala
@@ -75,6 +75,7 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
   def @@(that: Bool): SInt = S(this ## that)
 
   /* Implement Num operators */
+
   override def + (right: SInt): SInt = wrapBinaryOperator(right, new Operator.SInt.Add)
   override def - (right: SInt): SInt = wrapBinaryOperator(right, new Operator.SInt.Sub)
   override def * (right: SInt): SInt = wrapBinaryOperator(right, new Operator.SInt.Mul)
@@ -536,6 +537,11 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
   private[core] override def newMultiplexerExpression() = new MultiplexerSInt
   private[core] override def newBinaryMultiplexerExpression() = new BinaryMultiplexerSInt
 
+
+  /** Return a resized copy of x.
+    * 
+    * If enlarged, it is extended with the sign at MSB as necessary.
+    */
   override def resize(width: Int): this.type = wrapWithWeakClone({
     val node   = new ResizeSInt
     node.input = this
@@ -543,6 +549,10 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
     node
   })
 
+  /** Return a resized copy of x.
+    * 
+    * If enlarged, it is extended with the sign at MSB as necessary.
+    */
   override def resize(width: BitCount) : SInt = resize(width.value)
 
   override def minValue: BigInt = -(BigInt(1) << (getWidth - 1))

--- a/core/src/main/scala/spinal/core/SInt.scala
+++ b/core/src/main/scala/spinal/core/SInt.scala
@@ -24,9 +24,9 @@ import spinal.core.internals._
 import spinal.idslplugin.Location
 
 /**
-  * SInt factory used for instance by the IODirection to create a in/out SInt
+  * `SInt` factory used for instance by the `IODirection` to create a in/out `SInt`
   */
-trait SIntFactory{
+trait SIntFactory {
   /** Create a new SInt */
   def SInt(u: Unit = ()) = new SInt()
   /** Create a new SInt of a given width */
@@ -34,8 +34,7 @@ trait SIntFactory{
 }
 
 
-/**
-  * The SInt type corresponds to a vector of bits that can be used for signed integer arithmetic.
+/** The `SInt` type corresponds to a vector of bits that can be used for signed integer arithmetic.
   *
   * @example{{{
   *     val mySInt = SInt(8 bits)
@@ -43,7 +42,7 @@ trait SIntFactory{
   *     mySInt    := S(4) - S"h1A"
   * }}}
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/Int SInt Documentation]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html `UInt/`SInt` Documentation]]
   */
 class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimitives[SInt] with BaseTypePrimitives[SInt]  with BitwiseOp[SInt] {
   override def tag(q: QFormat): SInt = {
@@ -64,15 +63,15 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
   private[spinal] override  def _data: SInt = this
 
   /**
-    * Concatenation between two SInt
+    * Concatenation between two `SInt`
     * @example{{{ val mySInt = sInt1 @@ sInt2 }}}
     * @param that an SInt to append
-    * @return a new SInt of width (width(this) + width(right))
+    * @return a new `SInt` of width (width(this) + width(right))
     */
   def @@(that: SInt): SInt = S(this ## that)
-  /** Concatenation between a SInt and UInt */
+  /** Concatenation between a `SInt` and `UInt` */
   def @@(that: UInt): SInt = S(this ## that)
-  /** Concatenation between a SInt and a Bool */
+  /** Concatenation between a `SInt` and a `Bool` */
   def @@(that: Bool): SInt = S(this ## that)
 
   /* Implement Num operators */
@@ -106,9 +105,9 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
   /* Implement fixPoint operators */
   def sign: Bool = this.msb
   /**
-    * SInt symmetric
+    * `SInt` symmetric
     * @example{{{ val symmetrySInt = mySInt.symmetry }}}
-    * @return return a SInt which minValue equal -maxValue
+    * @return return a `SInt` which minValue equal -maxValue
     */
   def symmetry: SInt = {
     val ret = cloneOf(this)
@@ -116,7 +115,7 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
     ret
   }
 
-  /**Saturation highest m bits*/
+  /** Saturation highest m bits */
   override def sat(m: Int): SInt = {
     require(getWidth > m, s"Saturation bit width $m must be less than data bit width $getWidth")
     m match {
@@ -128,14 +127,14 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
 
   private def _sat(m: Int): SInt ={
     val ret = SInt(getWidth-m bit)
-    when(this.sign){//negative process
-      when(!this(getWidth-1 downto getWidth-m-1).asBits.andR){
+    when(this.sign) { // negative process
+      when(!this(getWidth-1 downto getWidth-m-1).asBits.andR) {
         ret := ret.minValue
       }.otherwise{
         ret := this(getWidth-m-1 downto 0)
       }
-    }.otherwise{//positive process
-      when(this(getWidth-2 downto getWidth-m-1).asBits.orR){
+    }.otherwise { // positive process
+      when(this(getWidth-2 downto getWidth-m-1).asBits.orR) {
         ret := ret.maxValue
       }.otherwise {
         ret := this(getWidth-m- 1 downto 0)
@@ -146,12 +145,12 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
 
   def satWithSym(m: Int): SInt = sat(m).symmetry
 
-  /**highest m bits Discard */
+  /** Discard the highest `m` bits */
   override def trim(m: Int): SInt = this(getWidth-m-1 downto 0)
 
-  /**Round Api*/
+  /** Round Api */
 
-  /**return w(this)-n bits*/
+  /** return `w(this)-n` bits */
   override def floor(n: Int): SInt = {
     require(getWidth > n, s"floor bit width $n must be less than data bit width $getWidth")
     n match {
@@ -163,7 +162,7 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
   private def _floor(n: Int): SInt = this >> n
 
   /**
-    * SInt ceil
+    * `SInt` ceil
     * @example{{{ val mySInt = SInt(w bits).ceil }}}
     * @param  n : ceil lowerest n bit
     * @return a new SInt of width (w - n + 1)

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -362,7 +362,7 @@ object Nameable{
 }
 
 
-trait Nameable extends OwnableRef with ContextUser{
+trait Nameable extends OwnableRef with ContextUser {
   import Nameable._
 
   var name: String = null
@@ -894,46 +894,46 @@ trait Num[T <: Data] {
     hpos downto lpos
   }
 
-  /** Addition */
+  /** Hardware addition */
   def + (right: T): T
-  /** Safe Addition with 1 bit expand */
+  /** Hardware safe addition with 1 bit expand */
   def +^(right: T): T
-  /** Safe Addition with saturation */
+  /** Hardware safe addition with saturation */
   def +| (right: T): T
-  /** Substraction */
+  /** Hardware subtraction */
   def - (right: T): T
-  /** Safe Substraction with 1 bit expand*/
+  /** Hardware safe subtraction with 1 bit expand */
   def -^ (right: T): T
-  /** Safe Substraction with saturation*/
+  /** Hardware safe subtraction with saturation */
   def -| (right: T): T
-  /** Multiplication */
+  /** Hardware multiplication */
   def * (right: T): T
-  /** Division */
+  /** Hardware division */
   def / (right: T): T
-  /** Modulo */
+  /** Hardware modulo */
   def % (right: T): T
 
-  /** Is less than right */
+  /** Hardware "is less than right" */
   def <  (right: T): Bool
-  /** Is equal or less than right */
+  /** Hardware  "is equal or less than right" */
   def <= (right: T): Bool
-  /** Is greater than right */
+  /** Hardware "is greater than right" */
   def >  (right: T): Bool
-  /** Is equal or greater than right */
+  /** Hardware "is equal or greater than right" */
   def >= (right: T): Bool
 
-  /** Arithmetic left shift (w(T) = w(this) + shift)*/
+  /** Hardware arithmetic left shift (`w(T) = w(this) + shift`) */
   def << (shift: Int): T
-  /** Arithmetic right shift (w(T) = w(this) - shift)*/
+  /** Hardware arithmetic right shift (`w(T) = w(this) - shift`) */
   def >> (shift: Int): T
-  /** Arithmetic left shift (w(T) = w(this) + (1 << shift)-1*/
+  /** Hardware arithmetic left shift (`w(T) = w(this) + (1 << shift)-1`) */
   def << (shift: UInt): T
-  /** Arithmetic right shift (w(T) = w(this)*/
+  /** Hardware arithmetic right shift (`w(T) = w(this)`)*/
   def >> (shift: UInt): T
 
-  /** Return the minimum value between this and right  */
+  /** Return the hardware minimum value between this and right  */
   def min(right: T): T = Mux(this < right, this.asInstanceOf[T], right)
-  /** Return the maximum value between this and right  */
+  /** Return the hardware maximum value between this and right  */
   def max(right: T): T = Mux(this < right, right, this.asInstanceOf[T])
 
   /** highest m bits Saturation Operation*/

--- a/core/src/main/scala/spinal/core/UInt.scala
+++ b/core/src/main/scala/spinal/core/UInt.scala
@@ -36,8 +36,7 @@ trait UIntFactory{
 }
 
 
-/**
-  * The UInt type corresponds to a vector of bits that can be used for unsigned integer arithmetic.
+/** The `UInt` type corresponds to a vector of bits that can be used for unsigned integer arithmetic.
   *
   * @example {{{
   *    val myUInt = UInt(8 bits)
@@ -47,7 +46,7 @@ trait UIntFactory{
   *     myUInt := U"h1A"
   * }}}
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/Int UInt Documentation]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html `UInt`/`SInt` Documentation]]
   */
 class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimitives[UInt] with BaseTypePrimitives[UInt] with BitwiseOp[UInt]{
   override def tag(q: QFormat): UInt = {
@@ -117,33 +116,32 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
   }
   private def _sat(m: Int): UInt = {
     val ret = UInt(getWidth-m bit)
-    when(this(getWidth-1 downto getWidth-m).asBits.orR){
+    when(this(getWidth-1 downto getWidth-m).asBits.orR) {
       ret.setAll()
-    }.otherwise{
+    }.otherwise {
       ret := this(getWidth-m-1 downto 0)
     }
     ret
   }
   private def _satAsSInt2UInt(): UInt = {
     val ret = UInt(getWidth-1 bit)
-    when(this.msb){
+    when(this.msb) {
       ret.clearAll()
-    }.otherwise{
+    }.otherwise {
       ret := this(getWidth-2 downto 0)
     }
     ret
   }
-  /**highest m bits Discard */
+  /** highest `m` bits Discard */
   def trim(m: Int): UInt = this(getWidth-m-1 downto 0)
 
   def invertedMsb = !this.msb ## this.dropHigh(1)
   def clearedLow(n : Int) : UInt = (this >> n) << n
 
-  /**Round Api*/
+  /** Round Api */
 
-  /** UInt ceil
-    * floor(x)
-    * return w(this)-n bits
+  /** `UInt` floor
+    * @return `w(this)-n` bits
     * */
   override def floor(n: Int): UInt = {
     require(getWidth > n, s"floor bit width $n must be less than data bit width $getWidth")
@@ -155,10 +153,10 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
   }
   private def _floor(n: Int): UInt = this >> n
 
-  /** UInt ceil
-    * ceil(x)
-    * return if(align) w(this)-n bits else w(this)-n+1 bits
-    * */
+  /** `UInt` ceil
+    * 
+    * @return `w(this)-n` bits if(`align`) else `w(this)-n+1` bits
+    */
   override def ceil(n: Int, align: Boolean = true): UInt = {
     require(getWidth > n, s"ceil bit width $n must be less than data bit width $getWidth")
     n match {
@@ -167,7 +165,7 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
       case _          => this << -n
     }
   }
-  /**return w(this)-n + 1 bit*/
+  /** return w(this)-n + 1 bit */
   private[core] def _ceil(n: Int): UInt = {
     val ret = UInt(getWidth-n+1 bits)
     when(this(n-1 downto 0).asBits.orR){
@@ -182,10 +180,11 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
   override def ceilToInf(n: Int, align: Boolean = true): UInt   = ceil(n, align)
   override def roundToZero(n: Int, align: Boolean = true): UInt = roundDown(n, align)
   override def roundToInf(n: Int, align: Boolean = true): UInt  = roundUp(n, align)
-  /**
-    * UInt roundUp
+  /** `UInt` roundUp
+    * 
     * floor(x + 0.5)
-    * return if(align) w(this)-n bits else w(this)-n+1 bits
+    * 
+    * @return `w(this)-n` bits if(`align`) else `w(this)-n+1` bits
     */
   override def roundUp(n: Int, align: Boolean = true): UInt = {
     require(getWidth > n, s"RoundUp bit width $n must be less than data bit width $getWidth")
@@ -195,7 +194,7 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
       case _          => this << -n
     }
   }
-  /**return w(this)-n + 1 bit*/
+  /** return `w(this)-n+1` bit */
   private def _roundUp(n: Int): UInt = {
     val ret = UInt(getWidth-n+1 bits)
     val positive0p5: UInt = (Bits(getWidth-n bits).clearAll ## True).asUInt //0.5
@@ -203,10 +202,12 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
     ret
   }
 
-  /** UInt roundDown
+  /** `UInt` roundDown
+    * 
     * ceil(x - 0.5)
-    * return w(this)-n bits
-    * */
+    * 
+    * @return `w(this)-n` bits
+    */
   override def roundDown(n: Int, align: Boolean): UInt = {
     require(getWidth > n, s"RoundDown bit width $n must be less than data bit width $getWidth")
     n match {
@@ -215,7 +216,7 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
       case _ => this << -n
     }
   }
-  /**return w(this)-n bit*/
+  /** return `w(this)-n` bit */
   private def _roundDown(n: Int): UInt = {
     require( n > 0, s"RoundDown bit width $n must be less than data bit width $getWidth")
     val ret = UInt(getWidth-n+1 bits)
@@ -265,10 +266,10 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
     ret
   }
 
-  //SpinalHDL chose roundToInf as default round
+  /** SpinalHDL choose `roundToInf` as default round */
   override def round(n: Int, align: Boolean = true): UInt = roundToInf(n, align)
 
-  protected def _fixEntry(roundN: Int, roundType: RoundType, satN: Int): UInt ={
+  protected def _fixEntry(roundN: Int, roundType: RoundType, satN: Int): UInt = {
     roundType match{
       case RoundType.CEIL          => this.ceil(roundN, false).sat(satN + 1)
       case RoundType.FLOOR         => this.floor(roundN).sat(satN)
@@ -283,7 +284,7 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
     }
   }
 
-  /**Factory fixTo Function*/
+  /** Factory `fixTo` Function */
   private def fixToWrap(section: Range.Inclusive, roundType: RoundType): UInt = {
     val w: Int = this.getWidth
     val wl: Int = w - 1
@@ -387,13 +388,14 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
   override def assignFromBits(bits: Bits, hi : Int, lo : Int): Unit = this(hi downto lo).assignFromBits(bits)
 
   /**
-    * Cast an UInt to a SInt
+    * Cast an `UInt` to a `SInt`
     * @example {{{ mySInt := myUInt.asSInt }}}
-    * @return a SInt data
+    * @return a `SInt` data
     */
   def asSInt: SInt = wrapCast(SInt(), new CastUIntToSInt)
-  /*UInt toSInt add 1 bit 0 at hsb for sign bit*/
+  /** `UInt` `intoSInt` add 1 bit 0 at MSB for sign bit */
   def intoSInt: SInt = this.expand.asSInt
+  /** Add 1 bit 0 at MSB */
   def expand: UInt = (False ## this.asBits).asUInt
 
   override def asBits: Bits = wrapCast(Bits(), new CastUIntToBits)
@@ -493,7 +495,7 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
 
 
 /**
-  * Define an UInt 2D point
+  * Define an `UInt` 2D point
   * @example{{{ val positionOnScreen = Reg(UInt2D(log2Up(p.screenResX) bits, log2Up(p.screenResY) bits)) }}}
   * @param xBitCount width of the x point
   * @param yBitCount width of the y point
@@ -504,12 +506,12 @@ case class UInt2D(xBitCount: BitCount, yBitCount: BitCount) extends Bundle {
 }
 
 
-object UInt2D{
+object UInt2D {
 
   /**
-    * Construct a UInt2D with x and y of the same width
+    * Construct a `UInt2D` with x and y of the same width
     * @param commonBitCount the width of the x and y
-    * @return an UInt2 with x and y of the same width
+    * @return an `UInt2D` with x and y of the same width
     */
   def apply(commonBitCount: BitCount) : UInt2D = UInt2D(commonBitCount, commonBitCount)
 }

--- a/core/src/main/scala/spinal/core/UInt.scala
+++ b/core/src/main/scala/spinal/core/UInt.scala
@@ -417,6 +417,10 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
   private[core] override def newMultiplexerExpression() = new MultiplexerUInt
   private[core] override def newBinaryMultiplexerExpression() = new BinaryMultiplexerUInt
 
+  /** Return a resized representation of x.
+   * 
+   *  If enlarged, it is extended with zero padding at MSB as necessary.
+   */
   override def resize(width: Int): this.type = wrapWithWeakClone({
     val node   = new ResizeUInt
     node.input = this
@@ -424,13 +428,16 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
     node
   })
 
+  /** Return a resized representation of x.
+   * 
+   *  If enlarged, it is extended with zero padding at MSB as necessary.
+   */
   override def resize(width: BitCount) : this.type = resize(width.value)
 
   override def minValue: BigInt = BigInt(0)
   override def maxValue: BigInt = (BigInt(1) << getWidth) - 1
 
-  /**
-    * Assign a mask to the output signal
+  /** Assign a mask to the output signal.
     * @example {{{ output4 assignMask M"1111 }}}
     * @param maskedLiteral masked literal value
     */

--- a/core/src/main/scala/spinal/core/Vec.scala
+++ b/core/src/main/scala/spinal/core/Vec.scala
@@ -330,7 +330,7 @@ class VecBitwisePimper[T <: Data with BitwiseOp[T]](pimped : Vec[T]) extends Bit
 
   private def map2with(f: (T, T) => T)(other: Vec[T]): Vec[T] = {
     if (pimped.length != other.length)
-      SpinalError(s"Cannot apply a bitwize opration on vectors with different size (${pimped.length} vs ${other.length})")
+      SpinalError(s"Cannot apply a bitwise operation on vectors with different sizes (${pimped.length} vs ${other.length})")
     Vec((pimped, other).zipped.map(f))
   }
 }

--- a/core/src/main/scala/spinal/core/Vec.scala
+++ b/core/src/main/scala/spinal/core/Vec.scala
@@ -104,14 +104,13 @@ class VecAccessAssign[T <: Data](enables: Seq[Bool], tos: Seq[BaseType], vec: Ve
 }
 
 
-/**
-  * The Vec is a composite type that defines a group of indexed signals (of any SpinalHDL basic type) under a single name
+/** A `Vec` is a composite type that defines a group of indexed signals (of any SpinalHDL basic type) under a single name
   *
   * @example {{{
   *     val myVecOfSInt = Vec(SInt(8 bits), 2)
   * }}}
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/types/Vector Vec Documentation]]
+  * @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Vec.html `Vec` Documentation]]
   */
 class Vec[T <: Data](var _dataType : HardType[T], val vec: Vector[T]) extends MultiData with collection.IndexedSeq[T] {
 
@@ -171,13 +170,13 @@ class Vec[T <: Data](var _dataType : HardType[T], val vec: Vector[T]) extends Mu
     vecTransposedCache
   }
 
-  /** Access an element of the vector by an Int index */
+  /** Access an element of the vector by an `Int` index */
   override def apply(idx: Int): T = {
     if (idx < 0 || idx >= vec.size) SpinalError(s"Static Vec($idx) is outside the range (${vec.size - 1} downto 0) of ${this}")
     vec(idx)
   }
 
-  /** Access an element of the vector by an UInt index */
+  /** Access an element of the vector by an `UInt` index */
   def apply(address: UInt): T = access(address)
 
   private def readEmu(address : UInt): T = {
@@ -203,7 +202,7 @@ class Vec[T <: Data](var _dataType : HardType[T], val vec: Vector[T]) extends Mu
 
 
     val ret = dataType()
-    def rec(ret : Data, elements : Traversable[Data]): Unit ={
+    def rec(ret : Data, elements : Traversable[Data]): Unit = {
       ret match {
         case ret : MultiData =>{
           val iRet = ret.elements.iterator
@@ -227,8 +226,8 @@ class Vec[T <: Data](var _dataType : HardType[T], val vec: Vector[T]) extends Mu
     ret
   }
 
-  private def fixAddress(address : UInt) : UInt = if(widthOf(address) != log2Up(length)){
-    if(address.hasTag(tagAutoResize)){
+  private def fixAddress(address : UInt) : UInt = if(widthOf(address) != log2Up(length)) {
+    if(address.hasTag(tagAutoResize)) {
       address.resize(log2Up(length))
     }else{
       LocatedPendingError(s"Vec address width mismatch.\n- Vec : $this\n- Address width : ${widthOf(address)}\n")
@@ -265,7 +264,7 @@ class Vec[T <: Data](var _dataType : HardType[T], val vec: Vector[T]) extends Mu
   }
 
   //TODO sub element composite assignment, as well for indexed access (std)
-  /** Access an element of the vector by a oneHot value */
+  /** Access an element of the vector by a `oneHot` value */
   def oneHotAccess(oneHot: Bits): T = {
 
     if(elements.size != oneHot.getWidth){

--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -262,12 +262,12 @@ package object core extends BaseTypeFactory with BaseTypeCast {
   }
 
 
-  /**
-    * True / False definition
-    */
+  /** SpinalHDL true value
+   */
   def True(implicit loc: Location)  = Bool(true)
+  /** SpinalHDL false value  
+   */  
   def False(implicit loc: Location) = Bool(false)
-
 
   /**
     * Implicit conversion from Int/BigInt/String to UInt/SInt/Bits

--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -292,9 +292,53 @@ package object core extends BaseTypeFactory with BaseTypeCast {
     def BU(args: Any*): BigInt = intStringParser(getString(args), false)._1
     def BS(args: Any*): BigInt = intStringParser(getString(args), true)._1
 
+    /** Create a `Bits` hardware literal.
+      * @example{{{
+      * val myBits1 = B"8'xFF"   // Base could be x,h (base 16)
+      *                          //               d   (base 10)
+      *                          //               o   (base 8)
+      *                          //               b   (base 2)
+      * val myBits2 = B"1001_0011"  // _ can be used for readability}}}
+      * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#declaration `Bits` declaration]]
+      */
     def B(args: Any*): Bits = bitVectorStringParser(spinal.core.B, getString(args), signed = false)
+    
+    /** Create a `UInt` hardware literal.
+      * @example{{{
+      * myUInt := U"0000_0101"  // Base per default is binary => 5
+      * myUInt := U"h1A"        // Base could be x (base 16)
+      *                         //               h (base 16)
+      *                         //               d (base 10)
+      *                         //               o (base 8)
+      *                         //               b (base 2)
+      * myUInt := U"8'h1A"}}}  
+      * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html#declaration `UInt`/`SInt` declaration]]
+      */
     def U(args: Any*): UInt = bitVectorStringParser(spinal.core.U, getString(args), signed = false)
+    
+    /** Create a `SInt` hardware literal.
+      * @example{{{
+      * mySInt := S"0000_0101"  // Base per default is binary => 5
+      * mySInt := S"h1A"        // Base could be x (base 16)
+      *                         //               h (base 16)
+      *                         //               d (base 10)
+      *                         //               o (base 8)
+      *                         //               b (base 2)
+      * mySInt := S"8'h1A"}}}  
+      * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/Int.html#declaration `UInt`/`SInt` declaration]]
+      */
     def S(args: Any*): SInt = bitVectorStringParser(spinal.core.S, getString(args), signed = true)
+
+    /** Create a mask hardware literal.
+      *  
+      * Useful for don't care comparisons.
+      * @example{{{
+      * val myBits = B"1101"    
+      * val test1 = myBits === M"1-01" // True
+      * val test2 = myBits === M"0---" // False
+      * val test3 = myBits === M"1--1" // True}}}
+      * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/bits.html#maskedliteral `MaskedLiteral` documentation]]
+      */
     def M(args: Any*): MaskedLiteral = MaskedLiteral(sc.parts(0))
     class LList extends ArrayBuffer[Any]{
       def stripMargin = {

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -633,10 +633,10 @@ class ComponentEmitterVerilog(
     }
   }
 
-  def emitEnumDebugLogic(): Unit ={
+  def emitEnumDebugLogic(): Unit = {
     if(enumDebugStringList.nonEmpty) {
       logics ++= "  `ifndef SYNTHESIS\n"
-      for((signal, name, charCount) <- enumDebugStringList){
+      for((signal, name, charCount) <- enumDebugStringList) {
         def normalizeString(that : String) = that + " " * (charCount - that.length)
         logics ++= s"  always @(*) begin\n"
         logics ++= s"    case(${emitReference(signal, false)})\n"

--- a/core/src/main/scala/spinal/core/when.scala
+++ b/core/src/main/scala/spinal/core/when.scala
@@ -58,19 +58,19 @@ object ConditionalContext {
 
 
 /**
-  * If statement
+  * Allow to express SpinalHDL conditional statements based on a `Bool` expression like an `if`.
   *
   * @example {{{
-  *     when(cond1){
+  *     when(cond1) {
   *       myCnt := 0
-  *     }elsewhen(cond2){
+  *     }elsewhen(cond2) {
   *       myCnt := myCnt + 1
-  *     }otherwise{
+  *     }otherwise {
   *       myCnt := myCnt - 1
   *     }
   * }}}
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/when_switch/ when Documentation]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#when `when` Documentation]]
   */
 object when {
 
@@ -100,10 +100,7 @@ class ElseWhenClause(val cond : Bool, _block: => Unit){
 }
 
 
-/**
-  * else / else if  statement
-  *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/when_switch/ when Documentation]]
+/** Used by SpinalHDL `when`/`elsewhen`/`otherwise` and `WhenBuilder` to keep track of the structure.
   */
 class WhenContext(whenStatement: WhenStatement) extends ConditionalContext with ScalaLocated {
 
@@ -113,9 +110,17 @@ class WhenContext(whenStatement: WhenStatement) extends ConditionalContext with 
     ctx.restore()
   }
 
+  /** Allows to express conditional SpinalHDL statements in a `when` structure.
+   * @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#when `when` Documentation]]
+   */
   def elsewhen(clause : ElseWhenClause)(implicit loc: Location) : WhenContext = protElsewhen(clause.cond)(clause.block)(loc)
-//  @deprecated("Use `elsewhen` instead of `.elsewhen` (without the prefix `.`)", "1.1.2")
+
+  // @deprecated("Use `elsewhen` instead of `.elsewhen` (without the prefix `.`)", "1.1.2")
+  /** Allows to express conditional SpinalHDL statements in a `when` structure.
+   * @see  [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#when `when` Documentation]]
+   */
   def elsewhen(cond: Bool)(block: => Unit)(implicit loc: Location): WhenContext = protElsewhen(cond)(block)(loc)
+
   protected def protElsewhen(cond: Bool)(block: => Unit)(loc: Location): WhenContext = {
     var newWhenContext: WhenContext = null
     otherwise {
@@ -125,27 +130,23 @@ class WhenContext(whenStatement: WhenStatement) extends ConditionalContext with 
   }
 }
 
-
-
-
-/**
-  * case/switch statement
+/** `case`/`switch` SpinalHDL statement
   *
   * @example {{{
-  *     switch(x){
-  *         is(value1){
-  *             //execute when x === value1
+  *     switch(x) {
+  *         is(value1) {
+  *             // execute when x === value1
   *         }
-  *         is(value2){
-  *             //execute when x === value2
+  *         is(value2) {
+  *             // execute when x === value2
   *         }
-  *         default{
-  *            //execute if none of precedent condition meet
+  *         default {
+  *            // execute if none of precedent conditions are meet
   *         }
   *      }
   * }}}
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/when_switch/ switch Documentation]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#switch `switch` Documentation]]
   */
 object switch {
 
@@ -166,10 +167,9 @@ object switch {
 }
 
 
-/**
-  * is statement of a switch case
+/** `is` statement of a SpinalHDL `switch`/ `case`
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/when_switch/ switch Documentation]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#switch `switch` Documentation]]  
   */
 object is {
 
@@ -182,15 +182,13 @@ object is {
     val switchElement = new SwitchStatementElement(ArrayBuffer[Expression](), new ScopeStatement(switchContext.statement))
     val switchValue   = switchContext.statement.value
 
-    def onBaseType(value : BaseType): Unit ={
+    def onBaseType(value : BaseType): Unit = {
       if(value.getClass == switchValue.getClass){
         switchElement.keys += value
       }else{
         SpinalError("is(xxx) doesn't match switch(yyy) type")
       }
     }
-
-
 
     values.foreach {
       case value: BaseType => onBaseType(value)
@@ -232,7 +230,6 @@ object is {
 //      case key: Seq[Data] => switchElement.keys += SwitchStatementKeyBool(key.map(d => (switchValue.asInstanceOf[Data] === d)).reduce(_ || _))
     }
 
-
     switchContext.statement.elements += switchElement
     val ctx = switchElement.scopeStatement.push()
     block
@@ -241,10 +238,9 @@ object is {
 }
 
 
-/**
-  * default statement of a switch case
+/** `default` statement of a SpinalHDL `switch`/ `case`
   *
-  * @see  [[http://spinalhdl.github.io/SpinalDoc/spinal/core/when_switch/ switch Documentation]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#switch `switch` Documentation]]  
   */
 object default {
 

--- a/lib/src/main/scala/spinal/lib.scala
+++ b/lib/src/main/scala/spinal/lib.scala
@@ -157,6 +157,8 @@ package object lib  {
     def binIntsToLong: Long     = binIntsToBigInt.toLong
   }
 
-
+  /** One-Hot multiplexer
+    * @see [[https://en.wikipedia.org/wiki/One-hot one-hot encoding]]
+    */
   val OHMux = new MuxOHImpl
 }

--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -102,7 +102,7 @@ object OHToUInt {
   }
 }
 
-//Will be target dependent
+// Will be target dependent
 class MuxOHImpl {
   def apply[T <: Data](oneHot : BitVector,inputs : Seq[T]): T = apply(oneHot.asBools,inputs)
   def apply[T <: Data](oneHot : collection.IndexedSeq[Bool],inputs : Iterable[T]): T =  apply(oneHot,Vec(inputs))
@@ -116,16 +116,16 @@ class MuxOHImpl {
     }
   }
 
-  def mux[T <: Data](oneHot : BitVector,inputs : Seq[T]): T = apply(oneHot.asBools,inputs)
+  def mux[T <: Data](oneHot : BitVector,inputs : Seq[T]): T = apply(oneHot.asBools, inputs)
   def mux[T <: Data](oneHot : collection.IndexedSeq[Bool],inputs : Iterable[T]): T =  apply(oneHot,Vec(inputs))
 
-  def mux[T <: Data](oneHot : BitVector,inputs : Vec[T]): T = apply(oneHot.asBools,inputs)
+  def mux[T <: Data](oneHot : BitVector,inputs : Vec[T]): T = apply(oneHot.asBools, inputs)
   def mux[T <: Data](oneHot : collection.IndexedSeq[Bool],inputs : Vec[T]): T = apply(oneHot, inputs)
 
 
-  def or[T <: Data](oneHot : BitVector,inputs : Seq[T]): T = or(oneHot.asBools,inputs)
+  def or[T <: Data](oneHot : BitVector,inputs : Seq[T]): T = or(oneHot.asBools, inputs)
   def or[T <: Data](oneHot : collection.IndexedSeq[Bool],inputs : Iterable[T]): T =  or(oneHot,Vec(inputs))
-  def or[T <: Data](oneHot : BitVector,inputs : Vec[T]): T = or(oneHot.asBools,inputs)
+  def or[T <: Data](oneHot : BitVector,inputs : Vec[T]): T = or(oneHot.asBools, inputs)
   def or[T <: Data](oneHot : collection.IndexedSeq[Bool],inputs : Vec[T]): T = or(oneHot, inputs, false)
   
   def or[T <: Data](oneHot : BitVector,inputs : Seq[T], bypassIfSingle : Boolean): T = or(oneHot.asBools,inputs, bypassIfSingle)
@@ -141,7 +141,6 @@ class MuxOHImpl {
 
 object MuxOH extends MuxOHImpl
 object OhMux extends MuxOHImpl
-
 
 object Min {
     def apply[T <: Data with Num[T]](nums: T*) = list(nums)
@@ -194,7 +193,7 @@ object SetFromFirstOne{
     tmp.as(that)
   }
 }
-object Napot{
+object Napot {
   /**
    * @return Bits(widthOf(that + 1 bits) which work as a mask which will bet set after the lowest index in which that contains a bit 0
    *         Ex : that = 1111 => 00000
@@ -206,7 +205,7 @@ object Napot{
   def apply(that: Bits, firstOrder: Int = LutInputs.get): Bits = SetFromFirstOne(~that, firstOrder) << 1
 }
 
-object OH{
+object OH {
   def isLegal(that : Bits): Bool = {
     val oneHots = (0 until widthOf(that)).map(e => that === (BigInt(1) << e))
     (oneHots :+ (that === 0)).orR
@@ -246,14 +245,14 @@ object OHMasking{
         cache(offset to target) = inputs.orR.setCompositeName(that, s"range_${offset}_to_${target}")
       }
 
-      if(offset != 0){
+      if(offset != 0) {
         cache(offset to target) || build(offset-1, nextOrder)
       } else {
         cache(offset to target)
       }
     }
 
-    for(i <- 0 until size){
+    for(i <- 0 until size) {
       cache(i to i) = input(i)
       tmp(i) := input(i) && !build(i-1, 1)
     }
@@ -262,13 +261,13 @@ object OHMasking{
   }
 
 
-  //Avoid combinatorial loop on the first
+  // Avoid combinatorial loop on the first
   def first(that : Vec[Bool]) : Vec[Bool] = {
     val bitsFirst = first(that.asBits)
     Vec(that.head +: bitsFirst.asBools.tail)
   }
 
-  //Avoid combinatorial loop on the first
+  // Avoid combinatorial loop on the first
   def first(that : Seq[Bool]) : Vec[Bool] = first(Vec(that))
 
   /** returns an one hot encoded vector with only MSB of the word present */
@@ -279,7 +278,6 @@ object OHMasking{
     ret.assignFromBits(Reverse(masked.asBits))
     ret
   }
-
 
   def roundRobin[T <: Data](requests : T,ohPriority : T) : T = {
     val width = requests.getBitsWidth
@@ -306,7 +304,7 @@ object OHMasking{
   // 0000000 -> 1111111 -> 1111110 -> .. -> 1000000 -> 0000000
   // Ex of priority shift
   //   priority := priority |<< 1
-  //   when(priority === 0){
+  //   when(priority === 0) {
   //     priority := (default -> true)
   //   }
   def roundRobinMasked[T <: Data, T2 <: Data](requests : T, priority : T2) : Bits = new Composite(requests, "roundRobinMasked"){
@@ -320,7 +318,7 @@ object OHMasking{
     val selOh = (pHigh << 1) | pLow
   }.selOh
 
-  //Based on the same principal than roundRobinMasked, but with inverted priorities
+  // Based on the same principal than roundRobinMasked, but with inverted priorities
   def roundRobinMaskedInvert[T <: Data, T2 <: Data](requests : T, priority : T2) : Bits = new Composite(requests, "roundRobinMasked"){
     val input = B(requests).reversed
     val priorityBits = ~B(priority).reversed
@@ -1401,8 +1399,7 @@ class StringPimped(pimped : String){
   }
 }
 
-
-object PriorityMux{
+object PriorityMux {
   def apply[T <: Data](in: Seq[(Bool, T)], msbFirst: Boolean = false): T = {
     if (in.size == 1) {
       in.head._2
@@ -1418,12 +1415,10 @@ object PriorityMux{
   def apply[T <: Data](sel: Bits, in: Seq[T], msbFirst: Boolean): T = apply(sel.asBools.zip(in), msbFirst)
 }
 
-
-
-object WrapWithReg{
+object WrapWithReg {
   def on(c : Component): Unit = {
     for(e <- c.getOrdredNodeIo){
-      if(e.isInput){
+      if(e.isInput) {
         e := RegNext(RegNext(in(cloneOf(e).setName(e.getName))))
       }else{
         out(cloneOf(e).setName(e.getName)) := RegNext(RegNext(e))
@@ -1437,9 +1432,7 @@ object WrapWithReg{
   }
 }
 
-
-
-object Callable{
+object Callable {
   def apply(doIt : => Unit) = new Area{
     val isCalled = False
     when(isCalled){doIt}
@@ -1448,24 +1441,24 @@ object Callable{
   }
 }
 
-case class DataOr[T <: Data](dataType : HardType[T]) extends Area{
+case class DataOr[T <: Data](dataType : HardType[T]) extends Area {
   val value = dataType()
   val values = ArrayBuffer[T]()
-  Component.current.afterElaboration{
+  Component.current.afterElaboration {
     values.size match {
       case 0 => value := value.getZero
       case _ => value.assignFromBits(values.map(_.asBits).reduceBalancedTree(_ | _))
     }
   }
-  def newPort(): T ={
+  def newPort(): T = {
     val port = dataType()
     values += port
     port
   }
 }
 
-object whenMasked{
-  def apply[T](things : TraversableOnce[T], conds : TraversableOnce[Bool])(body : T => Unit): Unit ={
+object whenMasked {
+  def apply[T](things : TraversableOnce[T], conds : TraversableOnce[Bool])(body : T => Unit): Unit = {
     val thingsList = things.toList
     val condsList = conds.toList
     assert(thingsList.size == condsList.size, s"number of things to mask (${things.size}) must match width of conditions (${condsList.size})")
@@ -1477,7 +1470,7 @@ object whenMasked{
   }
 }
 
-object whenIndexed{
+object whenIndexed {
   def apply[T](things : TraversableOnce[T], index : UInt, relaxedWidth : Boolean = false)(body : T => Unit): Unit ={
     val thingsList = things.toList
     var indexPatched = index
@@ -1530,7 +1523,6 @@ case class WhenBuilder() {
     }
 }
 
-
 class ClockDomainPimped(cd : ClockDomain) {
   def withBufferedResetFrom(resetCd : ClockDomain, bufferDepth : Option[Int] = None) : ClockDomain = {
     val key = Tuple3(cd, resetCd,  bufferDepth)
@@ -1546,8 +1538,8 @@ class ClockDomainPimped(cd : ClockDomain) {
   }
 }
 
-object Shift{
-  //Accumulate shifted out bits into the lsb of the result
+object Shift {
+  /** Accumulate shifted out bits into the lsb of the result */
   def rightWithScrap(that : Bits, by : UInt) : Bits = {
     var logic = that
     val scrap = False

--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -1491,11 +1491,15 @@ object whenIndexed{
   }
 }
 
-case class WhenBuilder(){
+/** Allow for example to add `when` programmatically in loops.
+  *
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Semantic/when_switch.html#whenbuilder `WhenBuilder` Documentation]]
+  */
+case class WhenBuilder() {
     var ctx:WhenContext = null
 
     def when(cond : Bool)(body : => Unit): this.type = {
-        if(ctx == null){
+        if(ctx == null) {
             ctx = spinal.core.when(cond){body}
         }
         else{
@@ -1515,7 +1519,7 @@ case class WhenBuilder(){
     }
 
     def otherwise(body : => Unit): Unit = {
-        if(ctx == null){
+        if(ctx == null) {
             body
         }
         else{
@@ -1527,7 +1531,7 @@ case class WhenBuilder(){
 }
 
 
-class ClockDomainPimped(cd : ClockDomain){
+class ClockDomainPimped(cd : ClockDomain) {
   def withBufferedResetFrom(resetCd : ClockDomain, bufferDepth : Option[Int] = None) : ClockDomain = {
     val key = Tuple3(cd, resetCd,  bufferDepth)
     if(resetCd.config.resetKind == BOOT){

--- a/lib/src/main/scala/spinal/lib/bus/regif/Block/RegBase.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Block/RegBase.scala
@@ -23,7 +23,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf, se
   def haveWO = fields.filter(_.isWriteOnly).size != 0
   def readBits: Bits = {
     this.checkLast
-    //when field is WriteOnly, need mask data as 0 for security consider
+    // when field is WriteOnly, need mask data as 0 for security consider
     fields.map(t => if(t.isWriteOnly) B(0, t.getWidth bit) else t.hardbit)
       .reverse
       .foldRight(B(0, 0 bit))(_ ## _)
@@ -45,7 +45,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf, se
 
   protected def RO(bc: BitCount): Bits = Bits(bc)
 
-  protected def _W1[T <: BaseType](reg: T, section: Range): T ={
+  protected def _W1[T <: BaseType](reg: T, section: Range): T = {
     val hardRestFirstFlag = Reg(Bool()) init True
     hardRestFirstFlag.setName(s"${reg.getName}_w1lock_flag", weak = true)
     when(hitDoWrite && hardRestFirstFlag){
@@ -55,7 +55,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf, se
     reg
   }
 
-  protected def W1(bc: BitCount, section: Range, resetValue: BigInt): Bits ={
+  protected def W1(bc: BitCount, section: Range, resetValue: BigInt): Bits = {
     val ret = Reg(Bits(bc)) init B(resetValue)
     val hardRestFirstFlag = Reg(Bool()) init True
     hardRestFirstFlag.setName(s"wlock_flag", weak = true)
@@ -66,14 +66,14 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf, se
     ret
   }
 
-  protected def _W[T <: BaseType](reg: T, section: Range): T ={
+  protected def _W[T <: BaseType](reg: T, section: Range): T = {
     when(hitDoWrite){
       reg.assignFromBits(busif.wdata(reg, section))
     }
     reg
   }
 
-  protected def W(bc: BitCount, section: Range, resetValue: BigInt ): Bits ={
+  protected def W(bc: BitCount, section: Range, resetValue: BigInt ): Bits = {
     val ret = Reg(Bits(bc)) init B(resetValue)
     when(hitDoWrite){
       ret := busif.wdata(ret, section)
@@ -258,7 +258,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf, se
     ret
   }
 
-  protected def _WBR[T <: BaseType](reg: T, section: Range, accType: AccessType): T ={
+  protected def _WBR[T <: BaseType](reg: T, section: Range, accType: AccessType): T = {
     section.reverse.map(_ - section.min).foreach { i =>
       val regbit = reg match {
         case t: Bool => require(section.size == 1); t
@@ -267,7 +267,7 @@ abstract class RegBase(name: String, addr: BigInt, doc: String, busif: BusIf, se
       val x = i + section.min
       accType match {
         case AccessType.W1SRC => {
-          when(hitDoWrite && busif.mwdata(x)) {regbit := busif.wdata(regbit, x, "set" )  }//regbit.set()}
+          when(hitDoWrite && busif.mwdata(x)) {regbit := busif.wdata(regbit, x, "set" )  } //regbit.set()}
             .elsewhen(hitDoRead)              {regbit.clear()} //regbit := busif.wdata(regbit, x, "clear" )
         }
         case AccessType.W1CRS => {


### PR DESCRIPTION
# Context, Motivation & Description

A few weeks ago, I was newcomer to HDL, Spinal and Scala with no prior verilog of VHDL knowledge (but with a electronic and functional programming background).

This PR is an improvement of the scaladoc that I missed when I started to learn SpinalHDL. I added scaladoc for the operator and the basic constructs like `mux`, `when`, etc. with a mention of SpinalHDL. The reason is when you start both Scala and SpinalHDL it's difficult to tell them apart, for example is `===` as Scala construct, are UInt a Scala type. Of course with an IDE you can jump to the class file and check its location, but you are then distracted and it's difficult to concentrate on the code meaning. With the IDE mouse hover text it's much easier (at is on vscode).

1b9c154ba119cc7e is also a correction of typo in a text error. Perhaps it can break some workflows that parse the error. I don't mind if it's not merged, it's not that important.

I also noted there is a `@deprecated` that is not active due to the use of only `//` here:
https://github.com/SpinalHDL/SpinalHDL/blob/2c93394cedce78e885df5cf2b7c6ebebc702ce03/core/src/main/scala/spinal/core/when.scala#L117

I don't know if I should be reactivated or removed.

# Impact on code generation

No impact on code generation.
