### PR TITLE
Switch emit rework

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -945,12 +945,12 @@ class ComponentEmitterVerilog(
                     }
                     if(emitScope)  b ++= s"${tab}  end\n"
                   })
+                  b ++= s"${tab}  default : begin\n"
                   if (nextScope == switchStatement.defaultScope) {
-                    b ++= s"${tab}  default : begin\n"
                     statementIndex = emitLeafStatements(statements, statementIndex, switchStatement.defaultScope, assignmentKind, b, tab + "    ")
                     nextScope = findSwitchScope()
-                    b ++= s"${tab}  end\n"
                   }
+                  b ++= s"${tab}  end\n"
                   b ++= s"${tab}endcase\n"
                 }
               }

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2285,8 +2285,8 @@ class PhaseCompletSwitchCases extends PhaseNetlist{
           if (s.defaultScope != null && !s.defaultScope.isEmpty) {
             PendingError(s"UNREACHABLE DEFAULT STATEMENT on \n" + s.getScalaLocationLong)
           }
-          s.defaultScope = s.elements.last.scopeStatement
-          s.elements.remove(s.elements.length - 1)
+//          s.defaultScope = s.elements.last.scopeStatement
+//          s.elements.remove(s.elements.length - 1)
         }
       case _ =>
     }

--- a/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
+++ b/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
@@ -153,6 +153,7 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
   val wantStart = False
   val wantKill = False
   var autoStart = true
+  var defaultToBootState = false
 
 
   @dontName var parentStateMachine: StateMachineAccessor = null
@@ -222,7 +223,7 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
 
     switch(stateReg){
       for(state <- states){
-        if(state == stateBoot) default {
+        if(defaultToBootState && state == stateBoot) default {
           state.whenActiveTasks.sortBy(_.priority).foreach(_.body())
         } else is(enumOf(state)) {
           state.whenActiveTasks.sortBy(_.priority).foreach(_.body())
@@ -243,7 +244,7 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
 
     switch(stateNext){
       for(state <- states){
-        if(state == stateBoot) default {
+        if(defaultToBootState && state == stateBoot) default {
           state.whenIsNextTasks.foreach(_())
         } else is(enumOf(state)) {
           state.whenIsNextTasks.foreach(_())


### PR DESCRIPTION
So mostly, this PR avoid the verilog backend form emiting very large cases as : 

```verilog
  always @(*) begin
    frontend_checksumIp_push = 1'b0;
    (* parallel_case *)
    case(1) // synthesis parallel_case
      (frontend_stateReg[frontend_INIT_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_ETH_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_DONE_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_IPV4_OH_ID]) : begin
        if(io_input_fire) begin
          frontend_checksumIp_push = ((((frontend_counter != 16'h0002) && (frontend_counter != 16'h0003)) && (frontend_counter != 16'h000a)) && (frontend_counter != 16'h000b));
        end
      end
      (frontend_stateReg[frontend_IPV4_UNKNOWN_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TCP_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_UDP_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_ICMP_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_CS_WRITE_0_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_CS_WRITE_1_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_IP4_LENGTH_0_OH_ID]) : begin
        frontend_checksumIp_push = 1'b1;
      end
      (frontend_stateReg[frontend_IP4_LENGTH_1_OH_ID]) : begin
        frontend_checksumIp_push = 1'b1;
      end
      (frontend_stateReg[frontend_IP4_CS_0_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_IP4_CS_1_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_DATA_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_IP4_LENGTH_0_OH_ID]) : begin
        frontend_checksumIp_push = 1'b1;
      end
      (frontend_stateReg[frontend_TSO_IP4_LENGTH_1_OH_ID]) : begin
        frontend_checksumIp_push = 1'b1;
      end
      (frontend_stateReg[frontend_TSO_IP4_CS_0_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_IP4_CS_1_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_SN_0_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_SN_1_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_SN_2_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_SN_3_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_FLAG_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_CS_0_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_CS_1_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_SPLIT_END_OH_ID]) : begin
      end
      (frontend_stateReg[frontend_TSO_HEADER_CPY_OH_ID]) : begin
      end
      default : begin
      end
    endcase
  end
```

and instead will only emit the cases required to implement the same logic.

This was implemented because some synthesis tools generate unoptimal logic otherwise.