### PR TITLE
assume ghdl frontend of yosys is compiled within on Windows, just as …

### DIFF
--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -174,9 +174,12 @@ class SymbiYosysFormalBackendImpl(val config: SymbiYosysFormalBackendConfig) ext
   def doVerify(name: String): Unit = {
     println(f"[Progress] Start ${config.toplevelName} formal verification with $name.")
     val isWindows = System.getProperty("os.name").toLowerCase.contains("windows")
-    val command = if (isWindows) "sby.exe" else "sby"
-    val yosysCmd = if (config.withGhdl) "yosys -m ghdl" else "yosys"
-    val success = Process(Seq(command, "--yosys", yosysCmd, "-f", sbyFilePath.toString()), workspacePath.toFile()).!(new Logger()) == 0
+    var command = if (isWindows) Seq("sby.exe") else Seq("sby")
+    if (config.withGhdl && !isWindows) {
+      command ++= Seq("--yosys", "yosys -m ghdl")
+    }
+    command ++= Seq("-f", sbyFilePath.toString())
+    val success = Process(command, workspacePath.toFile()).!(new Logger()) == 0
 
     if (!success) {
       var assertedLines = ArrayBuffer[String]()


### PR DESCRIPTION
…MSYS2 package do. Only built as module requires '-m ghdl' explicitly.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

This assumes ghdl plugins is built into yosys staticly on Windows. 

I do not want to add more option for this tiny difference.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
