### PR TITLE
correct reg.name to reg.getName. in DocHtml.scala

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/Doc/DocHtml.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Doc/DocHtml.scala
@@ -97,7 +97,7 @@ object TableTreeNodeImplicits{
   }
 
   implicit class RegSliceExtend(reg: RegSlice) extends TableTreeNode {
-    override val name: String = reg.name
+    override val name: String = reg.getName
     override val children: List[TableTreeNode] = reg.getFields.reverse.map(new FieldExtend(_))
     val regType= reg.regType.toLowerCase
     override def tr_begin = s"""<tr align="left" class="${regType}">""".stripMargin


### PR DESCRIPTION
newReg(doc="example").setName("test")  works for all docs except HTML doc. "reg.name" whitch used by class RegSliceExtend in DocHtml.scala should be "reg.getName".

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1523

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
