### PR TITLE
Enhances hierarchy violation report within PhaseCheckHierarchy phase

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -341,7 +341,7 @@ class PhaseAnalog extends PhaseNetlist{
               case _ => SpinalError(s"Unsupported statement $s")
             }
             if(targetRange.size != sourceRange.size)
-              SpinalError(s"WIDTH MISMATCH IN ANALOG ASSIGNMENT $s\n${s.getScalaLocationLong}")
+              SpinalError(s"WIDTH MISMATCH IN ANALOG ASSIGNMENT: $s.\nLocation:\n${s.getScalaLocationLong}")
 
             if(targetRange.size > 0) {
               if (sourceBt == null) SpinalError(":(")

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2501,11 +2501,13 @@ class PhaseCheckHierarchy extends PhaseCheck {
             }
           case s_expr: MemPortStatement => {
             if (s_expr.mem.component != c) {
-              PendingError(s"HIERARCHY/SCOPE VIOLATION (OLD NETLIST RE-USED): Memory port '${s_expr.toString()}' " +
-                           s"of memory '${s_expr.mem.toString()}' (defined in ${getComponentDesc(s_expr.mem.component)}) " +
-                           s"is used in statement '${s.toString()}' within ${getComponentDesc(c)}.\n" +
-                           s"Memory port access should typically occur within the memory's own component scope (${getComponentDesc(s_expr.mem.component)}).\n" +
-                           s"Location:\n${s.getScalaLocationLong}")
+              val detailedMemPortMessage = new StringBuilder()
+              detailedMemPortMessage ++= s"HIERARCHY/SCOPE VIOLATION (OLD NETLIST RE-USED): Memory port '${s_expr.toString()}'\n"
+              detailedMemPortMessage ++= s"  of memory '${s_expr.mem.toString()}' (defined in ${getComponentDesc(s_expr.mem.component)}) "
+              detailedMemPortMessage ++= s"is used in statement '${s.toString()}' within ${getComponentDesc(c)}.\n"
+              detailedMemPortMessage ++= s"  Memory port access should typically occur within the memory's own component scope (${getComponentDesc(s_expr.mem.component)}).\n"
+              detailedMemPortMessage ++= s"Location:\n${s.getScalaLocationLong}"
+              PendingError(detailedMemPortMessage.toString())
             }
           }
           case _ =>

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -756,7 +756,7 @@ trait PhaseMemBlackboxing extends PhaseNetlist {
         }
 
         if(!(topo.writes.nonEmpty || topo.readWriteSync.nonEmpty || topo.writeReadSameAddressSync.nonEmpty || mem.initialContent != null)) {
-          SpinalError(s"MEM-WITHOUT-DRIVER. $mem has no write ports nor initial content. Defined at :\n${mem.getScalaLocationLong}")
+          SpinalError(s"MEM-WITHOUT-DRIVER: Memory '$mem' has no write ports nor initial content.\nDefined at:\n${mem.getScalaLocationLong}")
         }
 
         mem.component.rework{

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2415,7 +2415,6 @@ class PhaseCheckHierarchy extends PhaseCheck {
               detailedMessage ++= s"  3. Be an 'in' or 'inout' port of a direct child component of $currentComponentInfo (Actual: $condIsInputOrInOutInChildOfC).\n"
               detailedMessage ++= s"Contextual Details:\n"
               detailedMessage ++= s"  - Target Signal ('${bt.toString()}'):\n"
-              detailedMessage ++= s"    - Full Hierarchical Name: ${getComponentPath(bt.component)}\n" // BaseType has getName for full path
               detailedMessage ++= s"    - Defining Component: ${getComponentDesc(bt.component)}\n"
               detailedMessage ++= s"    - isDirectionLess: ${bt.isDirectionLess}, isInput: ${bt.isInput}, isOutput: ${bt.isOutput}, isInOut: ${bt.isInOut}\n"
               detailedMessage ++= s"  - Current Component (where assignment occurs):\n"

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2463,7 +2463,8 @@ class PhaseCheckHierarchy extends PhaseCheck {
                 val currentNetlistHeadInfo = if (pc.topLevel != null) s"'${getComponentPath(pc.topLevel)}'" else "N/A (current toplevel is null)"
 
                 val detailedOldNetlistMessage = new StringBuilder()
-                detailedOldNetlistMessage ++= s"OLD NETLIST RE-USED / DANGLING REFERENCE: $signalInfo, $contextInfo, but $problem\n"
+                detailedOldNetlistMessage ++= s"OLD NETLIST RE-USED / DANGLING REFERENCE: Signal $signalInfo $problem.\n"
+                detailedOldNetlistMessage ++= s"  It was $contextInfo.\n"
                 detailedOldNetlistMessage ++= s"Details for this signal:\n"
                 detailedOldNetlistMessage ++= s"  - Defining component: $signalComponentInfo\n"
                 detailedOldNetlistMessage ++= s"  - Inferred toplevel: $signalNetlistHeadInfo\n"

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -1516,7 +1516,10 @@ class PhaseInferEnumEncodings(pc: PhaseContext, encodingSwap: (SpinalEnumEncodin
 
         for((key,elements) <- reserveds){
           if(elements.length != 1){
-            PendingError(s"Conflict in the $senum enumeration with the '$encoding' encoding with the key $key' and following elements:.\n${elements.mkString(", ")}\n\nEnumeration defined at :\n${senum.getScalaLocationLong}Encoding defined at :\n${encoding.getScalaLocationLong}")
+            PendingError(s"Conflict in the $senum enumeration with the '$encoding' encoding with key '$key' and following elements:.\n" +
+                         s"${elements.mkString(", ")}\n" +
+                         s"Enumeration defined at:\n${senum.getScalaLocationLong}" +
+                         s"Encoding defined at:\n${encoding.getScalaLocationLong}")
           }
         }
       }

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2380,10 +2380,13 @@ class PhaseCheckHierarchy extends PhaseCheck {
     }
 
     def getComponentDesc(comp: Component): String = {
-      if (comp == null) return "<null_component_ref>"
-      val parentName = if (comp.parent != null) comp.parent.getName() else "<None>"
-      s"component '${comp.getName()}' (parent: '$parentName')"
-    }
+      if (comp == null) return "<None>"
+      if (comp == pc.topLevel) {
+        s"component '${comp.getName()}'"
+      } else {
+        val parentName = if (comp.parent != null) comp.parent.getName() else "<None>"
+        s"component '${comp.getName()}' (parent: '$parentName')"
+      }
 
 
     //Check hierarchy read/write violation

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2367,6 +2367,25 @@ class PhaseCheckHierarchy extends PhaseCheck{
   override def impl(pc: PhaseContext): Unit = {
     import pc._
 
+    def getSignalDirectionString(bt: BaseType): String = {
+      if (bt.isInput) "input"
+      else if (bt.isOutput) "output"
+      else if (bt.isInOut) "inout"
+      else if (bt.isDirectionLess) "directionless"
+      else "unknown"
+    }
+
+    def getComponentPath(comp: Component): String = {
+      if (comp == null) "<null_component_ref>" else comp.getName()
+    }
+
+    def getComponentDesc(comp: Component): String = {
+      if (comp == null) return "<null_component_ref>"
+      val parentName = if (comp.parent != null) getComponentPath(comp.parent) else "None"
+      s"component '${getComponentPath(comp)}' (parent: '$parentName')"
+    }
+
+
     //Check hierarchy read/write violation
     walkComponents(c => {
       val autoPullOn = mutable.LinkedHashSet[Expression]()

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2482,14 +2482,16 @@ class PhaseCheckHierarchy extends PhaseCheck {
 
 
                   val detailedMessage = new StringBuilder()
-                  detailedMessage ++= s"HIERARCHY VIOLATION (read access): $readSignalDescription (an instance of ${bt.getClass.getSimpleName}), $readSignalContextDescription,\n"
-                  detailedMessage ++= s"  is read by statement '${s.toString()}', but is not readable from $currentComponentDesc.\n"
+                  detailedMessage ++= s"HIERARCHY VIOLATION (read access): Attempted to read $readSignalDescription, which is not readable from $currentComponentDesc.\n"
+                  detailedMessage ++= s"  (Accessed by statement: '${s.toString()}')\n" // 更明确地指出语句
                   detailedMessage ++= s"To be readable from $currentComponentDesc, this signal must satisfy one of the following:\n"
                   detailedMessage ++= s"  1. Be any signal (directionless, in, out, or inout) defined directly within $currentComponentDesc.\n"
                   detailedMessage ++= s"  2. Be an 'in', 'out', or 'inout' port of a direct child component of $currentComponentDesc.\n"
                   detailedMessage ++= s"Contextual details for this read signal:\n"
                   detailedMessage ++= s"  - Its full name: '${bt.toString()}'\n"
+                  detailedMessage ++= s"  - Instance type: ${bt.getClass.getSimpleName}\n" // 移到此处
                   detailedMessage ++= s"  - Defining component: ${getComponentDesc(bt.component)}\n"
+                  detailedMessage ++= s"  - Declared direction: '${getSignalDirectionString(bt)}'\n" // 移到此处
                   detailedMessage ++= s"  - isDirectionLess: ${bt.isDirectionLess}, isInput: ${bt.isInput}, isOutput: ${bt.isOutput}, isInOut: ${bt.isInOut}\n"
                   detailedMessage ++= s"  - Current component (where read occurs): $currentComponentDesc\n"
                   detailedMessage ++= s"Location of read:\n${s.getScalaLocationLong}"

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2407,16 +2407,17 @@ class PhaseCheckHierarchy extends PhaseCheck {
               val targetSignalContextDescription = s"defined in ${getComponentDesc(bt.component)} with direction '${getSignalDirectionString(bt)}'"
 
               val detailedMessage = new StringBuilder()
-              detailedMessage ++= s"HIERARCHY VIOLATION (assignment): $targetSignalDescription (an instance of ${bt.getClass.getSimpleName}), $targetSignalContextDescription,\n"
-              detailedMessage ++= s"  is assigned by expression '${s.source.toString()}', but is not assignable from $currentComponentDesc.\n"
+              detailedMessage ++= s"HIERARCHY VIOLATION (assignment): Attempted to assign to $targetSignalDescription, which is not assignable from $currentComponentDesc.\n"
+              detailedMessage ++= s"  (Assigned by expression: '${s.source.toString()}')\n"
               detailedMessage ++= s"To be assignable from $currentComponentDesc, this signal must satisfy one of the following:\n"
               detailedMessage ++= s"  1. Be a directionless signal defined directly within $currentComponentDesc.\n"
               detailedMessage ++= s"  2. Be an 'out' or 'inout' port of $currentComponentDesc.\n"
               detailedMessage ++= s"  3. Be an 'in' or 'inout' port of a direct child component of $currentComponentDesc.\n"
               detailedMessage ++= s"Contextual details for this target signal:\n"
               detailedMessage ++= s"  - Its full name: '${bt.toString()}'\n"
+              detailedMessage ++= s"  - Instance type: ${bt.getClass.getSimpleName}\n"
               detailedMessage ++= s"  - Defining component: ${getComponentDesc(bt.component)}\n"
-              detailedMessage ++= s"  - isDirectionLess: ${bt.isDirectionLess}, isInput: ${bt.isInput}, isOutput: ${bt.isOutput}, isInOut: ${bt.isInOut}\n"
+              detailedMessage ++= s"  - Declared direction: '${getSignalDirectionString(bt)}'\n"
               detailedMessage ++= s"  - Current component (where assignment occurs): $currentComponentDesc\n"
               detailedMessage ++= s"Location of assignment:\n${s.getScalaLocationLong}"
               PendingError(detailedMessage.toString())

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2376,12 +2376,12 @@ class PhaseCheckHierarchy extends PhaseCheck {
     }
 
     def getComponentPath(comp: Component): String = {
-      if (comp == null) "<null_component_ref>" else comp.getName()
+      if (comp != null) comp.getPath() else "<None>"
     }
 
     def getComponentDesc(comp: Component): String = {
       if (comp == null) return "<null_component_ref>"
-      val parentName = if (comp.parent != null) comp.parent.getName() else "None"
+      val parentName = if (comp.parent != null) comp.parent.getName() else "<None>"
       s"component '${comp.getName()}' (parent: '$parentName')"
     }
 
@@ -2487,7 +2487,6 @@ class PhaseCheckHierarchy extends PhaseCheck {
                   detailedMessage ++= s"  2. Be an 'in', 'out', or 'inout' port of a direct child component of $currentComponentInfo (Actual: $condIsSignalInOutOrInoutOfChild).\n"
                   detailedMessage ++= s"Contextual Details:\n"
                   detailedMessage ++= s"  - Read Signal ('${bt.toString()}'):\n"
-                  detailedMessage ++= s"    - Full Hierarchical Name: ${getComponentPath(bt.component)}\n"
                   detailedMessage ++= s"    - Defining Component: ${getComponentDesc(bt.component)}\n"
                   detailedMessage ++= s"    - isDirectionLess: ${bt.isDirectionLess}, isInput: ${bt.isInput}, isOutput: ${bt.isOutput}, isInOut: ${bt.isInOut}\n"
                   detailedMessage ++= s"  - Current Component (where read occurs):\n"

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2381,8 +2381,8 @@ class PhaseCheckHierarchy extends PhaseCheck {
 
     def getComponentDesc(comp: Component): String = {
       if (comp == null) return "<null_component_ref>"
-      val parentName = if (comp.parent != null) getComponentPath(comp.parent) else "None"
-      s"component '${getComponentPath(comp)}' (parent: '$parentName')"
+      val parentName = if (comp.parent != null) comp.parent.getName() else "None"
+      s"component '${comp.getName()}' (parent: '$parentName')"
     }
 
 
@@ -2410,9 +2410,9 @@ class PhaseCheckHierarchy extends PhaseCheck {
               detailedMessage ++= s"HIERARCHY VIOLATION (Assignment): $targetSignalDesc, $targetSignalContext,\n"
               detailedMessage ++= s"  is assigned by expression '${s.source.toString()}', but is not assignable from $currentComponentInfo.\n"
               detailedMessage ++= s"To be assignable from $currentComponentInfo, signal '${bt.toString()}' must satisfy one of the following:\n"
-              detailedMessage ++= s"  1. Be a directionless signal defined directly within $currentComponentInfo (Actual: $condIsDirectionLessInC).\n"
-              detailedMessage ++= s"  2. Be an 'out' or 'inout' port of $currentComponentInfo (Actual: $condIsOutputOrInOutInC).\n"
-              detailedMessage ++= s"  3. Be an 'in' or 'inout' port of a direct child component of $currentComponentInfo (Actual: $condIsInputOrInOutInChildOfC).\n"
+              detailedMessage ++= s"  1. Be a directionless signal defined directly within $currentComponentInfo (Actual: False).\n"
+              detailedMessage ++= s"  2. Be an 'out' or 'inout' port of $currentComponentInfo (Actual: False).\n"
+              detailedMessage ++= s"  3. Be an 'in' or 'inout' port of a direct child component of $currentComponentInfo (Actual: False).\n"
               detailedMessage ++= s"Contextual Details:\n"
               detailedMessage ++= s"  - Target Signal ('${bt.toString()}'):\n"
               detailedMessage ++= s"    - Defining Component: ${getComponentDesc(bt.component)}\n"


### PR DESCRIPTION
# Context, Motivation & Description

This change enhances the error reporting capabilities within the `PhaseCheckHierarchy` phase.

Previously, when a hierarchy violation (e.g., illegal cross-component signal assignment or read) or a related issue like "OLD NETLIST RE-USED" occurred, the error messages provided by `PhaseCheckHierarchy` were often generic. This made it challenging for developers especially beginners to quickly identify the precise nature of the error. 

This modification refactors the hierarchy checking logic to provide significantly more detailed and actionable diagnostic messages.

# Impact on code generation

Zero. Solely improves compile-time diagnostic messages.

# Checklist

- [N/A] Unit tests were added (no need).
- [N/A] API changes are or will be documented (no public API alteration).
