### PR TITLE
Enable nested FiberPlugin 

### DIFF
--- a/lib/src/main/scala/spinal/lib/misc/plugin/Fiber.scala
+++ b/lib/src/main/scala/spinal/lib/misc/plugin/Fiber.scala
@@ -53,7 +53,10 @@ class FiberPlugin extends Area with Hostable {
 
   override def setHost(h: PluginHost): Unit = {
     h.addService(this)
-    subservices.foreach(h.addService)
+    subservices.foreach {
+      case s: Hostable => s.setHost(h)
+      case s => h.addService(s)
+    }
     host = h
     if(!isNamed){
       this.setName(ClassName(this))


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1779

# Context, Motivation & Description
Modify the implementation of FiberPlugin.setHost to enable nested usage of FiberPlugin.

# Impact on code generation
Has no impact on code generation. However , I'm not entirely certain  whether it might affect projects that heavily depend on fiberplugin, like VexiiRiscv

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
