### PR TITLE
Add IEEE 754 and RecFloating testing utility functions and FloatingTester2 that tests BigDecimal assign operator

### DIFF
--- a/tester/src/test/python/spinal/FloatingTestCommon/__init__.py
+++ b/tester/src/test/python/spinal/FloatingTestCommon/__init__.py
@@ -8,6 +8,13 @@ IEEE_EXP_BITS = 8
 IEEE_MANT_BITS = 23
 IEEE_BIAS = (1 << (IEEE_EXP_BITS - 1)) - 1
 
+# RecFloating32 Consts
+REC_EXP_BITS = 9
+REC_MANT_BITS = 23
+REC_EXP_ADD_NORMAL = (1 << (REC_EXP_BITS - 2)) | 1
+REC_EXP_ADD_SUBNORMAL = (1 << (REC_EXP_BITS - 2)) | 3
+REC_EXP_MAX_VAL = (1 << REC_EXP_BITS) - 1
+
 
 def f32_to_bits(f_val):
     return struct.unpack('>I', struct.pack('>f', float(f_val)))[0]
@@ -86,3 +93,66 @@ def get_ieee754_single_fields(val):
                 return {'sign': sign, 'exp_field': 0xFF, 'mant_field': 0, 'category': 'inf'}
 
     return {'sign': sign, 'exp_field': exp_field, 'mant_field': mant_field, 'category': category}
+
+
+def get_recfloat_fields(val, rec_exp_bits=REC_EXP_BITS, rec_mant_bits=REC_MANT_BITS):
+    """
+    Calculates the expected RecFloating fields based on IEEE fields and HardFloat rules.
+    Matches the logic in the provided SpinalHDL 'toRecFloating'.
+
+    Returns: dict {'sign': int, 'exp': int,'mant': int}
+    """
+    ieee = get_ieee754_single_fields(val)
+    ieee_sign = ieee['sign']
+    ieee_exp = ieee['exp_field']
+    ieee_mant = ieee['mant_field']
+
+    rec_sign = ieee_sign
+    rec_exp = 0
+    rec_mant = 0
+
+    is_exponent_zero = (ieee_exp == 0)
+    is_mantissa_zero = (ieee_mant == 0)
+    is_zero = is_exponent_zero and is_mantissa_zero
+    is_inf = (ieee_exp == 0xFF) and is_mantissa_zero
+    is_nan = (ieee_exp == 0xFF) and not is_mantissa_zero
+
+    if is_zero:
+        rec_sign = 0
+        rec_exp = 0
+        rec_mant = 0
+    elif is_inf:
+        rec_sign = ieee_sign
+        rec_exp = 0x180
+        rec_mant = 0
+    elif is_nan:
+        rec_sign = ieee_sign
+        rec_exp_intermediate = 0x180
+        rec_exp = 0x1C0
+        rec_mant = ieee_mant
+    elif is_exponent_zero:
+        if ieee_mant == 0:
+            raise ValueError("Subnormal case called with zero mantissa")
+
+        lzc = IEEE_MANT_BITS - ieee_mant.bit_length()
+        first_mantissa_bit = lzc + 1
+        norm_mant_tmp = ieee_mant << first_mantissa_bit
+        rec_mant = norm_mant_tmp & ((1 << rec_mant_bits) - 1)
+
+        denorm_exp_mask = (1 << rec_exp_bits) - 1
+        first_mantissa_bit_resized = first_mantissa_bit & denorm_exp_mask
+        denorm_exp = denorm_exp_mask ^ first_mantissa_bit_resized
+
+        rec_exp_intermediate = (
+            denorm_exp + REC_EXP_ADD_SUBNORMAL) & denorm_exp_mask
+
+        rec_exp = rec_exp_intermediate
+
+    else:
+
+        rec_exp_intermediate = (
+            ieee_exp + REC_EXP_ADD_NORMAL) & ((1 << rec_exp_bits) - 1)
+        rec_exp = rec_exp_intermediate
+        rec_mant = ieee_mant
+
+    return {'sign': rec_sign, 'exp': rec_exp, 'mant': rec_mant}

--- a/tester/src/test/python/spinal/FloatingTestCommon/__init__.py
+++ b/tester/src/test/python/spinal/FloatingTestCommon/__init__.py
@@ -1,5 +1,88 @@
 
+import math
 import struct
+from decimal import Decimal, getcontext
+
+# IEEE 754 SP Consts
+IEEE_EXP_BITS = 8
+IEEE_MANT_BITS = 23
+IEEE_BIAS = (1 << (IEEE_EXP_BITS - 1)) - 1
+
 
 def f32_to_bits(f_val):
     return struct.unpack('>I', struct.pack('>f', float(f_val)))[0]
+
+
+def get_ieee754_single_fields(val):
+    """
+    Converts a Python float or Decimal into IEEE 754 single-precision fields.
+    Handles normal, subnormal, zero, inf, nan.
+
+    Returns: dict {'sign': int, 'exp_field': int, 'mant_field': int, 'category': str}
+             category is 'zero', 'subnormal', 'normal', 'inf', 'nan'
+    """
+    if isinstance(val, Decimal):
+
+        try:
+            f_val = float(val)
+        except (OverflowError, ValueError):
+
+            if val.is_zero():
+                f_val = 0.0
+            elif val > 0:
+                f_val = float('inf')
+            else:
+                f_val = float('-inf')
+
+    elif isinstance(val, (float, int)):
+        f_val = float(val)
+    else:
+        raise TypeError("Input must be float, int, or Decimal")
+
+    if math.isnan(f_val):
+
+        bits = struct.unpack('>I', struct.pack('>f', f_val))[0]
+        sign = (bits >> 31) & 1
+        exp_field = (bits >> 23) & 0xFF
+        mant_field = bits & 0x7FFFFF
+
+        if mant_field == 0:
+            mant_field = 1 << (IEEE_MANT_BITS - 1)
+        return {'sign': sign, 'exp_field': 0xFF, 'mant_field': mant_field, 'category': 'nan'}
+
+    if math.isinf(f_val):
+        sign = 1 if f_val < 0 else 0
+        return {'sign': sign, 'exp_field': 0xFF, 'mant_field': 0, 'category': 'inf'}
+
+    if f_val == 0.0:
+        sign = 1 if math.copysign(1.0, f_val) < 0 else 0
+        return {'sign': sign, 'exp_field': 0, 'mant_field': 0, 'category': 'zero'}
+
+    sign = 1 if f_val < 0 else 0
+    abs_f_val = abs(f_val)
+
+    m, e = math.frexp(abs_f_val)
+
+    unbiased_exp = e - 1
+
+    if unbiased_exp < -IEEE_BIAS:
+        category = 'subnormal'
+        exp_field = 0
+
+        scale = 1 << (IEEE_BIAS - 1 + IEEE_MANT_BITS)
+        mant_field = int(abs_f_val * scale + 0.5)
+        mant_field &= ((1 << IEEE_MANT_BITS) - 1)
+    else:
+        category = 'normal'
+        exp_field = unbiased_exp + IEEE_BIAS
+
+        mant_field = int((m * 2.0 - 1.0) * (1 << IEEE_MANT_BITS) + 0.5)
+        mant_field &= ((1 << IEEE_MANT_BITS) - 1)
+
+        if mant_field == 0 and m != 0.5:
+            exp_field += 1
+
+            if exp_field >= 0xFF:
+                return {'sign': sign, 'exp_field': 0xFF, 'mant_field': 0, 'category': 'inf'}
+
+    return {'sign': sign, 'exp_field': exp_field, 'mant_field': mant_field, 'category': category}

--- a/tester/src/test/python/spinal/FloatingTestCommon/__init__.py
+++ b/tester/src/test/python/spinal/FloatingTestCommon/__init__.py
@@ -1,7 +1,7 @@
 
 import math
 import struct
-from decimal import Decimal, getcontext
+from decimal import Decimal
 
 # IEEE 754 SP Consts
 IEEE_EXP_BITS = 8

--- a/tester/src/test/python/spinal/FloatingTestCommon/__init__.py
+++ b/tester/src/test/python/spinal/FloatingTestCommon/__init__.py
@@ -1,0 +1,5 @@
+
+import struct
+
+def f32_to_bits(f_val):
+    return struct.unpack('>I', struct.pack('>f', float(f_val)))[0]

--- a/tester/src/test/python/spinal/FloatingTester2/.gitignore
+++ b/tester/src/test/python/spinal/FloatingTester2/.gitignore
@@ -1,0 +1,1 @@
+floatingtester

--- a/tester/src/test/python/spinal/FloatingTester2/.gitignore
+++ b/tester/src/test/python/spinal/FloatingTester2/.gitignore
@@ -1,1 +1,2 @@
 floatingtester
+__pycache__

--- a/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
+++ b/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
@@ -1,0 +1,44 @@
+import cocotb
+from cocotb.triggers import Timer
+from cocotb.result import TestFailure
+import struct
+from decimal import Decimal
+
+from spinal.FloatingTestCommon import f32_to_bits, get_recfloat_fields
+
+
+@cocotb.test()
+async def bigdecimal_conversion_test(dut):
+    """Test BigDecimal to Floating and RecFloating assignments"""
+    await Timer(10, units="ns")
+
+    test_cases = [
+        ("0.0", 0.0)
+    ]
+
+    # Test Case 0.0
+    bd_str, py_float_val = test_cases[0]
+    dut._log.info(f"Testing BigDecimal: {bd_str}")
+
+    # Floating
+    expected_f_bits = f32_to_bits(py_float_val)
+    actual_f_bits = dut.io_f_zero_bits.value.integer
+    if actual_f_bits != expected_f_bits:
+        raise TestFailure(
+            f"Floating['{bd_str}']: Expected 0x{expected_f_bits:08X}, Got 0x{actual_f_bits:08X}")
+
+    # RecFloating
+    expected_rf = get_recfloat_fields(Decimal(bd_str))
+    if expected_rf:
+        if dut.io_rf_zero_sign.value.integer != expected_rf['sign']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_zero_sign.value.integer}")
+        if dut.io_rf_zero_exp.value.integer != expected_rf['exp']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Exp: Expected {expected_rf['exp']}, Got {dut.io_rf_zero_exp.value.integer}")
+        if dut.io_rf_zero_mant.value.integer != expected_rf['mant']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Mant: Expected {expected_rf['mant']}, Got {dut.io_rf_zero_mant.value.integer}")
+    else:
+        dut._log.warning(
+            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_zero_sign.value}, Exp={dut.io_rf_zero_exp.value}, Mant={dut.io_rf_zero_mant.value}")

--- a/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
+++ b/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
@@ -6,13 +6,13 @@ from spinal.FloatingTestCommon import f32_to_bits, get_recfloat_fields
 
 async def check_conversion(dut, bd_str, py_float_val, f_bits_signal_name, rf_sign_signal_name, rf_exp_signal_name, rf_mant_signal_name):
     bd_val = Decimal(bd_str)
-
+    prefix = "io_"
     expected_f_bits = f32_to_bits(py_float_val)
     try:
-        actual_f_bits_signal = getattr(dut, f_bits_signal_name)
+        actual_f_bits_signal = getattr(dut, prefix + f_bits_signal_name)
         actual_f_bits = actual_f_bits_signal.value.integer
     except AttributeError:
-        assert False, f"DUT signal dut.{f_bits_signal_name} not found!"
+        assert False, f"DUT signal dut.{prefix + f_bits_signal_name} not found!"
 
     assert actual_f_bits == expected_f_bits, \
         f"Floating['{bd_str}']: Expected 0x{expected_f_bits:08X}, Got 0x{actual_f_bits:08X}"
@@ -23,9 +23,9 @@ async def check_conversion(dut, bd_str, py_float_val, f_bits_signal_name, rf_sig
         f"Could not calculate expected RecFloat fields for {bd_str}"
 
     try:
-        actual_rf_sign_signal = getattr(dut, rf_sign_signal_name)
-        actual_rf_exp_signal  = getattr(dut, rf_exp_signal_name)
-        actual_rf_mant_signal = getattr(dut, rf_mant_signal_name)
+        actual_rf_sign_signal = getattr(dut, prefix + rf_sign_signal_name)
+        actual_rf_exp_signal  = getattr(dut, prefix + rf_exp_signal_name)
+        actual_rf_mant_signal = getattr(dut, prefix + rf_mant_signal_name)
 
         actual_rf_sign = actual_rf_sign_signal.value.integer
         actual_rf_exp  = actual_rf_exp_signal.value.integer

--- a/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
+++ b/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
@@ -14,7 +14,8 @@ async def bigdecimal_conversion_test(dut):
 
     test_cases = [
         ("0.0", 0.0),
-        ("1.5", 1.5)
+        ("1.5", 1.5),
+        ("-2.0", -2.0)
     ]
 
     # Test Case 0.0
@@ -71,3 +72,32 @@ async def bigdecimal_conversion_test(dut):
     else:
         dut._log.warning(
             f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_one_point_five_sign.value}, Exp={dut.io_rf_one_point_five_exp.value}, Mant={dut.io_rf_one_point_five_mant.value}")
+
+    # Test Case -2.0
+    bd_str, py_float_val = test_cases[2]
+    dut._log.info(f"Testing BigDecimal: {bd_str}")
+    expected_f_bits = f32_to_bits(py_float_val)  # Standard: 0xC0000000
+    actual_f_bits = dut.io_f_neg_two_bits.value.integer
+    if actual_f_bits != expected_f_bits:
+        dut._log.warning(
+            f"Floating['{bd_str}']: Expected (standard IEEE) 0x{expected_f_bits:08X}, Got (DUT logic) 0x{actual_f_bits:08X}")
+        # Trace Floating.:= for -2.0: SA=22, FBI=1. Mant=0. Exp_val = 127+1 = 128 (0x80)
+        # Sign=1, Exp=0x80, Mant=0 -> 1_10000000_000...0 = 0xC0000000. Should match.
+        if actual_f_bits != 0xC0000000:
+            raise TestFailure(
+                f"Floating['{bd_str}']: Expected 0xC0000000, Got 0x{actual_f_bits:08X}")
+
+    expected_rf = get_recfloat_fields(Decimal(bd_str))
+    if expected_rf:
+        if dut.io_rf_neg_two_sign.value.integer != expected_rf['sign']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_neg_two_sign.value.integer}")
+        if dut.io_rf_neg_two_exp.value.integer != expected_rf['exp']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Exp: Expected 0x{expected_rf['exp']:X}, Got 0x{dut.io_rf_neg_two_exp.value.integer:X}")
+        if dut.io_rf_neg_two_mant.value.integer != expected_rf['mant']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Mant: Expected 0x{expected_rf['mant']:X}, Got 0x{dut.io_rf_neg_two_mant.value.integer:X}")
+    else:
+        dut._log.warning(
+            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_neg_two_sign.value}, Exp={dut.io_rf_neg_two_exp.value}, Mant={dut.io_rf_neg_two_mant.value}")

--- a/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
+++ b/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
@@ -15,7 +15,8 @@ async def bigdecimal_conversion_test(dut):
         ("0.0", 0.0),
         ("1.5", 1.5),
         ("-2.0", -2.0),
-        ("0.125", 0.125)
+        ("0.125", 0.125),
+        ("0.0009765625", 0.0009765625)
     ]
 
     # Test Case 0.0
@@ -130,3 +131,35 @@ async def bigdecimal_conversion_test(dut):
     else:
         dut._log.warning(
             f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_one_eighth_sign.value}, Exp={dut.io_rf_one_eighth_exp.value}, Mant={dut.io_rf_one_eighth_mant.value}")
+
+    # Test Case 0.0009765625 (2^-10)
+    bd_str, py_float_val = test_cases[4]
+    dut._log.info(f"Testing BigDecimal: {bd_str}")
+    expected_f_bits = f32_to_bits(py_float_val)  # Standard: 0x3A800000
+    actual_f_bits = dut.io_f_small_val_bits.value.integer
+    if actual_f_bits != expected_f_bits:
+        dut._log.warning(
+            f"Floating['{bd_str}']: Expected (standard IEEE) 0x{expected_f_bits:08X}, Got (DUT logic) 0x{actual_f_bits:08X}")
+        # Trace Floating.:= for 2^-10: SA=33, FBI=-10. Mant=0. Exp_val = 127-10 = 117 (0x75)
+        # Sign=0, Exp=0x75, Mant=0 -> 0_01110101_000...0 = 0x3A800000. Should match.
+        if actual_f_bits != 0x3A800000:
+            raise TestFailure(
+                f"Floating['{bd_str}']: Expected 0x3A800000, Got 0x{actual_f_bits:08X}")
+
+    expected_rf = get_recfloat_fields(Decimal(bd_str))
+    if expected_rf:
+        if dut.io_rf_small_val_sign.value.integer != expected_rf['sign']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_small_val_sign.value.integer}")
+        if dut.io_rf_small_val_exp.value.integer != expected_rf['exp']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Exp: Expected 0x{expected_rf['exp']:X}, Got 0x{dut.io_rf_small_val_exp.value.integer:X}")
+        if dut.io_rf_small_val_mant.value.integer != expected_rf['mant']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Mant: Expected 0x{expected_rf['mant']:X}, Got 0x{dut.io_rf_small_val_mant.value.integer:X}")
+    else:
+        dut._log.warning(
+            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_small_val_sign.value}, Exp={dut.io_rf_small_val_exp.value}, Mant={dut.io_rf_small_val_mant.value}")
+
+    dut._log.info(
+        "All BigDecimal conversion checks passed for implemented cases.")

--- a/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
+++ b/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
@@ -1,7 +1,6 @@
 import cocotb
 from cocotb.triggers import Timer
 from cocotb.result import TestFailure
-import struct
 from decimal import Decimal
 
 from spinal.FloatingTestCommon import f32_to_bits, get_recfloat_fields
@@ -15,7 +14,8 @@ async def bigdecimal_conversion_test(dut):
     test_cases = [
         ("0.0", 0.0),
         ("1.5", 1.5),
-        ("-2.0", -2.0)
+        ("-2.0", -2.0),
+        ("0.125", 0.125)
     ]
 
     # Test Case 0.0
@@ -101,3 +101,32 @@ async def bigdecimal_conversion_test(dut):
     else:
         dut._log.warning(
             f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_neg_two_sign.value}, Exp={dut.io_rf_neg_two_exp.value}, Mant={dut.io_rf_neg_two_mant.value}")
+
+    # Test Case 0.125
+    bd_str, py_float_val = test_cases[3]
+    dut._log.info(f"Testing BigDecimal: {bd_str}")
+    expected_f_bits = f32_to_bits(py_float_val)  # Standard: 0x3E000000
+    actual_f_bits = dut.io_f_one_eighth_bits.value.integer
+    if actual_f_bits != expected_f_bits:
+        dut._log.warning(
+            f"Floating['{bd_str}']: Expected (standard IEEE) 0x{expected_f_bits:08X}, Got (DUT logic) 0x{actual_f_bits:08X}")
+        # Trace Floating.:= for 0.125: SA=26, FBI=-3. Mant=0. Exp_val = 127-3 = 124 (0x7C)
+        # Sign=0, Exp=0x7C, Mant=0 -> 0_01111100_000...0 = 0x3E000000. Should match.
+        if actual_f_bits != 0x3E000000:
+            raise TestFailure(
+                f"Floating['{bd_str}']: Expected 0x3E000000, Got 0x{actual_f_bits:08X}")
+
+    expected_rf = get_recfloat_fields(Decimal(bd_str))
+    if expected_rf:
+        if dut.io_rf_one_eighth_sign.value.integer != expected_rf['sign']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_one_eighth_sign.value.integer}")
+        if dut.io_rf_one_eighth_exp.value.integer != expected_rf['exp']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Exp: Expected 0x{expected_rf['exp']:X}, Got 0x{dut.io_rf_one_eighth_exp.value.integer:X}")
+        if dut.io_rf_one_eighth_mant.value.integer != expected_rf['mant']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Mant: Expected 0x{expected_rf['mant']:X}, Got 0x{dut.io_rf_one_eighth_mant.value.integer:X}")
+    else:
+        dut._log.warning(
+            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_one_eighth_sign.value}, Exp={dut.io_rf_one_eighth_exp.value}, Mant={dut.io_rf_one_eighth_mant.value}")

--- a/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
+++ b/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
@@ -13,7 +13,8 @@ async def bigdecimal_conversion_test(dut):
     await Timer(10, units="ns")
 
     test_cases = [
-        ("0.0", 0.0)
+        ("0.0", 0.0),
+        ("1.5", 1.5)
     ]
 
     # Test Case 0.0
@@ -42,3 +43,31 @@ async def bigdecimal_conversion_test(dut):
     else:
         dut._log.warning(
             f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_zero_sign.value}, Exp={dut.io_rf_zero_exp.value}, Mant={dut.io_rf_zero_mant.value}")
+
+    # Test Case 1.5
+    bd_str, py_float_val = test_cases[1]
+    dut._log.info(f"Testing BigDecimal: {bd_str}")
+
+    expected_f_bits = f32_to_bits(py_float_val)
+    actual_f_bits = dut.io_f_one_point_five_bits.value.integer
+    if actual_f_bits != expected_f_bits:
+        dut._log.warning(
+            f"Floating['{bd_str}']: Expected (standard IEEE) 0x{expected_f_bits:08X}, Got (DUT logic) 0x{actual_f_bits:08X}")
+        if actual_f_bits != 0x3FC00000:  # Standard for 1.5f
+            raise TestFailure(
+                f"Floating['{bd_str}']: Expected 0x3FC00000, Got 0x{actual_f_bits:08X}")
+
+    expected_rf = get_recfloat_fields(Decimal(bd_str))
+    if expected_rf:
+        if dut.io_rf_one_point_five_sign.value.integer != expected_rf['sign']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_one_point_five_sign.value.integer}")
+        if dut.io_rf_one_point_five_exp.value.integer != expected_rf['exp']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Exp: Expected 0x{expected_rf['exp']:X}, Got 0x{dut.io_rf_one_point_five_exp.value.integer:X}")
+        if dut.io_rf_one_point_five_mant.value.integer != expected_rf['mant']:
+            raise TestFailure(
+                f"RecFloating['{bd_str}'] Mant: Expected 0x{expected_rf['mant']:X}, Got 0x{dut.io_rf_one_point_five_mant.value.integer:X}")
+    else:
+        dut._log.warning(
+            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_one_point_five_sign.value}, Exp={dut.io_rf_one_point_five_exp.value}, Mant={dut.io_rf_one_point_five_mant.value}")

--- a/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
+++ b/tester/src/test/python/spinal/FloatingTester2/FloatingTester2.py
@@ -1,165 +1,65 @@
 import cocotb
 from cocotb.triggers import Timer
-from cocotb.result import TestFailure
 from decimal import Decimal
 
 from spinal.FloatingTestCommon import f32_to_bits, get_recfloat_fields
 
+async def check_conversion(dut, bd_str, py_float_val, f_bits_signal_name, rf_sign_signal_name, rf_exp_signal_name, rf_mant_signal_name):
+    bd_val = Decimal(bd_str)
+
+    expected_f_bits = f32_to_bits(py_float_val)
+    try:
+        actual_f_bits_signal = getattr(dut, f_bits_signal_name)
+        actual_f_bits = actual_f_bits_signal.value.integer
+    except AttributeError:
+        assert False, f"DUT signal dut.{f_bits_signal_name} not found!"
+
+    assert actual_f_bits == expected_f_bits, \
+        f"Floating['{bd_str}']: Expected 0x{expected_f_bits:08X}, Got 0x{actual_f_bits:08X}"
+
+    expected_rf = get_recfloat_fields(bd_val)
+
+    assert expected_rf is not None, \
+        f"Could not calculate expected RecFloat fields for {bd_str}"
+
+    try:
+        actual_rf_sign_signal = getattr(dut, rf_sign_signal_name)
+        actual_rf_exp_signal  = getattr(dut, rf_exp_signal_name)
+        actual_rf_mant_signal = getattr(dut, rf_mant_signal_name)
+
+        actual_rf_sign = actual_rf_sign_signal.value.integer
+        actual_rf_exp  = actual_rf_exp_signal.value.integer
+        actual_rf_mant = actual_rf_mant_signal.value.integer
+    except AttributeError as e:
+        assert False, f"DUT signal access error: {e}"
+
+
+    # Compare fields
+    assert actual_rf_sign == expected_rf['sign'], \
+        f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {actual_rf_sign}"
+
+    assert actual_rf_exp == expected_rf['exp'], \
+        f"RecFloating['{bd_str}'] Exp: Expected 0x{expected_rf['exp']:03X}, Got 0x{actual_rf_exp:03X}"
+
+    assert actual_rf_mant == expected_rf['mant'], \
+        f"RecFloating['{bd_str}'] Mant: Expected 0x{expected_rf['mant']:06X}, Got 0x{actual_rf_mant:06X}"
 
 @cocotb.test()
 async def bigdecimal_conversion_test(dut):
-    """Test BigDecimal to Floating and RecFloating assignments"""
-    await Timer(10, units="ns")
+    """Test BigDecimal to Floating and RecFloating assignments."""
+    await Timer(10, units="ns") # Allow signals to settle
 
-    test_cases = [
-        ("0.0", 0.0),
-        ("1.5", 1.5),
-        ("-2.0", -2.0),
-        ("0.125", 0.125),
-        ("0.0009765625", 0.0009765625)
+    test_data = [
+        # ("<bd_str>",  <py_float>,    "<f_signal>",          "<rf_s_sig>",           "<rf_e_sig>",                "<rf_m_sig>")
+        ("0.0",          0.0,          "f_zero_bits",          "rf_zero_sign",          "rf_zero_exp",          "rf_zero_mant"),
+        ("1.5",          1.5,          "f_one_point_five_bits","rf_one_point_five_sign","rf_one_point_five_exp","rf_one_point_five_mant"),
+        ("-2.0",         -2.0,         "f_neg_two_bits",       "rf_neg_two_sign",       "rf_neg_two_exp",       "rf_neg_two_mant"),
+        ("0.125",        0.125,        "f_one_eighth_bits",    "rf_one_eighth_sign",    "rf_one_eighth_exp",    "rf_one_eighth_mant"),
+        ("0.0009765625", 0.0009765625, "f_small_val_bits",     "rf_small_val_sign",     "rf_small_val_exp",     "rf_small_val_mant"),
     ]
 
-    # Test Case 0.0
-    bd_str, py_float_val = test_cases[0]
-    dut._log.info(f"Testing BigDecimal: {bd_str}")
+    for test_case in test_data:
+        bd_s, py_f, f_sig, rf_s_sig, rf_e_sig, rf_m_sig = test_case
+        await check_conversion(dut, bd_s, py_f, f_sig, rf_s_sig, rf_e_sig, rf_m_sig)
 
-    # Floating
-    expected_f_bits = f32_to_bits(py_float_val)
-    actual_f_bits = dut.io_f_zero_bits.value.integer
-    if actual_f_bits != expected_f_bits:
-        raise TestFailure(
-            f"Floating['{bd_str}']: Expected 0x{expected_f_bits:08X}, Got 0x{actual_f_bits:08X}")
-
-    # RecFloating
-    expected_rf = get_recfloat_fields(Decimal(bd_str))
-    if expected_rf:
-        if dut.io_rf_zero_sign.value.integer != expected_rf['sign']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_zero_sign.value.integer}")
-        if dut.io_rf_zero_exp.value.integer != expected_rf['exp']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Exp: Expected {expected_rf['exp']}, Got {dut.io_rf_zero_exp.value.integer}")
-        if dut.io_rf_zero_mant.value.integer != expected_rf['mant']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Mant: Expected {expected_rf['mant']}, Got {dut.io_rf_zero_mant.value.integer}")
-    else:
-        dut._log.warning(
-            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_zero_sign.value}, Exp={dut.io_rf_zero_exp.value}, Mant={dut.io_rf_zero_mant.value}")
-
-    # Test Case 1.5
-    bd_str, py_float_val = test_cases[1]
-    dut._log.info(f"Testing BigDecimal: {bd_str}")
-
-    expected_f_bits = f32_to_bits(py_float_val)
-    actual_f_bits = dut.io_f_one_point_five_bits.value.integer
-    if actual_f_bits != expected_f_bits:
-        dut._log.warning(
-            f"Floating['{bd_str}']: Expected (standard IEEE) 0x{expected_f_bits:08X}, Got (DUT logic) 0x{actual_f_bits:08X}")
-        if actual_f_bits != 0x3FC00000:  # Standard for 1.5f
-            raise TestFailure(
-                f"Floating['{bd_str}']: Expected 0x3FC00000, Got 0x{actual_f_bits:08X}")
-
-    expected_rf = get_recfloat_fields(Decimal(bd_str))
-    if expected_rf:
-        if dut.io_rf_one_point_five_sign.value.integer != expected_rf['sign']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_one_point_five_sign.value.integer}")
-        if dut.io_rf_one_point_five_exp.value.integer != expected_rf['exp']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Exp: Expected 0x{expected_rf['exp']:X}, Got 0x{dut.io_rf_one_point_five_exp.value.integer:X}")
-        if dut.io_rf_one_point_five_mant.value.integer != expected_rf['mant']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Mant: Expected 0x{expected_rf['mant']:X}, Got 0x{dut.io_rf_one_point_five_mant.value.integer:X}")
-    else:
-        dut._log.warning(
-            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_one_point_five_sign.value}, Exp={dut.io_rf_one_point_five_exp.value}, Mant={dut.io_rf_one_point_five_mant.value}")
-
-    # Test Case -2.0
-    bd_str, py_float_val = test_cases[2]
-    dut._log.info(f"Testing BigDecimal: {bd_str}")
-    expected_f_bits = f32_to_bits(py_float_val)  # Standard: 0xC0000000
-    actual_f_bits = dut.io_f_neg_two_bits.value.integer
-    if actual_f_bits != expected_f_bits:
-        dut._log.warning(
-            f"Floating['{bd_str}']: Expected (standard IEEE) 0x{expected_f_bits:08X}, Got (DUT logic) 0x{actual_f_bits:08X}")
-        # Trace Floating.:= for -2.0: SA=22, FBI=1. Mant=0. Exp_val = 127+1 = 128 (0x80)
-        # Sign=1, Exp=0x80, Mant=0 -> 1_10000000_000...0 = 0xC0000000. Should match.
-        if actual_f_bits != 0xC0000000:
-            raise TestFailure(
-                f"Floating['{bd_str}']: Expected 0xC0000000, Got 0x{actual_f_bits:08X}")
-
-    expected_rf = get_recfloat_fields(Decimal(bd_str))
-    if expected_rf:
-        if dut.io_rf_neg_two_sign.value.integer != expected_rf['sign']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_neg_two_sign.value.integer}")
-        if dut.io_rf_neg_two_exp.value.integer != expected_rf['exp']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Exp: Expected 0x{expected_rf['exp']:X}, Got 0x{dut.io_rf_neg_two_exp.value.integer:X}")
-        if dut.io_rf_neg_two_mant.value.integer != expected_rf['mant']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Mant: Expected 0x{expected_rf['mant']:X}, Got 0x{dut.io_rf_neg_two_mant.value.integer:X}")
-    else:
-        dut._log.warning(
-            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_neg_two_sign.value}, Exp={dut.io_rf_neg_two_exp.value}, Mant={dut.io_rf_neg_two_mant.value}")
-
-    # Test Case 0.125
-    bd_str, py_float_val = test_cases[3]
-    dut._log.info(f"Testing BigDecimal: {bd_str}")
-    expected_f_bits = f32_to_bits(py_float_val)  # Standard: 0x3E000000
-    actual_f_bits = dut.io_f_one_eighth_bits.value.integer
-    if actual_f_bits != expected_f_bits:
-        dut._log.warning(
-            f"Floating['{bd_str}']: Expected (standard IEEE) 0x{expected_f_bits:08X}, Got (DUT logic) 0x{actual_f_bits:08X}")
-        # Trace Floating.:= for 0.125: SA=26, FBI=-3. Mant=0. Exp_val = 127-3 = 124 (0x7C)
-        # Sign=0, Exp=0x7C, Mant=0 -> 0_01111100_000...0 = 0x3E000000. Should match.
-        if actual_f_bits != 0x3E000000:
-            raise TestFailure(
-                f"Floating['{bd_str}']: Expected 0x3E000000, Got 0x{actual_f_bits:08X}")
-
-    expected_rf = get_recfloat_fields(Decimal(bd_str))
-    if expected_rf:
-        if dut.io_rf_one_eighth_sign.value.integer != expected_rf['sign']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_one_eighth_sign.value.integer}")
-        if dut.io_rf_one_eighth_exp.value.integer != expected_rf['exp']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Exp: Expected 0x{expected_rf['exp']:X}, Got 0x{dut.io_rf_one_eighth_exp.value.integer:X}")
-        if dut.io_rf_one_eighth_mant.value.integer != expected_rf['mant']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Mant: Expected 0x{expected_rf['mant']:X}, Got 0x{dut.io_rf_one_eighth_mant.value.integer:X}")
-    else:
-        dut._log.warning(
-            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_one_eighth_sign.value}, Exp={dut.io_rf_one_eighth_exp.value}, Mant={dut.io_rf_one_eighth_mant.value}")
-
-    # Test Case 0.0009765625 (2^-10)
-    bd_str, py_float_val = test_cases[4]
-    dut._log.info(f"Testing BigDecimal: {bd_str}")
-    expected_f_bits = f32_to_bits(py_float_val)  # Standard: 0x3A800000
-    actual_f_bits = dut.io_f_small_val_bits.value.integer
-    if actual_f_bits != expected_f_bits:
-        dut._log.warning(
-            f"Floating['{bd_str}']: Expected (standard IEEE) 0x{expected_f_bits:08X}, Got (DUT logic) 0x{actual_f_bits:08X}")
-        # Trace Floating.:= for 2^-10: SA=33, FBI=-10. Mant=0. Exp_val = 127-10 = 117 (0x75)
-        # Sign=0, Exp=0x75, Mant=0 -> 0_01110101_000...0 = 0x3A800000. Should match.
-        if actual_f_bits != 0x3A800000:
-            raise TestFailure(
-                f"Floating['{bd_str}']: Expected 0x3A800000, Got 0x{actual_f_bits:08X}")
-
-    expected_rf = get_recfloat_fields(Decimal(bd_str))
-    if expected_rf:
-        if dut.io_rf_small_val_sign.value.integer != expected_rf['sign']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Sign: Expected {expected_rf['sign']}, Got {dut.io_rf_small_val_sign.value.integer}")
-        if dut.io_rf_small_val_exp.value.integer != expected_rf['exp']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Exp: Expected 0x{expected_rf['exp']:X}, Got 0x{dut.io_rf_small_val_exp.value.integer:X}")
-        if dut.io_rf_small_val_mant.value.integer != expected_rf['mant']:
-            raise TestFailure(
-                f"RecFloating['{bd_str}'] Mant: Expected 0x{expected_rf['mant']:X}, Got 0x{dut.io_rf_small_val_mant.value.integer:X}")
-    else:
-        dut._log.warning(
-            f"RecFloating['{bd_str}']: No pre-calculated expectation. Sign={dut.io_rf_small_val_sign.value}, Exp={dut.io_rf_small_val_exp.value}, Mant={dut.io_rf_small_val_mant.value}")
-
-    dut._log.info(
-        "All BigDecimal conversion checks passed for implemented cases.")
+    dut._log.info("All BigDecimal conversion checks passed.")

--- a/tester/src/test/python/spinal/FloatingTester2/Makefile
+++ b/tester/src/test/python/spinal/FloatingTester2/Makefile
@@ -1,0 +1,15 @@
+include ../common/Makefile.def
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+	VERILOG_SOURCES += $(SPINALROOT)/FloatingTester2.v
+	TOPLEVEL=FloatingTester2
+endif
+
+ifeq ($(TOPLEVEL_LANG),vhdl)
+	VHDL_SOURCES += $(SPINALROOT)/FloatingTester2.vhd
+	TOPLEVEL=floatingtester2
+endif
+
+MODULE=FloatingTester2
+
+include ../common/Makefile.sim

--- a/tester/src/test/python/spinal/FloatingTester2/__init__.py
+++ b/tester/src/test/python/spinal/FloatingTester2/__init__.py
@@ -1,0 +1,1 @@
+#!/bin/env python

--- a/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
+++ b/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
@@ -14,6 +14,12 @@ class FloatingTester2 extends Component {
     val rf_zero_exp = out Bits (9 bits)
     val rf_zero_mant = out Bits (23 bits)
 
+    // Test Case: BigDecimal("1.5")
+    val f_one_point_five_bits = out Bits(32 bits)
+    val rf_one_point_five_sign = out Bool()
+    val rf_one_point_five_exp = out Bits(9 bits)
+    val rf_one_point_five_mant = out Bits(23 bits)
+
   }
 
   // Test Case: BigDecimal("0.0")
@@ -26,6 +32,17 @@ class FloatingTester2 extends Component {
   io.rf_zero_sign := rf_zero.sign
   io.rf_zero_exp := rf_zero.exponent
   io.rf_zero_mant := rf_zero.mantissa
+
+  // Test Case: BigDecimal("1.5")
+  val f_one_point_five = Floating32()
+  f_one_point_five := BigDecimal("1.5")
+  io.f_one_point_five_bits := f_one_point_five.asBits
+
+  val rf_one_point_five = RecFloating32()
+  rf_one_point_five := BigDecimal("1.5")
+  io.rf_one_point_five_sign := rf_one_point_five.sign
+  io.rf_one_point_five_exp := rf_one_point_five.exponent
+  io.rf_one_point_five_mant := rf_one_point_five.mantissa
 
 }
 

--- a/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
+++ b/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
@@ -25,6 +25,13 @@ class FloatingTester2 extends Component {
     val rf_neg_two_sign = out Bool()
     val rf_neg_two_exp = out Bits(9 bits)
     val rf_neg_two_mant = out Bits(23 bits)
+
+    
+    // Test Case: BigDecimal("0.125") (1/8)
+    val f_one_eighth_bits = out Bits(32 bits)
+    val rf_one_eighth_sign = out Bool()
+    val rf_one_eighth_exp = out Bits(9 bits)
+    val rf_one_eighth_mant = out Bits(23 bits)
   }
 
   // Test Case: BigDecimal("0.0")
@@ -59,6 +66,17 @@ class FloatingTester2 extends Component {
   io.rf_neg_two_sign := rf_neg_two.sign
   io.rf_neg_two_exp := rf_neg_two.exponent
   io.rf_neg_two_mant := rf_neg_two.mantissa
+
+  // Test Case: BigDecimal("0.125")
+  val f_one_eighth = Floating32()
+  f_one_eighth := BigDecimal("0.125")
+  io.f_one_eighth_bits := f_one_eighth.asBits
+
+  val rf_one_eighth = RecFloating32()
+  rf_one_eighth := BigDecimal("0.125")
+  io.rf_one_eighth_sign := rf_one_eighth.sign
+  io.rf_one_eighth_exp := rf_one_eighth.exponent
+  io.rf_one_eighth_mant := rf_one_eighth.mantissa
 
 }
 

--- a/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
+++ b/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
@@ -1,0 +1,37 @@
+package spinal.lib.experimental.math
+
+import scala.math.BigDecimal
+
+import spinal.core._
+import spinal.lib._
+import spinal.tester.SpinalTesterCocotbBase
+
+class FloatingTester2 extends Component {
+  val io = new Bundle {
+    // Test Case: BigDecimal("0.0")
+    val f_zero_bits = out Bits (32 bits)
+    val rf_zero_sign = out Bool ()
+    val rf_zero_exp = out Bits (9 bits)
+    val rf_zero_mant = out Bits (23 bits)
+
+  }
+
+  // Test Case: BigDecimal("0.0")
+  val f_zero = Floating32()
+  f_zero := BigDecimal("0.0")
+  io.f_zero_bits := f_zero.asBits
+
+  val rf_zero = RecFloating32()
+  rf_zero := BigDecimal("0.0")
+  io.rf_zero_sign := rf_zero.sign
+  io.rf_zero_exp := rf_zero.exponent
+  io.rf_zero_mant := rf_zero.mantissa
+
+}
+
+class FloatingTester2Cocotb extends SpinalTesterCocotbBase {
+  override def getName: String = "FloatingTester2"
+  override def pythonTestLocation: String = "tester/src/test/python/spinal/FloatingTester2"
+  override def createToplevel: Component = new FloatingTester2
+  override def backendConfig(config: SpinalConfig): SpinalConfig = config.dumpWave()
+}

--- a/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
+++ b/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
@@ -15,23 +15,29 @@ class FloatingTester2 extends Component {
     val rf_zero_mant = out Bits (23 bits)
 
     // Test Case: BigDecimal("1.5")
-    val f_one_point_five_bits = out Bits(32 bits)
-    val rf_one_point_five_sign = out Bool()
-    val rf_one_point_five_exp = out Bits(9 bits)
-    val rf_one_point_five_mant = out Bits(23 bits)
+    val f_one_point_five_bits = out Bits (32 bits)
+    val rf_one_point_five_sign = out Bool ()
+    val rf_one_point_five_exp = out Bits (9 bits)
+    val rf_one_point_five_mant = out Bits (23 bits)
 
     // Test Case: BigDecimal("-2.0")
-    val f_neg_two_bits = out Bits(32 bits)
-    val rf_neg_two_sign = out Bool()
-    val rf_neg_two_exp = out Bits(9 bits)
-    val rf_neg_two_mant = out Bits(23 bits)
+    val f_neg_two_bits = out Bits (32 bits)
+    val rf_neg_two_sign = out Bool ()
+    val rf_neg_two_exp = out Bits (9 bits)
+    val rf_neg_two_mant = out Bits (23 bits)
 
-    
     // Test Case: BigDecimal("0.125") (1/8)
-    val f_one_eighth_bits = out Bits(32 bits)
-    val rf_one_eighth_sign = out Bool()
-    val rf_one_eighth_exp = out Bits(9 bits)
-    val rf_one_eighth_mant = out Bits(23 bits)
+    val f_one_eighth_bits = out Bits (32 bits)
+    val rf_one_eighth_sign = out Bool ()
+    val rf_one_eighth_exp = out Bits (9 bits)
+    val rf_one_eighth_mant = out Bits (23 bits)
+
+    // Test Case: A value that might stress the current normalization loop
+    val small_val_num = BigDecimal("0.0009765625")
+    val f_small_val_bits = out Bits (32 bits)
+    val rf_small_val_sign = out Bool ()
+    val rf_small_val_exp = out Bits (9 bits)
+    val rf_small_val_mant = out Bits (23 bits)
   }
 
   // Test Case: BigDecimal("0.0")
@@ -78,6 +84,16 @@ class FloatingTester2 extends Component {
   io.rf_one_eighth_exp := rf_one_eighth.exponent
   io.rf_one_eighth_mant := rf_one_eighth.mantissa
 
+  // Test Case: BigDecimal from io.small_val_num
+  val f_small_val = Floating32()
+  f_small_val := io.small_val_num
+  io.f_small_val_bits := f_small_val.asBits
+
+  val rf_small_val = RecFloating32()
+  rf_small_val := io.small_val_num
+  io.rf_small_val_sign := rf_small_val.sign
+  io.rf_small_val_exp := rf_small_val.exponent
+  io.rf_small_val_mant := rf_small_val.mantissa
 }
 
 class FloatingTester2Cocotb extends SpinalTesterCocotbBase {

--- a/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
+++ b/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester2.scala
@@ -20,6 +20,11 @@ class FloatingTester2 extends Component {
     val rf_one_point_five_exp = out Bits(9 bits)
     val rf_one_point_five_mant = out Bits(23 bits)
 
+    // Test Case: BigDecimal("-2.0")
+    val f_neg_two_bits = out Bits(32 bits)
+    val rf_neg_two_sign = out Bool()
+    val rf_neg_two_exp = out Bits(9 bits)
+    val rf_neg_two_mant = out Bits(23 bits)
   }
 
   // Test Case: BigDecimal("0.0")
@@ -43,6 +48,17 @@ class FloatingTester2 extends Component {
   io.rf_one_point_five_sign := rf_one_point_five.sign
   io.rf_one_point_five_exp := rf_one_point_five.exponent
   io.rf_one_point_five_mant := rf_one_point_five.mantissa
+
+  // Test Case: BigDecimal("-2.0")
+  val f_neg_two = Floating32()
+  f_neg_two := BigDecimal("-2.0")
+  io.f_neg_two_bits := f_neg_two.asBits
+
+  val rf_neg_two = RecFloating32()
+  rf_neg_two := BigDecimal("-2.0")
+  io.rf_neg_two_sign := rf_neg_two.sign
+  io.rf_neg_two_exp := rf_neg_two.exponent
+  io.rf_neg_two_mant := rf_neg_two.mantissa
 
 }
 


### PR DESCRIPTION
# Context, Motivation & Description

This change introduces test infrastructure (`FloatingTester2` and associated Cocotb script) to validate the `BigDecimal` assignment functionality for `Floating` and `RecFloating` types.

The core floating-point libraries provide `:= (that: BigDecimal)` operators. However, specific verification for this conversion pathway, particularly for both standard `Floating` (IEEE 754 representation) and `RecFloating`, was previously absent. Ensuring the correctness of this conversion is important.

This modification adds:
1. IEEE 754 and RecFloating tool functions in python package `spinal.FloatingTestCommon`
2.  A SpinalHDL component `FloatingTester2.scala` that assigns several constant `BigDecimal` values (covering zero, positive, negative, and fractional exact binary numbers) and related Cocotb testbench.

The goal is to provide initial verification coverage for the `BigDecimal` assignment mechanism for both floating-point formats using a set of basic, exactly representable values.

# Impact on code generation

This change adds test code only and does not affect generated hardware derived from the core library components.

# Checklist

- [X] Unit tests were added.
- [N/A] API changes are or will be documented (Test infrastructure addition, no library API changes).