### PR TITLE
add anyseq function to component.

### DIFF
--- a/core/src/main/scala/spinal/core/Component.scala
+++ b/core/src/main/scala/spinal/core/Component.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import spinal.core.internals._
 import spinal.idslplugin.PostInitCallback
+import spinal.core.formal.anyseq
 
 
 object Component {
@@ -96,6 +97,12 @@ abstract class Component extends NameableByComponent with ContextUser with Scala
     this
   }
 
+  /**
+   * Use anyseq on any input signals to this component which do not have existing assignments.
+   */
+  def anyseq_inputs(): Unit = {
+    getAllIo.filter(_.isInput).filter(_.dlcIsEmpty).foreach(anyseq)
+  }
 
   var withHierarchyAutoPull = false
   def withAutoPull(): Unit ={

--- a/core/src/main/scala/spinal/core/Component.scala
+++ b/core/src/main/scala/spinal/core/Component.scala
@@ -100,7 +100,7 @@ abstract class Component extends NameableByComponent with ContextUser with Scala
   /**
    * Use anyseq on any input signals to this component which do not have existing assignments.
    */
-  def anyseq_inputs(): Unit = {
+  def makeInputsAnyseq(): Unit = {
     getAllIo.filter(_.isInput).filter(_.dlcIsEmpty).foreach(anyseq)
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

Borrow from #1659, where anyseq called for all inputs by one function is convenient.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
