### PR TITLE
Add optional 32-bit sysbus to RiscV DebugModule

### DIFF
--- a/lib/src/main/scala/spinal/lib/cpu/riscv/debug/DebugModule.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/debug/DebugModule.scala
@@ -62,19 +62,14 @@ case class DebugSysBusCmd() extends Bundle{
   val size = UInt(2 bit)
 }
 
-case class DebugSysBusRsp() extends Bundle with IMasterSlave{
-  val ready = Bool
+case class DebugSysBusRsp() extends Bundle{
   val error = Bool
   val data = Bits(32 bit)
-
-  override def asMaster(): Unit = {
-    out(ready,error,data)
-  }
 }
 
 case class DebugSysBus() extends Bundle with IMasterSlave{
   val cmd = Stream(DebugSysBusCmd())
-  val rsp = DebugSysBusRsp()
+  val rsp = Flow(DebugSysBusRsp())
 
   override def asMaster(): Unit = {
     master(cmd)
@@ -256,9 +251,9 @@ case class DebugModule(p : DebugModuleParameter) extends Component{
         }
 
         // bus response
-        when(io.sysBus.rsp.ready) {
+        when(io.sysBus.rsp.fire) {
           sbdata0 := io.sysBus.rsp.data
-          when (io.sysBus.rsp.error) {
+          when(io.sysBus.rsp.error) {
             sbcs.sberror := 7
           }
           sysBusBusy := False


### PR DESCRIPTION
# Description
This change adds an optional system bus `sysBus` to the RISC-V DebugModule and implements 32-bit read+write accesses per RISC-V Debug Specification v1.0.

When enabled using `withSysBus = true` in `DebugModuleParameter`, a simple `DebugSysBus` is added to the DebugModule's IO. It is up to the user to handle commands and responses. I've implemented support in VexRiscV's EmbeddedRiscvJtag plugin, and I'll raise a separate PR for that.

Only 32-bit addresses and accesses are supported for now, but this change could be extended for 128, 64, 16, or 8 bit accesses.

# Motivation and Context
Without system bus support, debug memory accesses must go through the CPU. I noticed this when building Rust firmware for a VexRiscV based system with RTT logging. When running the firmware with probe-rs, the host continuously looks for new logs in a ring buffer in memory. Without system bus support, this causes delays in the firmware's execution during those memory polls--not helpful when you're working on something with real-time requirements!

# Impact on code generation
Library change only

# Checklist
- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
