### PR TITLE
Improve error handling in getNameElseThrow to provide clearer context when a signal lacks a name

### DIFF
--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -439,8 +439,12 @@ trait Nameable extends OwnableRef with ContextUser {
 
   private[core] def getNameElseThrow: String = {
     getName(null) match {
-      case null =>  throw new Exception("Internal error")
-      case name =>  name
+      case null =>
+        val errorMessage =
+          s"Signal $this has no name but is used in a context where a name is required. " +
+          s"Location of the signal: \n${getScalaLocationLong}. " +
+        SpinalError(errorMessage)
+      case name => name
     }
   }
 


### PR DESCRIPTION
# Context, Motivation & Description

This Pull Request refactors the `getNameElseThrow` method to provide more informative and actionable error messages when a signal is utilized in a context requiring a name, but the signal itself is unnamed.

**Before this PR, the error output for such a scenario was typically:**

```
[info]   java.lang.Exception: Internal error
[info]   at spinal.core.Nameable.getNameElseThrow(Trait.scala:442)
// ... subsequent compiler stack trace
```
This generic "Internal error" message provided limited context, making it challenging for users to identify the specific unnamed signal and its origin within their design code. Debugging required manual tracing through the compiler's internal stack to infer the root cause.

**After this PR, the error output is significantly improved, for example:**

```
[info]   spinal.core.SpinalExit: Signal ??? :  UInt[0 bits]) has no name but is used in a context where a name is required. Location of the signal: 
[info]     at parallax.components.memory.SimulatedSplitGeneralMemory$$anon$1$$anon$3.$anonfun$new$15(SimulatedSplitGeneralMemory.scala:199)
// ... subsequent user design stack trace
[info] Design's errors are listed above.
[info] SpinalHDL compiler exit stack :
[info]   at spinal.core.SpinalError$.apply(Misc.scala:514)
[info]   at spinal.core.Nameable.getNameElseThrow(Trait.scala:446)
// ... subsequent compiler stack trace
```

This change aims to enhance the debuggability by providing more precise and actionable error information.

# Impact on code generation

No impact.

# Checklist

- [N/A] Unit tests were added
- [N/A] API changes are or will be documented:
    - using Scaladoc comments: `/** */`?
    - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
    - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
```