### PR TITLE
fix width issue in AFix negate()

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -662,7 +662,7 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
     if(this.minRaw >= 0)
       ret.raw := U(this.raw).twoComplement(enable, plusOneEnable).asBits
     else
-      ret.raw := S(this.raw).twoComplement(enable, plusOneEnable).asBits
+      ret.raw := S(this.raw).twoComplement(enable, plusOneEnable).asBits.resized
     ret
   }
 

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -198,6 +198,17 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
     }
   }
 
+  test("negate_width") {
+    // make sure `negate()` elaborates in some edge cases
+    SimConfig.compile(new Component {
+      val io = new Bundle {
+        val a = in(AFix.S(5 bits))
+        val o = out(AFix.S(6 bits))
+        o := a.negate().negate()
+      }
+    })
+  }
+
   def dutStateString(dut: AFixTester): String = {
     val model = AFixTesterModel(dut)
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->


# Context, Motivation & Description

The `AFix` `negate` method on signed `AFix`es always tries to assign the result's `raw` to a new bit vector that is one bit wider, but negating the `AFix` doesn't always make it wider.

# Impact on code generation

Now, when an `AFix`'s `raw` is assigned during negation, it is resized to fit. This should be fine since if it doesn't use the entire available range in that many bits, then it's just a sign extension bit being removed.

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented (none needed)
