### PR TITLE
Fix CI disk overflow in Verilator v5.018+ by disabling precompiled headers

### DIFF
--- a/.github/workflows/sbt-tests.yml
+++ b/.github/workflows/sbt-tests.yml
@@ -103,6 +103,8 @@ jobs:
     timeout-minutes: 90
     container:
       image: ghcr.io/spinalhdl/docker:latest
+    env:
+      VM_DEFAULT_RULES: "0"  # 禁用预编译头文件
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled
@@ -136,6 +138,8 @@ jobs:
     timeout-minutes: 90
     container:
       image: ghcr.io/spinalhdl/docker:latest
+    env:
+      VM_DEFAULT_RULES: "0"  # 禁用预编译头文件
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/get-compiled


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

The GitHub Actions CI test of the SpinalHDL project encountered a tricky problem of insufficient disk space. This problem is particularly stubborn and only appears in Verilator v5.018 and later versions.When multiple workflows (e.g. lib-test and tester-test) are running concurrently, the disk usage increases from the normal 1.7GB to well over the 23GB of free disk remaining, resulting in a "No space left on device" error and forced interruption.The test was interrupted.But if you run tester-test on its own, it passes regardless of the Verilator version, which makes me start to suspect that the problem is with a particular mechanism of concurrent builds.

Digging deeper, I located the root cause: Verilator v5.018 introduced precompiled header file (PCH) support, which was intended to speed up compilation but is counterproductive in large-scale projects such as SpinalHDL.When more than 128 C++ files are generated (a threshold easily reached by our tests), Verilator enables parallel build mode, generating .fast.gch and .slow.gch files for each compilation unit.These files can be 15-70MB in size individually, and cumulatively become disk killers - especially in the free version of GitHub Actions, where 72GB of total disk is quickly exhausted. v5.016 and earlier didn't have this mechanism, so everything was fine; but since v5.018, this "optimization" has been in place since v5.018, so it's not a problem.But from v5.018 onwards, this "optimization" has become a hidden problem.

To fix this, I added an environment variable setting to the CI workflow (e.g. sbt-tests.yml): VM_DEFAULT_RULES=0. This skips the pre-compile header file rules in the Verilator Makefile, forcing a fallback to the traditional direct compilation method.Testing has proven that this immediately pulls disk usage back to about 3GB, solving the overflow problem while having no negative impact on older versions of Verilator.The only tradeoff is a possible 10-15% increase in compile time, but in a CI environment this is far more acceptable than a test failure.


# Impact on code generation

This change is purely an optimization for the CI configuration and does not involve the SpinalHDL core code or any VHDL/Verilog/SystemVerilog generation logic.As a result, there is zero impact on code generation - generated RTL files, simulation behavior, and output formats are unaffected.The only change is that the CI tests are more stable and can run reliably with the new version of Verilator without interruption due to disk problems.
# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
