### PR TITLE
Add method to return a seq of tags of a given type

### DIFF
--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -29,6 +29,8 @@ import scala.collection.mutable.{ArrayBuffer, Stack}
 import spinal.core.internals._
 import spinal.idslplugin.Location
 
+import scala.reflect.ClassTag
+
 trait DummyTrait
 object DummyObject extends DummyTrait
 
@@ -717,6 +719,10 @@ trait SpinalTagReady {
   def filterTag(cond: (SpinalTag) => Boolean): Iterable[SpinalTag] = {
     if(_spinalTags == null) return Nil
     _spinalTags.filter(cond)
+  }
+
+  def getTagsOf[T <: SpinalTag]()(implicit tag: ClassTag[T]) : Set[T] = {
+    getTags().filter(tag.runtimeClass.isInstance(_)).map(_.asInstanceOf[T]).toSet
   }
 
   def addAttribute(attribute: Attribute): this.type = addTag(attribute)

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -721,8 +721,8 @@ trait SpinalTagReady {
     _spinalTags.filter(cond)
   }
 
-  def getTagsOf[T <: SpinalTag]()(implicit tag: ClassTag[T]) : Set[T] = {
-    getTags().filter(tag.runtimeClass.isInstance(_)).map(_.asInstanceOf[T]).toSet
+  def getTagsOf[T <: SpinalTag]()(implicit tag: ClassTag[T]) : Iterable[T] = {
+    getTags().filter(tag.runtimeClass.isInstance(_)).map(_.asInstanceOf[T])
   }
 
   def addAttribute(attribute: Attribute): this.type = addTag(attribute)


### PR DESCRIPTION
There wasn't a convenience function to grab a list of spinal tags and return them by type; this adds that in. 

I needed it for some code I am writing and thought others might also need something like it eventually