### PR TITLE
Axi4Crossbar: fix pipelining for Axi4 master

### DIFF
--- a/tester/src/test/scala/spinal/tester/scalatest/Axi4InterconnectTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/Axi4InterconnectTester.scala
@@ -26,6 +26,7 @@ object Axi4CrossbarTester{
         axiMasters(1) -> List(axiSlaves(0),axiSlaves(2),axiSlaves(3)),
         axiMasters(2) -> List(axiSlaves(0),axiSlaves(1),axiSlaves(3))
       )
+      .addPipelining(axiMasters(0)) { _ >> _ } { _ >> _ }
 
     val readCrossbar = crossbarFactory.build()
   }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

`addPipelining` would only work for full Axi4 busses when on the slave side. This was because the full axi4 was only split into the read and write only parts on `addSlaves`. Now this also happens when calling `addConnections`.

Respectively I changed the name of the `HashMap` from `axi4SlaveToReadWriteOnly` to `axi4ToReadWriteOnly`.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [ ] ~API changes are or will be documented:~
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
