### PR TITLE
Fix width inferr

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -567,7 +567,20 @@ object Operator {
 
     abstract class Mul extends BinaryOperatorWidthableInputs with Widthable {
       def getLiteralFactory: (BigInt, Int) => Expression
-      override def calcWidth: Int = left.getWidth + right.getWidth
+      override def calcWidth: Int = {
+        val isPowerOfTwoLiteral = right match {
+          case lit: UIntLiteral => 
+            val v = lit.value
+            (v > 0) && ((v & (v - 1)) == 0)
+          case _ => false
+        }
+        
+        if (isPowerOfTwoLiteral) {
+          left.getWidth + right.getWidth - 1
+        } else {
+          left.getWidth + right.getWidth
+        }
+      }
       override def simplifyNode: Expression = {SymplifyNode.binaryInductZeroWithOtherWidth(getLiteralFactory)(this)}
       override def toString() = s"(${super.toString()})[$getWidth bits]"
     }

--- a/tester/src/main/scala/spinal/tester/package.scala
+++ b/tester/src/main/scala/spinal/tester/package.scala
@@ -6,6 +6,12 @@ import spinal.core._
 package object tester {
   val simWorkspacePath = "./simWorkspace"
   class SpinalAnyFunSuite extends AnyFunSuite {
+    def shouldFail(body: => Unit) = assert(try {
+      body
+      false
+    } catch {
+      case e : Throwable => println(e); true
+    })
     SpinalConfig.defaultTargetDirectory = simWorkspacePath
   }
   type SpinalTesterCocotbBase = scalatest.SpinalTesterCocotbBase

--- a/tester/src/test/scala/spinal/core/FactorWidthTest.scala
+++ b/tester/src/test/scala/spinal/core/FactorWidthTest.scala
@@ -1,0 +1,44 @@
+package spinal.core
+
+import spinal.tester._
+import spinal.core.sim._
+import spinal.tester.code.FormalFifo.shouldFail
+
+class FactorWidthTest(factor: Int) extends Component {
+    val io = new Bundle {
+      val din = in UInt (4 bits)
+      val dout = out UInt (6 bits)
+    }
+    io.dout := io.din * factor
+}
+
+class FactorWidthTester extends SpinalAnyFunSuite {
+  test("compile") {
+    SimConfig.allOptimisation
+        .compile(new FactorWidthTest(4))
+  }
+  test("compile_factor_3") {
+    SimConfig.allOptimisation
+        .compile(new FactorWidthTest(3))
+  }
+  test("compile_vhdl") {
+    SimConfig.allOptimisation.withGhdl
+        .compile(new FactorWidthTest(4))
+  }
+  test("compile_factor_3_vhdl") {
+    SimConfig.allOptimisation.withGhdl
+        .compile(new FactorWidthTest(3))
+  }
+  test("compile_factor_5") {
+    shouldFail(SimConfig.allOptimisation
+        .compile(new FactorWidthTest(5)))
+  }
+  test("compile_factor_2") {
+    shouldFail(SimConfig.allOptimisation
+        .compile(new FactorWidthTest(2)))
+  }
+  test("compile_factor_neg") {
+    shouldFail(SimConfig.allOptimisation
+        .compile(new FactorWidthTest(-2)))
+  }
+}

--- a/tester/src/test/scala/spinal/core/FactorWidthTest.scala
+++ b/tester/src/test/scala/spinal/core/FactorWidthTest.scala
@@ -2,7 +2,6 @@ package spinal.core
 
 import spinal.tester._
 import spinal.core.sim._
-import spinal.tester.code.FormalFifo.shouldFail
 
 class FactorWidthTest(factor: Int) extends Component {
     val io = new Bundle {
@@ -40,5 +39,57 @@ class FactorWidthTester extends SpinalAnyFunSuite {
   test("compile_factor_neg") {
     shouldFail(SimConfig.allOptimisation
         .compile(new FactorWidthTest(-2)))
+  }
+}
+
+
+class SFactorWidthTest(factor: Int) extends Component {
+  val io = new Bundle {
+    val din = in SInt (4 bits)
+    val dout = out SInt (6 bits)
+  }
+  io.dout := io.din * factor
+}
+
+class SFactorWidthTester extends SpinalAnyFunSuite {
+  test("compile") {
+    SimConfig.allOptimisation
+        .compile(new SFactorWidthTest(4))
+  }
+  test("compile_factor_3") {
+    SimConfig.allOptimisation
+        .compile(new SFactorWidthTest(3))
+  }
+  test("compile_vhdl") {
+    SimConfig.allOptimisation.withGhdl
+        .compile(new SFactorWidthTest(4))
+  }
+  test("compile_factor_3_vhdl") {
+    SimConfig.allOptimisation.withGhdl
+        .compile(new SFactorWidthTest(3))
+  }
+  test("compile_factor_5") {
+    shouldFail(SimConfig.allOptimisation
+        .compile(new SFactorWidthTest(5)))
+  }
+  test("compile_factor_2") {
+    shouldFail(SimConfig.allOptimisation
+        .compile(new SFactorWidthTest(2)))
+  }
+  test("compile_factor_neg") {
+    shouldFail(SimConfig.allOptimisation
+        .compile(new SFactorWidthTest(-2)))
+  }
+  test("compile_factor_neg_3") {
+    SimConfig.allOptimisation
+        .compile(new SFactorWidthTest(-3))
+  }
+  test("compile_factor_neg_4") {
+    SimConfig.allOptimisation
+        .compile(new SFactorWidthTest(-4))
+  }
+  test("compile_factor_neg_5") {
+    shouldFail(SimConfig.allOptimisation
+        .compile(new SFactorWidthTest(-5)))
   }
 }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1623

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

Although, it only affects the SInt * factor and UInt * factor cases.
There should be lots of changes on the existing code, we should be careful on these changes.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
