### PR TITLE
Fix buffer name conflict in spinal.lib.misc.pipeline.S2MLink

### DIFF
--- a/lib/src/main/scala/spinal/lib/misc/pipeline/S2MLink.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/S2MLink.scala
@@ -30,7 +30,7 @@ class S2MLink(val up : Node, val down : Node) extends Link {
     val matches = down.fromUp.payload.intersect(up.fromDown.payload)
 
     val rValid = RegInit(False) setWhen (up.isValid) clearWhen (down.ready) setCompositeName(this, "rValid")
-    val rData = matches.map(e => RegNextWhen(up(e), up.ready).setCompositeName(this, "s2mBuffer"))
+    val rData = matches.map(e => RegNextWhen(up(e), up.ready).setCompositeName(up(e), "s2mBuffer"))
 
     up.ready := !rValid
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

`S2MLink` assigns the same name to buffers of different payloads, which causes naming conflict, as shown in the following example:

```scala
object S2MLinkBufferNameConflict extends App {
  case class Top() extends Component {
    val n1, n2 = Node()
    val p1, p2 = Payload(Bool())
    val o = out port Bool()

    val a1 = new n1.Area {
      p1 := True
      p2 := True
    }
    val a2 = new n2.Area {
      o := p1 && p2
    }

    n2.ready := True
    val l = S2MLink(n1, n2)
    Builder(List(l))
  }

  SpinalVerilog(Top())
}
```

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

We can use a name associated with the payload instead.
```scala
    val rData = matches.map(e => RegNextWhen(up(e), up.ready).setCompositeName(up(e), "s2mBuffer"))
```

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
