### PR TITLE
add StreamMux.merge to merge multiple streams into one.

### DIFF
--- a/core/src/main/scala/spinal/core/UInt.scala
+++ b/core/src/main/scala/spinal/core/UInt.scala
@@ -87,6 +87,7 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
   override def <=(right: UInt): Bool = wrapLogicalOperator(right, new Operator.UInt.SmallerOrEqual)
   override def >=(right: UInt): Bool = right <= this
   override def >>(that: Int): UInt   = wrapConstantOperator(new Operator.UInt.ShiftRightByInt(that))
+  def *<(that: Int): UInt            = (this * U(that)).resize(log2Up(this.maxValue * that) bits)
   override def <<(that: Int): UInt   = wrapConstantOperator(new Operator.UInt.ShiftLeftByInt(that))
   override def +^(right: UInt): UInt = this.expand + right.expand
   override def -^(right: UInt): UInt = this.expand - right.expand

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -927,6 +927,15 @@ object StreamMux {
     select >> c.io.createStreamRegSelect()
     c.io.output
   }
+  /**
+   * Directly merge multiple streams into a single one, only one stream is valid at a time.
+   */
+  def merge[T <: Data](inputs: Seq[Stream[T]]): Stream[T] = {
+    val c = new StreamMux(inputs(0).payload, inputs.length)
+    (c.io.inputs, inputs).zipped.foreach(_ << _)
+    c.io.select := OHToUInt(inputs.map(_.valid))
+    c.io.output
+  }
 }
 
 class StreamMux[T <: Data](dataType: T, portCount: Int) extends Component {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->


# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

When multiple streams become valid in turn,  it can be directly merged into a single one without an arbiter.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
None
# Checklist

- [ ] Unit tests were added
No
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`
 
