### PR TITLE
Fix path where waves get stored for IVerilog and Ghdl backends

### DIFF
--- a/sim/src/main/scala/spinal/sim/GhdlBackend.scala
+++ b/sim/src/main/scala/spinal/sim/GhdlBackend.scala
@@ -103,8 +103,8 @@ class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
     val thread = new Thread(new Runnable {
       val iface = sharedMemIface
       def run(): Unit = {
-        val waveFileDir = Paths.get(System.getProperty("user.dir"), config.testPath.replace("$TEST",testName)).toAbsolutePath.normalize()
-        val waveFile = f"${waveFileDir}/wave.${config.waveFormat.ext}"
+        val waveFilePath = Paths.get(config.testPath.replace("$TEST",testName)).toAbsolutePath.normalize()
+        val waveFile = f"${waveFilePath}/wave.${config.waveFormat.ext}"
         var waveArgString = ""
         if (!(Array(WaveFormat.DEFAULT, WaveFormat.NONE) contains format)) {
           if (format == WaveFormat.GHW) {
@@ -114,7 +114,7 @@ class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
           }
         }
         if (waveArgString != "") {
-          FileUtils.forceMkdirParent(new File(waveFileDir.toString, "."))
+          FileUtils.forceMkdirParent(new File(waveFilePath.toString, "."))
         }
 
         val retCode = Process(

--- a/sim/src/main/scala/spinal/sim/IVerilogBackend.scala
+++ b/sim/src/main/scala/spinal/sim/IVerilogBackend.scala
@@ -155,7 +155,7 @@ class IVerilogBackend(config: IVerilogBackendConfig) extends VpiBackend(config) 
       else (pluginsPath + "/" + vpiModuleName).replaceAll("/C", raw"C:").replaceAll(raw"/", raw"\\")
 
     val pathStr = if (!isWindows) sys.env("PATH")
-    val waveFilePath = Paths.get(System.getProperty("user.dir"), config.testPath.replace("$TEST",testName)).toAbsolutePath.normalize()
+    val waveFilePath = Paths.get(config.testPath.replace("$TEST",testName)).toAbsolutePath.normalize()
 
     val thread = new Thread(new Runnable {
       val iface = sharedMemIface


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
The path where waveforms would be stored was wrong: it would create the absolute path within the java user directory.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
