### PR TITLE
Fix AFix <<| bug

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -572,7 +572,7 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
   // Shift bits and decimal point left, adding padding bits right
   def <<|(shift: Int): AFix = {
     val shiftBig = BigInt(2).pow(shift)
-    val ret = new AFix(this.maxRaw * shiftBig, this.minRaw * shiftBig, (this.exp + shift))
+    val ret = new AFix(this.maxRaw * shiftBig, this.minRaw * shiftBig, this.exp)
 
     ret.raw := this.raw << shift
 

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -133,6 +133,23 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
     }
   }
 
+  test("expanding_left_shift") {
+    // there is nothing special to the values used for testing here; i just picked some
+    SimConfig.compile(new Component {
+      val shift: Int = 4
+      val inputSize: Int = 6
+      val io = new Bundle {
+        val input = in(AFix.S(inputSize exp, 0 exp))
+        val output = out(AFix.S(inputSize + shift exp, 0 exp))
+      }
+      io.output := io.input <<| shift
+    }).doSim(seed = 0) { dut =>
+      dut.io.input #= 42.0
+      sleep(1)
+      assert(dut.io.output.toDouble == 672.0)
+    }
+  }
+
   test("bitwise_ops") {
     // testing some obvious properties of bitwise ops with handpicked arbitrary examples
     SimConfig.compile(new Component {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->



# Context, Motivation & Description

The `AFix` `<<|` operator (where the right operand is a constant) did not behave in a way that made sense, and was not symmetric with the `AFix` `>>|` operator or other types' `<<|` and `>>|` operators. It shifted both the bit representation and the exponent of the `AFix`, when shifting either one of those would have produced a left-shift-like change in the value of the `AFix`.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

`AFix`'s `<<|` operator (where the right operand is a constant) no longer changes the resolution of the left operand.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
