### PR TITLE
add assignUnassignedFromBits for MultiData

### DIFF
--- a/core/src/main/scala/spinal/core/MultiData.scala
+++ b/core/src/main/scala/spinal/core/MultiData.scala
@@ -246,6 +246,21 @@ abstract class MultiData extends Data {
     }
   }
 
+  def assignUnassignedFromBits(bits: Bits): Unit = {
+    var offset = 0
+    for ((_, e) <- elements) {
+      e match {
+        case b : MultiData => b.assignUnassignedFromBits(bits(offset, e.getBitsWidth bit))
+        case bt: BaseType =>
+        if(!bt.hasDataAssignment && (bt.isDirectionLess || bt.isOutput && bt.component == Component.current || bt.isInput && bt.component.parent == Component.current)) {
+          val width = bt.getBitsWidth
+          bt.assignFromBits(bits(offset, width bit))
+          offset = offset + width
+        }
+      }
+    }
+  }
+
   def zipByName(that: MultiData, rec : ArrayBuffer[(BaseType, BaseType)] = ArrayBuffer()): ArrayBuffer[(BaseType, BaseType)] = {
     for ((name, element) <- elements) {
       val other = that.find(name)


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
Assign some uninterested bits to zeros or ones is quite common in engineering. 
# Impact on code generation
None
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
