### PR TITLE
add initialize argument to StreamFifo 

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -1882,7 +1882,7 @@ class PhaseCheckCrossClock() extends PhaseCheck{
           case node: Expression => node.foreachDrivingExpression(e => walk(e))
         }
       }
-      println(that)
+
       if(!that.isReg){
         that.foreachStatements(walk)
         for(cd <- cds) that.addTag(new ClockDomainReportTag(cd))

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1266,14 +1266,16 @@ object StreamFifo{
   def apply[T <: Data](dataType: HardType[T],
                        depth: Int,
                        latency: Int = 2,
-                       forFMax: Boolean = false): StreamFifo[T] = {
+                       forFMax: Boolean = false,
+                       initPayload: => Option[T] = None): StreamFifo[T] = {
     assert(latency >= 0 && latency <= 2)
     new StreamFifo(
       dataType,
       depth,
       withAsyncRead = latency < 2,
       withBypass = latency == 0,
-      forFMax = forFMax
+      forFMax = forFMax,
+      initPayload = initPayload
     )
   }
 }

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1351,9 +1351,11 @@ class StreamFifo[T <: Data](val dataType: HardType[T],
     }
   }
   val logic = (depth > 1) generate new Area {
-    val vec = useVec generate  initPayload match {
-      case Some(initValue) => Vec(Reg(dataType) init (initValue), depth)
-      case None => Vec(Reg(dataType), depth)
+    val vec = useVec generate {
+      initPayload match {
+        case Some(initValue) => Vec(Reg(dataType) init (initValue), depth)
+        case None => Vec(Reg(dataType), depth)
+      }
     }
     val ram = !useVec generate Mem(dataType, depth)
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
Register constructed `StreamFifo` can be fully initialized when necessary.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
