### PR TITLE
Fix scala 2.13 Seq naming

### DIFF
--- a/core/src/main/scala/spinal/core/Bundle.scala
+++ b/core/src/main/scala/spinal/core/Bundle.scala
@@ -25,6 +25,7 @@ import spinal.core.internals._
 import spinal.idslplugin.{Location, ValCallback}
 
 import scala.collection.mutable
+import scala.collection.Seq
 
 
 trait ValCallbackRec extends ValCallback {

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -409,6 +409,7 @@ package object sim {
   implicit class SimBoolPimper(bt: Bool) extends SimEquiv {
     def simProxy() = new SimProxy(bt)
     class SimProxy(bt : Bool){
+      assert(bt.isNamed)
       val manager = SimManagerContext.current.manager
       val signal = manager.raw.userData.asInstanceOf[ArrayBuffer[Signal]](bt.algoInt)
       def toBoolean = manager.getLong(signal) != 0
@@ -508,9 +509,10 @@ package object sim {
   implicit class SimBitVectorPimper(bt: BitVector) {
     def simProxy() = new SimProxy(bt)
     class SimProxy(bt : BitVector){
+      val alwaysZero = bt.getBitsWidth <= 0
+      assert(bt.isNamed)
       val manager = SimManagerContext.current.manager
       val signal = manager.raw.userData.asInstanceOf[ArrayBuffer[Signal]](bt.algoInt)
-      val alwaysZero = bt.getBitsWidth == 0
       def toInt = if(alwaysZero) 0 else manager.getInt(signal)
       def toLong = if(alwaysZero) 0 else manager.getLong(signal)
       def toBigInt = if(alwaysZero) 0 else manager.getBigInt(signal)
@@ -565,6 +567,7 @@ package object sim {
       new SimUnionElementPimper.PendingAssign())
 
     class SimProxy[E <: Data](rawBits: Bits, e: E) {
+      assert(rawBits.parentScope != null)
       var offset = 0
       breakable {
         for (ee <- dummyData.flatten) {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->
This fix was required for using scala 2.13 in [VexiiRiscv!47](https://github.com/SpinalHDL/VexiiRiscv/pull/47).

Do we need any additional tests for this?

The change is identical to [timing-extract](https://github.com/SpinalHDL/SpinalHDL/tree/timing-extract) of the main repo. I just rebased onto dev.

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
