### PR TITLE
Enhancements to make report statements more readable and flexible

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Statement.scala
+++ b/core/src/main/scala/spinal/core/internals/Statement.scala
@@ -601,6 +601,9 @@ object AssertStatementHelper {
     def process(item: Any): Unit = {
       item match {
         case nestedSeq: Seq[_] =>
+        case m @ (_: Byte | _: Short | _: Int | _: Long | _: Float | _: Double | _: Char | _: Boolean) => builder += m.toString
+        case m: BigInt => builder += m.toString
+        case m: BigDecimal => builder += m.toString
         case other =>
           builder += other
       }

--- a/core/src/main/scala/spinal/core/internals/Statement.scala
+++ b/core/src/main/scala/spinal/core/internals/Statement.scala
@@ -593,10 +593,26 @@ class SwitchStatement(var value: Expression) extends TreeStatement{
 }
 
 
-object AssertStatementHelper{
+object AssertStatementHelper {
+
+  private def flattenMessage(input: Seq[Any]): Seq[Any] = {
+    val builder = Seq.newBuilder[Any]
+
+    def process(item: Any): Unit = {
+      item match {
+        case nestedSeq: Seq[_] =>
+        case other =>
+          builder += other
+      }
+    }
+
+    input.foreach(process)
+    builder.result()
+  }
 
   def apply(cond: Bool, message: Seq[Any], severity: AssertNodeSeverity, kind: AssertStatementKind, trigger : AssertStatementTrigger, loc: Location): AssertStatement = {
-    val node = AssertStatement(cond, message, severity, kind, trigger, loc)
+    val flattenedMessage = flattenMessage(message)
+    val node = AssertStatement(cond, flattenedMessage, severity, kind, trigger, loc)
 
     if(!GlobalData.get.phaseContext.config.noAssert){
       DslScopeStack.get.append(node)
@@ -605,7 +621,7 @@ object AssertStatementHelper{
     node
   }
 
-  def apply(cond: Bool, message: String, severity: AssertNodeSeverity, kind : AssertStatementKind, trigger : AssertStatementTrigger, loc: Location): AssertStatement ={
+  def apply(cond: Bool, message: String, severity: AssertNodeSeverity, kind : AssertStatementKind, trigger : AssertStatementTrigger, loc: Location): AssertStatement = {
     AssertStatementHelper(cond, List(message), severity, kind, trigger, loc)
   }
 }

--- a/core/src/main/scala/spinal/core/internals/Statement.scala
+++ b/core/src/main/scala/spinal/core/internals/Statement.scala
@@ -601,6 +601,7 @@ object AssertStatementHelper {
     def process(item: Any): Unit = {
       item match {
         case nestedSeq: Seq[_] =>
+          nestedSeq.foreach(process)
         case m @ (_: Byte | _: Short | _: Int | _: Long | _: Float | _: Double | _: Char | _: Boolean) => builder += m.toString
         case m: BigInt => builder += m.toString
         case m: BigDecimal => builder += m.toString

--- a/tester/src/test/python/spinal/MsgSeqTester/.gitignore
+++ b/tester/src/test/python/spinal/MsgSeqTester/.gitignore
@@ -1,0 +1,2 @@
+msgseqtester
+__pycache__

--- a/tester/src/test/python/spinal/MsgSeqTester/Makefile
+++ b/tester/src/test/python/spinal/MsgSeqTester/Makefile
@@ -1,0 +1,15 @@
+include ../common/Makefile.def
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+	VERILOG_SOURCES += $(SPINALROOT)/MsgSeqTester.v
+	TOPLEVEL=MsgSeqTester
+endif
+
+ifeq ($(TOPLEVEL_LANG),vhdl)
+	VHDL_SOURCES += $(SPINALROOT)/MsgSeqTester.vhd
+	TOPLEVEL=msgseqtester
+endif
+
+COCOTB_LOG_LEVEL=TRACE
+MODULE=MsgSeqTester
+include ../common/Makefile.sim

--- a/tester/src/test/python/spinal/MsgSeqTester/MsgSeqTester.py
+++ b/tester/src/test/python/spinal/MsgSeqTester/MsgSeqTester.py
@@ -1,0 +1,92 @@
+import cocotb
+from cocotb.triggers import Timer
+from cocotb.result import TestFailure
+
+
+async def set_packet_header(dut, length, ptype, value, checksum):
+    dut.io_packetIn_packetLength.value = length
+    dut.io_packetIn_packetType.value = ptype
+    dut.io_packetIn_payload_value.value = value
+    dut.io_packetIn_payload_checksum.value = checksum
+
+
+def assert_equals(actual, expected, message=""):
+    if actual != expected:
+        raise TestFailure(
+            f"Assertion failed: {message} - Expected {expected}, got {actual}")
+    else:
+        cocotb.log.info(
+            f"Assertion passed: {message} - Expected {expected}, got {actual}")
+
+
+@cocotb.test()
+async def test_simple_packet_processor(dut):
+    dut._log.info("Cocotb test boot for SimplePacketProcessor (MsgSeqTester)")
+
+    dut.clk.value = 0
+    dut.reset.value = 0
+
+    dut._log.info("Initializing inputs...")
+    dut.io_controlSignal.value = 0
+    await set_packet_header(dut, length=0, ptype=0, value=0, checksum=0)
+
+    await Timer(1, units="ps")
+
+    # Initial State Check
+    cocotb.log.info(f"Raw value of io_isValid.value: <{dut.io_isValid.value}>")
+    cocotb.log.info(f"Type of io_isValid.value: {type(dut.io_isValid.value)}")
+    cocotb.log.info(
+        f"Integer value of io_isValid.value: {dut.io_isValid.value.integer}")
+
+    assert_equals(dut.io_isValid.value.integer, 0,
+                  "Initially, isValid should be false")
+    assert_equals(dut.io_processedValue.value.integer, 0,
+                  "Initially, processedValue should be 0")
+    dut._log.info(
+        f"Initial state: isValid={dut.io_isValid.value.integer}, processedValue={dut.io_processedValue.value.integer}")
+
+    # Test Case: Control Signal Disabled
+    dut.io_controlSignal.value = 0
+    await set_packet_header(dut, length=10, ptype=1, value=0xABCD, checksum=0xCD)
+    await Timer(1, units="ps")
+
+    assert_equals(dut.io_isValid.value.integer, 0,
+                  "isValid should be false when controlSignal is disabled")
+    assert_equals(dut.io_processedValue.value.integer, 0,
+                  "processedValue should be 0 when controlSignal is disabled")
+
+    # Test Case: Control Enabled, Type Mismatch
+    dut.io_controlSignal.value = 1
+    await set_packet_header(dut, length=10, ptype=2, value=0x1234, checksum=0x34)
+    await Timer(1, units="ps")
+
+    assert_equals(dut.io_isValid.value.integer, 0,
+                  "isValid should be false when packetType mismatches")
+    assert_equals(dut.io_processedValue.value.integer, 0,
+                  "processedValue should be 0 when packetType mismatches")
+
+    # Test Case: Valid Packet
+    valid_value = 0x5678
+    valid_checksum = 0x78
+    dut.io_controlSignal.value = 1
+    await set_packet_header(dut, length=12, ptype=1, value=valid_value, checksum=valid_checksum)
+    await Timer(1, units="ps")
+
+    assert_equals(dut.io_isValid.value.integer, 1,
+                  "isValid should be true for a valid packet")
+    assert_equals(dut.io_processedValue.value.integer, valid_value,
+                  "processedValue should match input value for a valid packet")
+
+    # Test Case: Checksum Mismatch
+    invalid_value = 0xABCD
+    wrong_checksum = 0xCC
+    dut.io_controlSignal.value = 1
+    await set_packet_header(dut, length=10, ptype=1, value=invalid_value, checksum=wrong_checksum)
+    await Timer(1, units="ps")
+
+    assert_equals(dut.io_isValid.value.integer, 0,
+                  "isValid should be false when checksum mismatches")
+    assert_equals(dut.io_processedValue.value.integer, 0,
+                  "processedValue should be 0 when checksum mismatches")
+
+    dut._log.info("Cocotb test done for SimplePacketProcessor")

--- a/tester/src/test/python/spinal/MsgSeqTester/__init__.py
+++ b/tester/src/test/python/spinal/MsgSeqTester/__init__.py
@@ -1,0 +1,1 @@
+#!/bin/env python

--- a/tester/src/test/scala/spinal/core/MsgSeqTester.scala
+++ b/tester/src/test/scala/spinal/core/MsgSeqTester.scala
@@ -108,6 +108,7 @@ class MsgSeqTester() extends Component {
   }
 
   // Test print scala primitive types
+  report(L"${null}") // null
   report(L"${Byte.MinValue}")
   report(L"${Short.MaxValue}")
   report(L"${123}") // Int

--- a/tester/src/test/scala/spinal/core/MsgSeqTester.scala
+++ b/tester/src/test/scala/spinal/core/MsgSeqTester.scala
@@ -1,0 +1,181 @@
+/*
+ * SpinalHDL
+ * Copyright (c) Dolu, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+
+package spinal.core
+
+import spinal.lib._
+import spinal.core.sim._
+import spinal.tester.SpinalSimFunSuite
+import spinal.tester.SpinalTesterCocotbBase
+
+import scala.util.Random
+import scala.collection.Seq
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import org.scalatest.tools.Runner
+import java.io.File
+import scala.tools.nsc.ScalaDoc.Command
+import scala.sys.process.ProcessLogger
+
+trait Formattable {
+  def format(): Seq[Any]
+}
+
+case class DataPayload() extends Bundle with Formattable {
+  val value = UInt(16 bits)
+  val checksum = UInt(8 bits)
+
+  override def format(): Seq[Any] = {
+    Seq(L"DataPayload(value=0x${value}, checksum=0x${checksum})")
+  }
+}
+
+case class PacketHeader() extends Bundle with Formattable {
+  val packetLength = UInt(8 bits)
+  val packetType = UInt(4 bits)
+  val payload = DataPayload()
+
+  override def format(): Seq[Any] = {
+    Seq(
+      L"PacketHeader(",
+      L"packetLength=0x${packetLength},",
+      L" packetType=0x${packetType},",
+      L" payload=${payload.format}",
+      L")"
+    ).flatten
+  }
+}
+
+case class PacketFrame() extends Bundle with Formattable {
+  val controlSignal = in(Bool())
+  val packetIn = in(PacketHeader())
+  val processedValue = out(UInt(16 bits))
+  val isValid = out(Bool())
+
+  override def format(): Seq[Any] = {
+    Seq(
+      L"PacketFrame(",
+      L"controlSignal=${controlSignal},",
+      L" packetIn=${packetIn.format}",
+      L" processedValue=0x${processedValue},",
+      L" isValid=${isValid}",
+      L")"
+    ).flatten
+  }
+}
+class MsgSeqTester() extends Component {
+  val io = PacketFrame()
+
+  io.processedValue := 0
+  io.isValid := False
+
+  val enable = io.controlSignal
+  val length = io.packetIn.packetLength
+  val pType = io.packetIn.packetType
+  val dataValue = io.packetIn.payload.value
+  val dataChecksum = io.packetIn.payload.checksum
+
+  when(enable && pType === 1) {
+    val calculatedChecksum = dataValue(7 downto 0)
+    when(dataChecksum === calculatedChecksum) {
+      io.processedValue := dataValue
+      io.isValid := True
+    } otherwise {
+      io.processedValue := 0
+      io.isValid := False
+    }
+
+    // Test print nested Seq[Any]
+    report(io.format)
+  } otherwise {
+    io.processedValue := 0
+    io.isValid := False
+  }
+}
+
+class MsgSeqTesterSim extends SpinalSimFunSuite {
+
+  test("MsgSeqTester simulation with three-level nested bundles") {
+    SimConfig
+      .doSim(new MsgSeqTester()) { dut =>
+        dut.clockDomain.forkStimulus(period = 10)
+        dut.io.controlSignal #= false
+        dut.io.packetIn.packetLength #= 0
+        dut.io.packetIn.packetType #= 0
+        dut.io.packetIn.payload.value #= 0
+        dut.io.packetIn.payload.checksum #= 0
+
+        dut.clockDomain.waitSampling()
+
+        // Initial State Check
+        assert(!dut.io.isValid.toBoolean, "Initially, isValid should be false")
+        assert(dut.io.processedValue.toBigInt == 0, "Initially, processedValue should be 0")
+
+        // Test Case: Control Signal Disabled
+        dut.io.controlSignal #= false
+        dut.io.packetIn.packetLength #= 10
+        dut.io.packetIn.packetType #= 1
+        dut.io.packetIn.payload.value #= 0xabcd
+        dut.io.packetIn.payload.checksum #= 0xcd
+
+        dut.clockDomain.waitSampling()
+        assert(!dut.io.isValid.toBoolean, "isValid should be false when controlSignal is disabled")
+        assert(dut.io.processedValue.toBigInt == 0, "processedValue should be 0 when controlSignal is disabled")
+
+        // Test Case: Control Enabled, Type Mismatch
+        dut.io.controlSignal #= true
+        dut.io.packetIn.packetLength #= 10
+        dut.io.packetIn.packetType #= 2 // Mismatch (expected 1)
+        dut.io.packetIn.payload.value #= 0x1234
+        dut.io.packetIn.payload.checksum #= 0x34
+
+        dut.clockDomain.waitSampling()
+        assert(!dut.io.isValid.toBoolean, "isValid should be false when packetType mismatches")
+        assert(dut.io.processedValue.toBigInt == 0, "processedValue should be 0 when packetType mismatches")
+
+        // Test Case: Valid Packet
+        val validValue = 0x5678
+        val validChecksum = 0x78
+        dut.io.controlSignal #= true
+        dut.io.packetIn.packetLength #= 12
+        dut.io.packetIn.packetType #= 1 // Match
+        dut.io.packetIn.payload.value #= validValue
+        dut.io.packetIn.payload.checksum #= validChecksum
+
+        dut.clockDomain.waitSampling()
+        assert(dut.io.isValid.toBoolean, "isValid should be true for a valid packet")
+        assert(
+          dut.io.processedValue.toBigInt == validValue,
+          "processedValue should match input value for a valid packet"
+        )
+
+        // Test Case: Checksum Mismatch
+        val invalidValue = 0xabcd
+        val wrongChecksum = 0xcc
+        dut.io.controlSignal #= true
+        dut.io.packetIn.packetLength #= 10
+        dut.io.packetIn.packetType #= 1 // Match
+        dut.io.packetIn.payload.value #= invalidValue
+        dut.io.packetIn.payload.checksum #= wrongChecksum
+
+        dut.clockDomain.waitSampling()
+        assert(!dut.io.isValid.toBoolean, "isValid should be false when checksum mismatches")
+        assert(dut.io.processedValue.toBigInt == 0, "processedValue should be 0 when checksum mismatches")
+      }
+  }
+}

--- a/tester/src/test/scala/spinal/core/MsgSeqTester.scala
+++ b/tester/src/test/scala/spinal/core/MsgSeqTester.scala
@@ -106,6 +106,18 @@ class MsgSeqTester() extends Component {
     io.processedValue := 0
     io.isValid := False
   }
+
+  // Test print scala primitive types
+  report(L"${Byte.MinValue}")
+  report(L"${Short.MaxValue}")
+  report(L"${123}") // Int
+  report(L"${123L}") // Long
+  report(L"${3.14f}") // Float
+  report(L"${3.1415926535}") // Double
+  report(L"${'A'}") // Char
+  report(L"${true}") // Boolean
+  report(L"${BigInt(0x12)}")
+  report(L"${BigDecimal("123.456")}")
 }
 
 class MsgSeqTesterSim extends SpinalSimFunSuite {


### PR DESCRIPTION
# Context, Motivation & Description

This PR enhances the message handling mechanisms for `report` statements. Key changes include:

1.  **Extended support for Scala primitive types in `report` messages.**
2.  **Introduction of structured reporting capabilities for complex nested data structures.**

---

### **1. Extended Scala Primitive Type Support**

**Current State:**
In `report` messages, only `String` types and SpinalHDL signal types are directly supported. Scala primitive types (e.g., `Int`, `Boolean`, `Float`, `BigInt`, `BigDecimal`, `Char`, `Byte`, `Short`, `Long`) cannot be directly printed without explicit `.toString()` calls, often leading to compilation errors. For instance:

```scala
for (i <- 0 until cacheConfig.fetchWordsPerFetchGroup) {
  report(L"AdvICache: sCompareTags - Instruction ${i}: ${io.cpu.rsp.payload.instructions(i)}")
}
```
In the above code, `${i}` (an `Int` type) would previously result in an error and had to be changed to `${i.toString()}`.

**Change:**
A new private method, `private def flattenMessage(input: Seq[Any]): Seq[Any]`, has been added to `AssertStatementHelper`. This method now automatically converts all Scala primitive numeric types, characters, booleans, `BigInt`, and `BigDecimal` to their string representations, and flattens any nested `Seq`.

Users can directly include various Scala primitive types in `report` messages without manual conversions, resolving previous type incompatibility issues and enhancing the efficiency of debug information generation.

---

### **2. Structured Reporting for Complex Data Types**

**Current State:**
When displaying the internal state of complex nested data structures in `report` statements, there was no direct support. Users had to manually construct strings by concatenating each internal signal's value, resulting in verbose and difficult-to-maintain code.

**Change:**
A `Formattable` trait has been introduced, providing a `format(): Seq[Any]` method. Users can implement this trait for their `Bundle`s to define a structured reporting mechanism. The `report` statement now processes nested `Seq[Any]` returned by the `format()` method, flattening them into a readable single-line message.

**Example Output:**
An instance of `PacketFrame`, when `report(io.format)` is called, can generate output similar to:
```
PacketFrame(controlSignal=1, packetIn=PacketHeader(packetLength=0x0c, packetType=0x1, payload=DataPayload(value=0x5678, checksum=0x78)) processedValue=0x5678, isValid=1)
```

Complex data structure states can be displayed in a structured, nested format, simplifying debug information generation for complex structures and reducing manual string concatenation and maintenance effort.

---

### **New Example (`MsgSeqTester`)**

A new `MsgSeqTester` module, along with accompanying SpinalSim and Cocotb tests, has been added. These tests verify the new structured reporting capabilities for nested `Bundle`s and support for various Scala primitive types.

# Impact on code generation

The changes in this PR are primarily focused on the Scala-side `AssertStatementHelper` logic and the new test module. They **do not have a direct functional impact on the generated VHDL/Verilog/SystemVerilog code**.

`report` statements are typically processed during simulation and synthesis to generate debug information or trigger design validation. The core hardware description logic remains unaffected.

# Checklist

- [x] Unit tests were added (Via the new `MsgSeqTesterSim` and Cocotb tests)
- [x] API changes are or will be documented:
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)? https://github.com/SpinalHDL/SpinalDoc-RTD/pull/278

```