### PR TITLE
add exclusive arbitration method for StreamArbiterFacotory

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -679,7 +679,7 @@ object StreamArbiter {
       maskProposal := OHMasking.roundRobin(Vec(io.inputs.map(_.valid)),Vec(maskLocked.last +: maskLocked.take(maskLocked.length-1)))
     }
     /** This arbiter requires that only one input is valid at any given time. */
-    def exclusive(core: StreamArbiter[_ <: Data]) = new Area {
+    def assumeOhInput(core: StreamArbiter[_ <: Data]) = new Area {
       import core._
       exclusiveInputs = true
       (maskProposal, io.inputs).zipped.map(_ := _.valid)
@@ -792,8 +792,8 @@ class StreamArbiterFactory {
     arbitrationLogic = StreamArbiter.Arbitration.sequentialOrder
     this
   }
-  def exclusive: this.type = {
-    arbitrationLogic = StreamArbiter.Arbitration.exclusive
+  def assumeOhInput: this.type = {
+    arbitrationLogic = StreamArbiter.Arbitration.assumeOhInput
     this
   }
 

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -678,6 +678,12 @@ object StreamArbiter {
       //maskProposal := maskLocked
       maskProposal := OHMasking.roundRobin(Vec(io.inputs.map(_.valid)),Vec(maskLocked.last +: maskLocked.take(maskLocked.length-1)))
     }
+    /** This arbiter requires that only one input is valid at any given time. */
+    def exclusive(core: StreamArbiter[_ <: Data]) = new Area {
+      import core._
+      exclusiveInputs = true
+      (maskProposal, io.inputs).zipped.map(_ := _.valid)
+    }
   }
 
   /** When a lock activates, the currently chosen input won't change until it is released. */
@@ -725,6 +731,7 @@ class StreamArbiter[T <: Data](dataType: HardType[T], val portCount: Int)(val ar
   }
 
   val locked = RegInit(False).allowUnsetRegToAvoidLatch
+  var exclusiveInputs = false
 
   val maskProposal = Vec(Bool(),portCount)
   val maskLocked = Reg(Vec(Bool(),portCount))
@@ -740,7 +747,7 @@ class StreamArbiter[T <: Data](dataType: HardType[T], val portCount: Int)(val ar
 
   io.output.valid := (io.inputs, maskRouted).zipped.map(_.valid & _).reduce(_ | _)
   io.output.payload := MuxOH(maskRouted,Vec(io.inputs.map(_.payload)))
-  (io.inputs, maskRouted).zipped.foreach(_.ready := _ & io.output.ready)
+  (io.inputs, maskRouted).zipped.foreach { case(input, mask) => input.ready := (Bool(exclusiveInputs) | mask) & io.output.ready }
 
   io.chosenOH := maskRouted.asBits
   io.chosen := OHToUInt(io.chosenOH)
@@ -783,6 +790,10 @@ class StreamArbiterFactory {
   }
   def sequentialOrder: this.type = {
     arbitrationLogic = StreamArbiter.Arbitration.sequentialOrder
+    this
+  }
+  def exclusive: this.type = {
+    arbitrationLogic = StreamArbiter.Arbitration.exclusive
     this
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1662 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
When several streams assert only one at the same time , a simple arbitration logic results in smaller area and better timing.

# Impact on code generation



<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`