### PR TITLE
Improve assignment overlap error message with previous location

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2467,7 +2467,7 @@ class PhaseCheck_noRegisterAsLatch() extends PhaseCheck{
   }
 }
 
-class PhaseCheck_noLatchNoOverride(pc: PhaseContext) extends PhaseCheck { // Renamed class for clarity
+class PhaseCheck_noLatchNoOverride(pc: PhaseContext) extends PhaseCheck {
   case class AssignmentInfo(bits: AssignedBits, lastLocation: Option[String])
 
   override def impl(pc : PhaseContext): Unit = {
@@ -2591,7 +2591,6 @@ class PhaseCheck_noLatchNoOverride(pc: PhaseContext) extends PhaseCheck { // Ren
                 }
             }
 
-          // --- Conditional Assignment: Switch ---
           case s: SwitchStatement =>
             val location = s.getScalaLocationLong
             val branchBodies = s.elements.map(_.scopeStatement) ++ Option(s.defaultScope)
@@ -2609,10 +2608,7 @@ class PhaseCheck_noLatchNoOverride(pc: PhaseContext) extends PhaseCheck { // Ren
                   val relevantBranches = if (s.isFullyCoveredWithoutDefault || s.defaultScope != null) {
                       branchAssignedsList
                   } else {
-                      // If not fully covered, intersection is only possible if *all* branches that *do* exist assign it.
-                      // However, a true intersection requires assignment in *all* possible paths.
-                      // For simplicity and safety, we won't calculate an intersection if not fully covered.
-                      Seq.empty // Effectively prevents calculating intersection
+                      Seq.empty
                   }
 
                   if (relevantBranches.nonEmpty) {
@@ -2634,7 +2630,6 @@ class PhaseCheck_noLatchNoOverride(pc: PhaseContext) extends PhaseCheck { // Ren
                   }
 
                   intersectionForBt.foreach { finalBits =>
-                    // *** FIX: Call processAssignment with isFullAssignmentCheck = false for merge result ***
                     processAssignment(bt, finalBits, isFullAssignmentCheck = false, location)
                   }
               }
@@ -2651,7 +2646,6 @@ class PhaseCheck_noLatchNoOverride(pc: PhaseContext) extends PhaseCheck { // Ren
 
         // --- Final Checks (Latch/No-Driver) --- performed only on the second pass (!checkOverlap)
         def finalCheck(bt : BaseType): Unit ={
-          // (Content of finalCheck remains the same as your refined version)
           // Hold off until suffix parent is processed
           if (bt.isSuffix)
             return
@@ -2688,7 +2682,7 @@ class PhaseCheck_noLatchNoOverride(pc: PhaseContext) extends PhaseCheck { // Ren
               }
             }
           }
-        } // End finalCheck
+        }
 
 
         if(!checkOverlap) {
@@ -2699,20 +2693,15 @@ class PhaseCheck_noLatchNoOverride(pc: PhaseContext) extends PhaseCheck { // Ren
           subInputsPerScope.get(body).foreach(_.foreach(finalCheck))
         }
 
-        assigneds // Return the assignment map for this scope
-      } // End walkBody
+        assigneds
+      }
 
-      // --- Run the two passes ---
       walkBody(c.dslBody, checkOverlap = true)
       walkBody(c.dslBody, checkOverlap = false)
 
-    }) // End walkComponentsExceptBlackbox
-  } // End impl
+    })
+  }
 }
-// ===============================================
-// End Fixed Code
-// ===============================================
-
 
 class PhaseGetInfoRTL(prunedSignals: mutable.Set[BaseType], unusedSignals: mutable.Set[BaseType], counterRegisters: Ref[Int], blackboxesSourcesPaths: mutable.LinkedHashSet[String])(pc: PhaseContext) extends PhaseCheck {
 


### PR DESCRIPTION
# Context, Motivation & Description

**Context:** The `PhaseCheck_noLatchNoOverride` phase in Spinal HDL performs checks for potential issues in combinatorial logic, including detecting when a signal is fully assigned multiple times within the same scope (assignment overlap).

**Motivation:** The previous error message for `ASSIGNMENT OVERLAP` only reported the source code location of the *second* (or subsequent) assignment that caused the overlap. Users had to manually search backwards in their code to find the *first* assignment that was being completely overwritten. This process was time-consuming and frustrating, especially in complex logic blocks.

**Description:** This PR enhances the usability of the `ASSIGNMENT OVERLAP` error reporting.

1.  It modifies the `PhaseCheck_noLatchNoOverride` phase to track the assigned bits of a signal within a scope and the source code location of the **most recent assignment operation** (`lastLocation`) that affected that signal in the scope. This is managed using a new internal `AssignmentInfo` case class.
2.  When a complete assignment overlap is detected (i.e., a signal is fully assigned again within the same scope, and it's not explicitly allowed via the `allowAssignmentOverride` tag), the generated `PendingError` message is updated.
3.  The new error message now presents **both**:
    *   The source code location of the **offending assignment** (the one causing the overlap).
    *   The source code location of the **previous assignment operation** that occurred just before the offending one within that scope.

This provides developers with immediate context, pointing directly to the two relevant lines of code involved in the overlap, and accelerates the debugging process.

# Impact on code generation

This change affects a compile-time check phase (`PhaseCheck_noLatchNoOverride`) and its error reporting mechanism. It does not alter the logic analysis or the final generated VHDL, Verilog, or SystemVerilog code.

# Checklist

- [ ] Unit tests were added.
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`.
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD).
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged).
