### PR TITLE
Fixes for when axi stream isnt a fragment

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Channel.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Channel.scala
@@ -293,7 +293,7 @@ object Axi4AxUnburstified{
         val address     = Axi4.incr(
           address = transaction.addr,
           burst   = if(stream.config.useBurst) transaction.burst else Axi4.burst.INCR,
-          len     = len,
+          len     = if(stream.config.useLen) len else U(0, 8 bits),
           size    = if(stream.config.useSize) transaction.size else U(log2Up(stream.config.bytePerWord)),
           bytePerWord = stream.config.bytePerWord
         )

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Decoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Decoder.scala
@@ -17,7 +17,7 @@ case class Axi4ReadOnlyDecoder(axiConfig: Axi4Config,decodings : Seq[SizeMapping
   val pendingCmdCounter = CounterUpDown(
     stateCount = pendingMax+1,
     incWhen = io.input.readCmd.fire,
-    decWhen = io.input.readRsp.fire && io.input.readRsp.last
+    decWhen = io.input.readRsp.fire && (if(axiConfig.useLast) io.input.readRsp.last else True)
   )
   val decodedCmdSels = decodings.map(_.hit(io.input.readCmd.addr) && io.input.readCmd.valid).asBits
   val decodedCmdError = decodedCmdSels === 0
@@ -77,7 +77,7 @@ case class Axi4WriteOnlyDecoder(axiConfig: Axi4Config,decodings : Seq[SizeMappin
   val pendingDataCounter = CounterUpDown(
     stateCount = pendingMax+1,
     incWhen = cmdAllowedStart,
-    decWhen = io.input.writeData.fire && io.input.writeData.last
+    decWhen = io.input.writeData.fire && (if(axiConfig.useLast) io.input.writeData.last else True)
   )
 
   val decodedCmdSels = decodings.map(_.hit(io.input.writeCmd.addr) && io.input.writeCmd.valid).asBits
@@ -159,7 +159,7 @@ case class Axi4SharedDecoder(axiConfig: Axi4Config,
   val pendingDataCounter = CounterUpDown(
     stateCount = pendingMax+1,
     incWhen = cmdAllowedStart && io.input.sharedCmd.write,
-    decWhen = io.input.writeData.fire && io.input.writeData.last
+    decWhen = io.input.writeData.fire && (if(axiConfig.useLast) io.input.writeData.last else True)
   )
 
   val decodings = readDecodings ++ writeDecodings ++ sharedDecodings

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4SlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4SlaveFactory.scala
@@ -17,7 +17,8 @@ class Axi4SlaveFactory(bus: Axi4) extends BusSlaveFactoryDelayed {
   val writeJoinEvent = StreamJoin.arg(writeCmd, bus.writeData)
   val writeRsp = Stream(Axi4B(bus.config))
   bus.writeRsp << writeRsp.stage()
-  when(bus.writeData.last) {
+  val writeDataLast = if(bus.writeData.last != null) bus.writeData.last else True
+  when(writeDataLast) {
     // backpressure in last beat
     writeJoinEvent.ready := writeRsp.ready && !writeHaltRequest
     writeRsp.valid := writeJoinEvent.fire
@@ -49,7 +50,10 @@ class Axi4SlaveFactory(bus: Axi4) extends BusSlaveFactoryDelayed {
     }
   }
   readRsp.data := 0
-  readRsp.last := readDataStage.last
+
+  if(readRsp.last != null) {
+    readRsp.last := readDataStage.last
+  }
   if(bus.config.useId) readRsp.id := readDataStage.id
 
   val writeOccur = writeJoinEvent.fire


### PR DESCRIPTION
There were a few places related to creating an AXI crossbar that assumes the AXI stream is a fragment stream. This isn't necessarily true all the time. These changes prevent the null pointer exception from happening. 