### PR TITLE
extract onMismatch method in ScoreboardInOrder

### DIFF
--- a/lib/src/main/scala/spinal/lib/sim/Scoreboard.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Scoreboard.scala
@@ -43,17 +43,21 @@ class ScoreboardInOrder[T]() {
 
   def compare(ref : T, dut : T) = !(ref != dut)
 
+  def onMismatch(ref: T, dut: T) = {
+    println("Transaction mismatch :")
+    println("REF :")
+    println(ref)
+    println("DUT :")
+    println(dut)
+    simFailure()
+  }
+
   def check(): Unit ={
     if(ref.nonEmpty && dut.nonEmpty){
       val dutHead = dut.dequeue()
       val refHead = ref.dequeue()
       if(!compare(refHead, dutHead)){
-        println("Transaction mismatch :")
-        println("REF :")
-        println(refHead)
-        println("DUT :")
-        println(dutHead)
-        simFailure()
+        onMismatch(refHead, dutHead)
       }
       matches += 1
     }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

If we want to change Scoreboard mismatch message currently, we need to override the whole `check` method, and copy the compare logic again.

I wish there could be a better way, so in this commit, the relavant code are copied to a new method.

ps. maybe it's better to leave `simFailure()` outside the new method? Someone may forget to call it when overriding.

# Example usage

```scala
// By this modification, we can use the code below:
val scoreboard = new ScoreboardInOrder[Int] {
  override def onMismatch(ref: Int, dut: Int) = {
    println(s"DUT $dut != REF $ref")
    simFailure()
  }
}

// Currently I have to use this:
val scoreboard = new ScoreboardInOrder[Int] {
  override def check(): Unit ={
    if(ref.nonEmpty && dut.nonEmpty){
      val dutHead = dut.dequeue()
      val refHead = ref.dequeue()
      if(!compare(refHead, dutHead)){
        println(s"DUT $dut != REF $ref")
        simFailure()
      }
      matches += 1
    }
  }
```

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

The modification will not change the existing code generated.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
