### PR TITLE
Revert "fix(sim): Prevent JVM crash on repeated doSim with Verilator5.x+"

### DIFF
--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -1078,32 +1078,10 @@ case class SpinalSimConfig(
         val deltaTime = (System.nanoTime() - startAt) * 1e-6
         println(f"[Progress] Verilator compilation done in $deltaTime%1.3f ms")
         new SimCompiled(report, compiledPath, this){
-          private val handles = mutable.ArrayBuffer[Long]()
-
           override def newSimRaw(name: String, seed: Int): SimRaw = {
-            val handle = backend.instanciate(name, seed)
-            handles.synchronized {
-              handles += handle
-            }
-            val raw = new SimVerilator(backend, handle, doEnd=false)
+            val raw = new SimVerilator(backend, backend.instanciate(name, seed))
             raw.userData = backend.config.signals
             raw
-          }
-
-          override def finalize(): Unit = {
-            try {
-              handles.synchronized {
-                if(handles.nonEmpty){
-                  //println(s"Finalizing ${_workspaceName}, cleaning up ${handles.size} C++ handles.")
-                  for(handle <- handles){
-                    backend.nativeInstance.deleteHandle(handle)
-                  }
-                  handles.clear()
-                }
-              }
-            } finally {
-              super.finalize()
-            }
           }
         }
 

--- a/sim/src/main/scala/spinal/sim/SimVerilator.scala
+++ b/sim/src/main/scala/spinal/sim/SimVerilator.scala
@@ -5,8 +5,7 @@ object SimVerilator{
 }
 
 class SimVerilator(backend : VerilatorBackend, 
-                   handle : Long,
-                   doEnd: Boolean = true) extends SimRaw(){
+                   handle : Long) extends SimRaw(){
   
   override def getIntMem(signal : Signal,
                       index : Long) : Int = {
@@ -108,7 +107,7 @@ class SimVerilator(backend : VerilatorBackend,
   override def sleep(cycles : Long) = backend.nativeInstance.sleep(handle, cycles)
   override def end() = {
     backend.nativeInstance.synchronized(backend.nativeInstance.close(handle))
-    if(doEnd) backend.nativeInstance.synchronized(backend.nativeInstance.deleteHandle(handle))
+    backend.nativeInstance.synchronized(backend.nativeInstance.deleteHandle(handle))
   }
   override def isBufferedWrite : Boolean = false
   override def enableWave(): Unit = backend.nativeInstance.enableWave(handle)

--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -327,7 +327,7 @@ ${    val signalInits = for((signal, id) <- config.signals.zipWithIndex) yield {
       //contextp->threadContextp()->gotFinish(true);
       top->final();
       delete top;
-      //delete contextp;
+      delete contextp;
     }
 
 };


### PR DESCRIPTION


This reverts commit 4c2560d32d9a8daa142297e1eb98ba8d02d926b5.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
I realized that the problem with one of my previous PR submissions (https://github.com/SpinalHDL/SpinalHDL/pull/1757) :,can also be fixed by this PR's (https://github.com/SpinalHDL/SpinalHDL/pull/1773),So delete the redundancy
<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
This is a simulation backend change only, with zero impact on VHDL/Verilog/SystemVerilog code generation, RTL output, or simulation logic.
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
