### PR TITLE
Fix typo in 'isFireing' to 'isFiring' across multiple sources

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Aligner.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Aligner.scala
@@ -108,7 +108,7 @@ class Axi4WriteOnlyAligner(upConfig: Axi4Config, bytesMax : Int, slotsCount : In
       context.write.address := ptr.cmd.resized
       context.write.data.last := LAST
       context.write.data.id := AW.id
-      when(isFireing) {
+      when(isFiring) {
         context.write.valid := True
         slots.onSel(ptr.cmd.resized) { slot =>
           slot.done := False
@@ -194,7 +194,7 @@ class Axi4WriteOnlyAligner(upConfig: Axi4Config, bytesMax : Int, slotsCount : In
       valid := ptr.cmd =/= ptr.fetch
       context.read.cmd.valid := False
       context.read.cmd.payload := ptr.fetch.resized
-      when(isFireing){
+      when(isFiring){
         context.read.cmd.valid := True
         ptr.fetch := ptr.fetch + 1
       }
@@ -204,7 +204,7 @@ class Axi4WriteOnlyAligner(upConfig: Axi4Config, bytesMax : Int, slotsCount : In
       val reader = slots.reader(ptr.rsp.resized)
       val done = reader(_.done)
       val error = reader(_.error)
-      val errorAcc = RegInit(False) setWhen(isFireing && error)
+      val errorAcc = RegInit(False) setWhen(isFiring && error)
 
       io.up.b.valid := False
       io.up.b.id := CTX.id
@@ -212,7 +212,7 @@ class Axi4WriteOnlyAligner(upConfig: Axi4Config, bytesMax : Int, slotsCount : In
       when(error || errorAcc){ io.up.b.setSLVERR() }
       haltWhen(!done)
       haltWhen(io.up.b.isStall)
-      when(isFireing){
+      when(isFiring){
         ptr.rsp := ptr.rsp + 1
       }
       when(valid && done) {
@@ -347,7 +347,7 @@ class Axi4ReadOnlyAligner(upConfig: Axi4Config, bytesMax : Int, slotsCount : Int
       context.write.data.id := AR.id
       context.write.data.header := (AR.addr.resized - CHUNK_START)(blockWordRange).andMask(FIRST)
       context.write.data.ups := split.spliter.CHUNKS_WORDS
-      when(isFireing) {
+      when(isFiring) {
         context.write.valid := True
         slots.onSel(ptr.cmd.resized) { slot =>
           slot.done := False
@@ -397,7 +397,7 @@ class Axi4ReadOnlyAligner(upConfig: Axi4Config, bytesMax : Int, slotsCount : Int
       valid := ptr.cmd =/= ptr.fetch
       context.read.cmd.valid := False
       context.read.cmd.payload := ptr.fetch.resized
-      when(isFireing){
+      when(isFiring){
         context.read.cmd.valid := True
         ptr.fetch := ptr.fetch + 1
       }
@@ -408,7 +408,7 @@ class Axi4ReadOnlyAligner(upConfig: Axi4Config, bytesMax : Int, slotsCount : Int
       val reader = slots.reader(ptr.rsp.resized)
       val done = reader(_.done)
       val error = reader(_.error)
-      val errorAcc = RegInit(False) setWhen (isFireing && error)
+      val errorAcc = RegInit(False) setWhen (isFiring && error)
       val counter = Reg(UInt(blockWordRange.size bits)) init (0)
       val CHUNK_LAST = counter === CTX.ups
       val ERRORED = insert(error || errorAcc)

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Compactor.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Compactor.scala
@@ -150,7 +150,7 @@ class Axi4ReadOnlyCompactor(config: Axi4Config) extends Component {
     val fetch = new Stage{
       driveFrom(io.down.r)
       val R = insert(io.down.r.payload)
-      context.read.cmd.valid := isFireing
+      context.read.cmd.valid := isFiring
       context.read.cmd.payload := io.down.r.id
     }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Ram.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Ram.scala
@@ -25,7 +25,7 @@ class Ram (p : NodeParameters,
       io.up.a.ready := isReady
 
       val addressShifted = (io.up.a.address >> log2Up(p.m.dataBytes))
-      port.enable := isFireing
+      port.enable := isFiring
       port.write := !IS_GET
       port.wdata := io.up.a.data
       port.mask := io.up.a.mask
@@ -57,7 +57,7 @@ class Ram (p : NodeParameters,
           SOURCE := source
           IS_GET := isGet
         }
-        when(isFireing) {
+        when(isFiring) {
           counter := counter + 1
           when(LAST) {
             counter := 0

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/Misc.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/Misc.scala
@@ -41,7 +41,7 @@ class ChannelDataBuffer(entries: Int,
     write.valid := valid && withBeats && !hazard
     write.address := BUFFER_ID @@ CMD.address(log2Up(blockSize)-1 downto log2Up(dataBytes))
     write.data := PAYLOAD
-    when(isFireing && LAST && withBeats) {
+    when(isFiring && LAST && withBeats) {
       set(BUFFER_ID) := True
       locked := False
     }

--- a/lib/src/main/scala/spinal/lib/pipeline/Stage.scala
+++ b/lib/src/main/scala/spinal/lib/pipeline/Stage.scala
@@ -39,7 +39,7 @@ class Stage(implicit _pip: Pipeline = null)  extends Area {
     stage.haltIt(doHalt)
 
     val fired = !syncronous generate new Area {
-      val done = RegInit(False) setWhen(isFireing) clearWhen(isChanging)
+      val done = RegInit(False) setWhen(isFiring) clearWhen(isChanging)
       when(done){
         doHalt := False
         isValid := False
@@ -171,7 +171,12 @@ class Stage(implicit _pip: Pipeline = null)  extends Area {
   def flushNext(cond : Bool) : Unit =  internals.request.flushNext += cond
   def removeIt(): Unit = ???
   def isValid: Bool = internals.input.valid
-  def isFireing: Bool = signalCache(this -> "isFireing")(isValid && isReady).setCompositeName(this, "isFireing")
+
+  @deprecated("Use isFiring instead", "")
+  def isFireing: Bool = isFiring
+
+  def isFiring: Bool = signalCache(this -> "isFiring")(isValid && isReady).setCompositeName(this, "isFiring")
+
   def isFirstCycle: Bool = {
     val wait = RegInit(False) setWhen(isValid) clearWhen(isReady || isFlushed)
     val ret = isValid && !wait


### PR DESCRIPTION
# Context, Motivation & Description

Fix typo in 'isFireing' to 'isFiring' across multiple source files.

NOTE: Old API isFireing is still available but marked `@deprecated`.

# Impact on code generation

As @Readon said, if a signal has "firing" in its name it will be replaced with "firing"

# Checklist

- [N/A] Unit tests were added
- [N/A] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
