### PR TITLE
sim: Extend logic to retrieve make binary path

### DIFF
--- a/sim/src/main/scala/spinal/Env.scala
+++ b/sim/src/main/scala/spinal/Env.scala
@@ -1,5 +1,34 @@
 package spinal
 
 object SpinalEnv {
-  val makeCmd = sys.env.getOrElse("SPINAL_MAKE_CMD", "make")
+  // Path to the GNU make binary
+  val makeCmd = getMakeBinaryPath()
+
+  /**
+   * This function retrieves the appropriate filesystem path to the "make" binary.
+   *
+   * It uses the following rules/priorities:
+   *   1. If the environment variable "SPINAL_MAKE_CMD" is defined, always use that value
+   *   2. If the OS/platform has a specified entry in this function, use that
+   *   3. Default to "make"
+   *
+   * @note SpinalHDL actually requires GNU Make (gmake on non-GNU platforms).
+   *
+   * @return Filesystem path to the make binary.
+   */
+  def getMakeBinaryPath(): String = {
+    // If the environment variable is defined, always use that
+    val envVal = sys.env.get("SPINAL_MAKE_CMD")
+    if (envVal.isDefined)
+      return envVal.get
+
+    // Platform specific logic
+    val osName = System.getProperty("os.name").toLowerCase
+    val makeBinaryPath = osName match {
+      case "freebsd" => "gmake"
+      case _         => "make"
+    }
+
+    makeBinaryPath
+  }
 }


### PR DESCRIPTION
Some time ago, the environment variable `SPINAL_MAKE_CMD` was introduce on my request to allow overriding the filesystem path to the `make` binary which was previously hardcoded to `"make"`.
This is due to the fact that SpinalHDL requires GNU make. On non-GNU platforms, this is typically `gmake`.

This PR adds logic to default to `"gmake"` on platforms that are known to be non-GNU (FreeBSD in this case).

This change should not affect any existing users as:
1. We always use `SPINAL_MAKE_CMD` if it's defined
2. We always default to `"make"`

Please review this carefully - still new to Scala.