### PR TITLE
Introduce Flow.discardWhen() and Stream.discardWhen()

### DIFF
--- a/lib/src/main/scala/spinal/lib/Flow.scala
+++ b/lib/src/main/scala/spinal/lib/Flow.scala
@@ -106,6 +106,20 @@ class Flow[T <: Data](val payloadType: HardType[T]) extends Bundle with IMasterS
     return next
   }
 
+  /**
+   * Discard transactions when cond is true.
+   *
+   * This is the same as throwWhen() but with a semantically clearer function name.
+   * Prefer discardWhen() over throwWhen() for new designs.
+   *
+   * @param cond Condition
+   *
+   * @return The resulting Flow
+   */
+  def discardWhen(cond: Bool): Flow[T] = {
+    this throwWhen(cond)
+  }
+
   def throwWhen(cond: Bool): Flow[T] = {
     this takeWhen (!cond)
   }

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -463,6 +463,20 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
     next.setCompositeName(this, "continueWhen", true)
   }
 
+  /**
+   * Discard transactions when cond is true.
+   *
+   * This is the same as throwWhen() but with a semantically clearer function name.
+   * Prefer discardWhen() over throwWhen() for new designs.
+   *
+   * @param cond Condition
+   *
+   * @return The resulting Stream
+   */
+  def discardWhen(cond: Bool): Stream[T] = {
+    this throwWhen(cond)
+  }
+
 /** Drop transactions of this when cond is True. Return the resulting stream
   */
   def throwWhen(cond: Bool): Stream[T] = {


### PR DESCRIPTION
As discussed separately, this PR introduces `Flow.discardWhen()` and `Stream.discardWhen()`.

The behavior is exactly the same as `Flow.throwWhen()` and `Stream.throwWhen()` (in fact, these are just wrappers) but the function names are semantically a lot clearer / self-explaining.

This does not affect any existing code whatsoever.