### PR TITLE
Add Workaround for RAM with init values in sim

### DIFF
--- a/core/src/main/scala/spinal/core/Mem.scala
+++ b/core/src/main/scala/spinal/core/Mem.scala
@@ -389,13 +389,7 @@ class Mem[T <: Data](val wordType: HardType[T], val wordCount: Int) extends Decl
   def writeImpl(address: UInt, data: Data, enable: Bool = null, mask: Bits = null, allowMixedWidth: Boolean = false): Unit = {
 
     val whenCond =  if(enable == null) ConditionalContext.isTrue() else enable
-    val whenGuarded =
-      if (GenerationFlags.simulation) {
-        val dummy = RegInit(B(True, 256))
-        dummy.setAll()
-        dummy.andR && whenCond
-      } else whenCond
-    val writePort = MemWrite(this, address, data.asBits, mask, whenGuarded, if(allowMixedWidth) data.getBitsWidth else getWidth ,ClockDomain.current)
+    val writePort = MemWrite(this, address, data.asBits, mask, whenCond, if(allowMixedWidth) data.getBitsWidth else getWidth ,ClockDomain.current)
     this.parentScope.append(writePort)
     this.dlcAppend(writePort)
 
@@ -477,13 +471,8 @@ class Mem[T <: Data](val wordType: HardType[T], val wordCount: Int) extends Decl
                                    clockCrossing   : Boolean = false,
                                    allowMixedWidth : Boolean = false,
                                    duringWrite : DuringWritePolicy = dontCare): U = {
-    val enableGuarded =
-      if (GenerationFlags.simulation) {
-        val dummy = RegInit(B(True, 256))
-        dummy.setAll()
-        dummy.andR && enable
-      } else enable
-    val readWritePort = MemReadWrite(this, address, data.asBits, mask, enableGuarded, write, if(allowMixedWidth) data.getBitsWidth else getWidth ,ClockDomain.current, readUnderWrite, duringWrite)
+
+    val readWritePort = MemReadWrite(this, address, data.asBits, mask,enable, write, if(allowMixedWidth) data.getBitsWidth else getWidth ,ClockDomain.current, readUnderWrite, duringWrite)
 
     this.parentScope.append(readWritePort)
     this.dlcAppend(readWritePort)

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -675,7 +675,7 @@ case class SpinalSimConfig(
                             var _workspacePath     : String = System.getenv().getOrDefault("SPINALSIM_WORKSPACE","./simWorkspace"),
                             var _workspaceName     : String = null,
                             var _waveDepth         : Int = 0, //0 => all
-                            var _spinalConfig      : SpinalConfig = SpinalConfig(),
+                            var _spinalConfig      : SpinalConfig = SpinalConfig().includeSimulation,
                             var _optimisationLevel : Int = 0,
                             var _simulatorFlags    : ArrayBuffer[String] = ArrayBuffer[String](),
                             var _runFlags          : ArrayBuffer[String] = ArrayBuffer[String](),


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

This is a workaround for #1259
The issue being with a RAM that has an init value, when using verilator it gets randomly overwritten at the initialization of the simulation.
The Init of the sim gets interpreted by the sim as a clock event if understand correctly, and then it is random if write enable is high or not. This is workaround by ANDing the enable with a wide register that gets reset to all ones. Thus being always one except for in init where it is very unlikely to be all ones.
I think this is quite hacky, but I do not have a better idea.

# Checklist

- [X] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
