### PR TITLE
Add an easy way to enable sync resets in FormalConfig

### DIFF
--- a/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
+++ b/core/src/main/scala/spinal/core/formal/FormalBootstraps.scala
@@ -24,7 +24,7 @@ import java.io.{File, PrintWriter}
 import org.apache.commons.io.FileUtils
 import spinal.core.internals.{PhaseContext, PhaseNetlist, DataAssignmentStatement, Operator}
 import spinal.core.sim.SimWorkspace
-import spinal.core.{BlackBox, Component, GlobalData, SpinalConfig, SpinalReport, SpinalWarning, ClockDomain, ASYNC}
+import spinal.core.{BlackBox, Component, GlobalData, SpinalConfig, SpinalReport, SpinalWarning, ClockDomain, ASYNC, SYNC}
 import spinal.core.{Reg, Bool, True, False}
 import spinal.sim._
 
@@ -205,6 +205,12 @@ case class SpinalFormalConfig(
 
   def withConfig(config: SpinalConfig): this.type = {
     _spinalConfig = config
+    this
+  }
+
+  def withSyncResetDefault: this.type = {
+    val syncConfig = _spinalConfig.defaultConfigForClockDomains.copy(resetKind = SYNC)
+    _spinalConfig = _spinalConfig.copy(defaultConfigForClockDomains = syncConfig)
     this
   }
 


### PR DESCRIPTION
# Context, Motivation & Description

Recent versions of yosys do not like to have async resets in the design when running in single clock mode. The error message looks like this:

ERROR: $check cell ... with TRG_WIDTH > 1 is not support by async2sync, use clk2fflogic.

See https://github.com/YosysHQ/yosys/issues/4424 and https://github.com/YosysHQ/yosys/issues/4231

In most cases the issue can be avoided by setting resetKind=SYNC on the default clock domain to make the whole design synchronous.

This PR adds an easy way to do that when creating new FormalConfig

Also related:
#1314
#1435
#1430

# Impact on code generation

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
