### PR TITLE
fix `AFix` bitwise op alignment bug

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -156,11 +156,15 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
   /** Number of bits to represent the numeric value, no sign */
   val numWidth = bitWidth - signWidth
 
+  /** The exponent of the smallest power of 2 bounding the range of the AFix. */
+  val maxExp = exp + numWidth
+  val leftExp = exp + bitWidth
+
   val raw: Bits = Bits(bitWidth bit)
 
   // Representable range, range which could be represented by the backing bit vector
-  private val maxRepr = BigInt(2).pow(numWidth)
-  private val minRepr = BigInt(2).pow(numWidth)+1
+  private val maxRepr: BigInt = BigInt(2).pow(numWidth) - 1
+  private val minRepr: BigInt = if (signed) -BigInt(2).pow(numWidth) else 0
 
   raw.setRefOwner(this)
   raw.setPartialName("", weak = true)
@@ -192,23 +196,6 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
        r.minRaw*BigInt(2).pow(-expDiff))
     } else {
       (l.maxRaw, l.minRaw, r.maxRaw, r.minRaw)
-    }
-  }
-
-  /** Aligns representable ranges of two AFix numbers */
-  private def alignRangesRepr(l: AFix, r: AFix): (BigInt, BigInt, BigInt, BigInt) = {
-    val expDiff = l.exp - r.exp
-    // Scale left or right ranges if there's a difference in precision
-    if (expDiff > 0) {
-      (l.maxRepr*BigInt(2).pow(expDiff),
-        l.minRepr*BigInt(2).pow(expDiff),
-        r.maxRepr, r.minRepr)
-    } else if (expDiff < 0) {
-      (l.maxRepr, l.minRaw,
-        r.maxRepr*BigInt(2).pow(-expDiff),
-        r.minRepr*BigInt(2).pow(-expDiff))
-    } else {
-      (l.maxRepr, l.minRepr, r.maxRepr, r.minRepr)
     }
   }
 
@@ -710,30 +697,21 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
     ret
   }
 
+  def bitwiseOp(right: AFix, op: (Bits, Bits) => Bits): AFix = {
+    val ret = AFix(Math.max(maxExp, right.maxExp) exp, Math.min(exp, right.exp) exp, signed || right.signed)
+    val (lraw, rraw) = alignLR(this, right)
+    val lpad = if (signed) lraw.asSInt.resize(ret.bitWidth).asBits else lraw.resize(ret.bitWidth)
+    val rpad = if (right.signed) rraw.asSInt.resize(ret.bitWidth).asBits else rraw.resize(ret.bitWidth)
+    ret.raw := op(lpad, rpad)
+    ret
+  }
 
   /** Logical AND operator */
-  override def &(right: AFix): AFix = {
-    val (lMax, lMin, rMax, rMin) = alignRangesRepr(this, right)
-    val ret = new AFix(lMax.max(rMin), lMin.min(rMax), Math.min(this.exp, right.exp))
-    ret.raw := this.raw & right.raw
-    ret
-  }
-
+  override def &(right: AFix): AFix = bitwiseOp(right, _ & _)
   /** Logical OR operator */
-  override def |(right: AFix): AFix = {
-    val (lMax, lMin, rMax, rMin) = alignRangesRepr(this, right)
-    val ret = new AFix(lMax.max(rMin), lMin.min(rMax), Math.min(this.exp, right.exp))
-    ret.raw := this.raw | right.raw
-    ret
-  }
-
+  override def |(right: AFix): AFix = bitwiseOp(right, _ | _)
   /** Logical XOR operator */
-  override def ^(right: AFix): AFix = {
-    val (lMax, lMin, rMax, rMin) = alignRangesRepr(this, right)
-    val ret = new AFix(lMax.max(rMin), lMin.min(rMax), Math.min(this.exp, right.exp))
-    ret.raw := this.raw ^ right.raw
-    ret
-  }
+  override def ^(right: AFix): AFix = bitwiseOp(right, _ ^ _)
 
   /** Inverse bitwise operator */
   override def unary_~ : AFix = {

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -133,6 +133,71 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
     }
   }
 
+  test("bitwise_ops") {
+    // testing some obvious properties of bitwise ops with handpicked arbitrary examples
+    SimConfig.compile(new Component {
+      val io = new Bundle {
+        val op = in UInt(2 bits)
+        val a = in(AFix.S(2 exp, -2 exp))
+        val b = in(AFix.S(1 exp, -4 exp))
+        val o = out(AFix.S(2 exp, -4 exp))
+        o.assignDontCare()
+        switch (op) {
+          is(0) {
+            o := a & b
+          }
+          is (1) {
+            o := a | b
+          }
+          is (2) {
+            o := a ^ b
+          }
+          default {
+            o.assignDontCare()
+          }
+        }
+      }
+    }).doSim(seed = 0) { dut =>
+        dut.io.op #= 0
+        dut.io.a #= 0.25
+        dut.io.b #= 0.125
+        sleep(1)
+        assert(dut.io.o.toDouble == 0.0)
+
+        dut.io.a #= 0.75
+        dut.io.b #= 0.375
+        sleep(1)
+        assert(dut.io.o.toDouble == 0.25)
+
+        dut.io.op #= 1
+        dut.io.a #= 0.25
+        dut.io.b #= 0.125
+        sleep(1)
+        assert(dut.io.o.toDouble == 0.375)
+
+        dut.io.a #= 0.75
+        dut.io.b #= 0.375
+        sleep(1)
+        assert(dut.io.o.toDouble == 0.875)
+
+        dut.io.op #= 2
+        dut.io.a #= 0.25
+        dut.io.b #= 0.125
+        sleep(1)
+        assert(dut.io.o.toDouble == 0.375)
+
+        dut.io.a #= 0.75
+        dut.io.b #= 0.375
+        sleep(1)
+        assert(dut.io.o.toDouble == 0.625)
+
+        dut.io.a #= 0.25
+        dut.io.b #= 0.25
+        sleep(1)
+        assert(dut.io.o.toDouble == 0.0)
+    }
+  }
+
   def dutStateString(dut: AFixTester): String = {
     val model = AFixTesterModel(dut)
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

No associated issue

# Context, Motivation & Description

It seems like the bitwise ops for `AFix`es have never been tested. The intent was clear from reading the code, but it didn't work.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented (none needed)