### PR TITLE
Add "at " in front of spinal error trace to be similar to java trace

### DIFF
--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -628,13 +628,15 @@ object ScalaLocated {
   def long(scalaTrace: Throwable, tab: String = "    "): String = {
     if(scalaTrace == null) return "???"
 
-    filterStackTrace(scalaTrace.getStackTrace).map(_.toString).filter(filter).map(tab + _ ).mkString("\n") + "\n\n"
+    filterStackTrace(scalaTrace.getStackTrace).map(_.toString).filter(filter).
+      map(tab + "at " + _ ).mkString("\n") + "\n\n"
   }
 
   def long2(trace: Array[StackTraceElement], tab: String = "    "): String = {
     if(trace == null) return "???"
 
-    filterStackTrace(trace).map(_.toString).filter(filter).map(tab + _ ).mkString("\n") + "\n\n"
+    filterStackTrace(trace).map(_.toString).filter(filter).
+      map(tab + "at " + _ ).mkString("\n") + "\n\n"
   }
 
   def short: String = short(new Throwable())


### PR DESCRIPTION
This allows for example in IDE to have link to the faulty line.

# Context, Motivation & Description

When there is a spinal error it is nice to be able to jump directly to the line in an IDE. For the IDE de recognize the line as a scala line, it has to have the same format as scala error stack. This PR add "at " in front of every trace line.

I don't have much java or scala experience, but from that I can find online, java call traces have always this format with "at ".

For example a generated error in VexiiRiscV looks like this in vscode before this PR:
![image](https://github.com/user-attachments/assets/16c973f9-ab02-4c4f-9d3e-db7bfd3fb847)

And will look like this after:
![image](https://github.com/user-attachments/assets/fc7536ea-cca9-412d-ba02-1fbf0dec45b1)


# Checklist

- This could break some tools that parse these error strings, but there are destined for humans so I think the change is fair.
- The the fonction long2 was not tested because I don't know how to use the only code it that use it in the lib (spinal.core.fiber.EngineContext)
