### PR TITLE
add Stream.delay and Flow.delay

### DIFF
--- a/lib/src/main/scala/spinal/lib/Flow.scala
+++ b/lib/src/main/scala/spinal/lib/Flow.scala
@@ -172,6 +172,18 @@ class Flow[T <: Data](val payloadType: HardType[T]) extends Bundle with IMasterS
 
   def stage() : Flow[T] = this.m2sPipe().setCompositeName(this, "stage", true)
 
+  /**
+   * Delay the flow by a given number of cycles
+   * @param cycleCount Number of cycles to delay the flow
+   * @return Delayed flow
+   */
+  def delay(cycleCount : Int) : Flow[T] = {
+    cycleCount match {
+      case 0 => this
+      case _ => this.stage().delay(cycleCount - 1)
+    }
+  }
+
   def push(that : T): Unit ={
     valid := True
     payload := that

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -399,6 +399,18 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
     */
   def stage() : Stream[T] = this.m2sPipe().setCompositeName(this, "stage", true)
 
+  /**
+   * Delay the stream by a given number of cycles.
+   * @param cycleCount Number of cycles to delay the stream
+   * @return Delayed stream
+   */
+  def delay(cycleCount: Int): Stream[T] = {
+    cycleCount match {
+      case 0 => this
+      case _ => this.stage().delay(cycleCount - 1)
+    }
+  }
+
   // ! if collapsBubble is enable then ready is not "don't care" during valid low !
   /** Return a stream that cut the ``valid`` and ``payload`` signals through registers.
     * 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
Compared to the  `StreamDelay` component in the lib, this provides a simple implementation to delay the `Stream` with a given number of cycles, which should save some area for small delay cycles.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist


- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`