### PR TITLE
Bus Slave Factory documentation passthrough

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -413,9 +413,10 @@ trait BusSlaveFactory extends Area{
   def createAndDriveFlow[T <: Data](dataType       : T,
                                     address        : BigInt,
                                     bitOffset      : Int = 0,
-                                    checkByteEnable: Boolean = false): Flow[T] = {
+                                    checkByteEnable: Boolean = false,
+                                    documentation: String = null): Flow[T] = {
     val flow = Flow(dataType)
-    driveFlow(flow, address, bitOffset, checkByteEnable)
+    driveFlow(flow, address, bitOffset, checkByteEnable, documentation)
     flow
   }
 
@@ -513,7 +514,8 @@ trait BusSlaveFactory extends Area{
   def driveFlow[T <: Data](that           : Flow[T],
                            address        : BigInt,
                            bitOffset      : Int = 0,
-                           checkByteEnable: Boolean = false): Unit = {
+                           checkByteEnable: Boolean = false,
+                           documentation: String = null): Unit = {
 
     val wordCount = (bitOffset + widthOf(that.payload) - 1 ) / busDataWidth + 1
     val byteEnable = writeByteEnable()
@@ -527,15 +529,15 @@ trait BusSlaveFactory extends Area{
 
     if (wordCount == 1){
       that.valid := False
-      onWrite(address){ assignValidNext(that.valid) }
-      nonStopWrite(that.payload, bitOffset)
+      onWrite(address, documentation){ assignValidNext(that.valid) }
+      nonStopWrite(that.payload, bitOffset, documentation)
     }else{
 
       assert(bitOffset == 0, "BusSlaveFactory ERROR [driveFlow] : BitOffset must be equal to 0 if the payload of the Flow is bigger than the data bus width")
 
       val regValid = RegNext(False) init(False)
-      onWrite(address + ((wordCount - 1) * wordAddressInc)){ assignValidNext(regValid) }
-      driveMultiWord(that.payload, address)
+      onWrite(address + ((wordCount - 1) * wordAddressInc), documentation){ assignValidNext(regValid) }
+      driveMultiWord(that.payload, address, documentation)
       that.valid := regValid
     }
   }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Some functions in `BusSlaveFactory` were missing a documentation field.

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
