### PR TITLE
Add random isolation test suites for SpinalHDL and Verilator

### DIFF
--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimRandomIsolationTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimRandomIsolationTester.scala
@@ -1,0 +1,193 @@
+package spinal.tester.scalatest
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.tester.SpinalAnyFunSuite
+
+import scala.collection.mutable
+import scala.concurrent.{Future, Await}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+/**
+ * SpinalHDL Random Number Isolation Test Suite
+ *
+ * This test suite focuses on isolation and consistency verification of SpinalHDL's
+ * random number generation mechanisms, complementing the basic functionality tests
+ * in SpinalSimRandomizeTester.scala.
+ *
+ * Test Coverage:
+ * 1. SpinalHDL's simRandom isolation between simulation runs
+ * 2. Signal randomization consistency and reproducibility
+ * 3. Seed independence verification
+ */
+case class RandomIsolationTestDut() extends Component {
+  val io = new Bundle {
+    // Randomizable input signals for testing randomize() method
+    val randomInput8 = in UInt(8 bits)
+    val randomInput16 = in UInt(16 bits)
+    val randomInput32 = in UInt(32 bits)
+    val randomInputBool = in Bool()
+
+    // Output signals that directly reflect the randomized inputs
+    val randomData8 = out UInt(8 bits)
+    val randomData16 = out UInt(16 bits)
+    val randomData32 = out UInt(32 bits)
+    val randomBool = out Bool()
+  }
+
+  // Direct output connections - no register delay
+  io.randomData8 := io.randomInput8
+  io.randomData16 := io.randomInput16
+  io.randomData32 := io.randomInput32
+  io.randomBool := io.randomInputBool
+}
+
+class SpinalSimRandomIsolationTester extends SpinalAnyFunSuite {
+  var dut: SimCompiled[RandomIsolationTestDut] = null
+  val testIterations = 30
+  val testTimeout = 120.seconds
+
+  test("compile") {
+    dut = SimConfig
+      .withConfig(SpinalConfig(
+        defaultConfigForClockDomains = ClockDomainConfig(resetActiveLevel = HIGH)
+      ))
+      .compile(RandomIsolationTestDut())
+  }
+
+  test("same seed produces identical results") {
+    val testSeed = 12345
+
+    def runSimulation(name: String): (List[Long], List[Long], List[Long]) = {
+      val simRandomSeq = mutable.ArrayBuffer[Long]()
+      val signalRandomSeq8 = mutable.ArrayBuffer[Long]()
+      val signalRandomSeq16 = mutable.ArrayBuffer[Long]()
+
+      dut.doSim(seed = testSeed, name = name) { dut =>
+        dut.clockDomain.forkStimulus(10)
+
+        for (_ <- 0 until testIterations) {
+          // Collect SpinalHDL's simRandom
+          simRandomSeq += simRandom.nextLong()
+
+          // Randomize input signals and collect output results
+          dut.io.randomInput8.randomize()
+          dut.io.randomInput16.randomize()
+          signalRandomSeq8 += dut.io.randomData8.toLong
+          signalRandomSeq16 += dut.io.randomData16.toLong
+
+          dut.clockDomain.waitSampling()
+        }
+      }
+
+      (simRandomSeq.toList, signalRandomSeq8.toList, signalRandomSeq16.toList)
+    }
+
+    // Run two simulations with the same seed
+    val (simSeq1, sigSeq8_1, sigSeq16_1) = runSimulation("test1")
+    val (simSeq2, sigSeq8_2, sigSeq16_2) = runSimulation("test2")
+
+    // Verify consistency
+    assert(simSeq1 == simSeq2, "simRandom sequences should be identical!")
+    assert(sigSeq8_1 == sigSeq8_2, "8-bit signal randomization sequences should be identical!")
+    assert(sigSeq16_1 == sigSeq16_2, "16-bit signal randomization sequences should be identical!")
+  }
+
+  test("different seeds produce different results") {
+    val seed1 = 11111
+    val seed2 = 22222
+
+    def runWithSeed(seed: Int, name: String): (List[Long], List[Long]) = {
+      val simRandomSeq = mutable.ArrayBuffer[Long]()
+      val signalRandomSeq = mutable.ArrayBuffer[Long]()
+
+      dut.doSim(seed = seed, name = name) { dut =>
+        dut.clockDomain.forkStimulus(10)
+
+        for (_ <- 0 until testIterations) {
+          simRandomSeq += simRandom.nextLong()
+          dut.io.randomInput16.randomize()
+          dut.clockDomain.waitSampling()
+          signalRandomSeq += dut.io.randomData16.toLong
+        }
+      }
+
+      (simRandomSeq.toList, signalRandomSeq.toList)
+    }
+
+    val (simSeq1, sigSeq1) = runWithSeed(seed1, "seed1")
+    val (simSeq2, sigSeq2) = runWithSeed(seed2, "seed2")
+
+    // Calculate difference ratios
+    val simDiff = simSeq1.zip(simSeq2).count { case (a, b) => a != b }
+    val sigDiff = sigSeq1.zip(sigSeq2).count { case (a, b) => a != b }
+    val simRatio = simDiff.toDouble / testIterations
+    val sigRatio = sigDiff.toDouble / testIterations
+
+    assert(simRatio > 0.95, s"Different seeds should produce mostly different simRandom values, actual difference: ${simRatio * 100}%")
+    assert(sigRatio > 0.95, s"Different seeds should produce mostly different signal randomization, actual difference: ${sigRatio * 100}%")
+  }
+
+  test("concurrent simulations with same seed") {
+    val testSeed = 33333
+    val numRuns = 3
+
+    // Create concurrent simulation tasks
+    val futures = (1 to numRuns).map { run =>
+      Future {
+        val simRandomSeq = mutable.ArrayBuffer[Long]()
+
+        dut.doSim(seed = testSeed, name = s"concurrent_${testSeed}_$run") { dut =>
+          dut.clockDomain.forkStimulus(10)
+
+          for (_ <- 0 until 5) { 
+            simRandomSeq += simRandom.nextLong()
+            dut.clockDomain.waitSampling()
+          }
+        }
+
+        simRandomSeq.toList
+      }
+    }
+
+    // Wait for all simulations to complete
+    val results = Await.result(Future.sequence(futures), testTimeout)
+
+    // Verify consistency - all runs with same seed should produce identical sequences
+    val firstSeq = results.head
+    val allSame = results.forall(_ == firstSeq)
+    assert(allSame, s"All runs with seed $testSeed should produce identical sequences")
+  }
+
+  test("reproducibility across multiple runs") {
+    val testSeed = 98765
+    val numRuns = 3
+
+    // Run the same test multiple times to verify reproducibility
+    val allResults = (1 to numRuns).map { run =>
+      val simRandomSeq = mutable.ArrayBuffer[Long]()
+      val signalRandomSeq = mutable.ArrayBuffer[Long]()
+
+      dut.doSim(seed = testSeed, name = s"repro_$run") { dut =>
+        dut.clockDomain.forkStimulus(10)
+
+        for (_ <- 0 until testIterations) {
+          simRandomSeq += simRandom.nextLong()
+          dut.io.randomInput32.randomize()
+          signalRandomSeq += dut.io.randomData32.toLong
+          dut.clockDomain.waitSampling()
+        }
+      }
+
+      (simRandomSeq.toList, signalRandomSeq.toList)
+    }
+
+    // Verify all runs produce identical results
+    val (referenceSimSeq, referenceSignalSeq) = allResults.head
+    allResults.foreach { case (simSeq, signalSeq) =>
+      assert(simSeq == referenceSimSeq, "All runs should produce identical simRandom sequences")
+      assert(signalSeq == referenceSignalSeq, "All runs should produce identical signal randomization sequences")
+    }
+  }
+}

--- a/tester/src/test/scala/spinal/tester/scalatest/VerilatorRandomIsolationTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/VerilatorRandomIsolationTester.scala
@@ -1,0 +1,206 @@
+package spinal.tester.scalatest
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.tester.SpinalAnyFunSuite
+
+import scala.collection.mutable
+import scala.concurrent.{Future, Await}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+/**
+ * Verilator Random Number Generator Isolation Test Suite
+ *
+ * This test suite focuses on Verilator's VL_RAND_RESET mechanism and VerilatedContext
+ * architecture isolation testing, complementing SpinalHDL's random isolation tests.
+ *
+ * Key Focus Areas:
+ * 1. Signal initialization randomization isolation between simulation runs
+ * 2. VerilatedContext architecture validation
+ * 3. VL_RAND_RESET function verification and consistency testing
+ */
+case class VerilatorRandomTestDut() extends Component {
+  val io = new Bundle {
+    val enable = in Bool()
+
+    // Signals for testing Verilator randomization
+    val verilatorRandom8 = out UInt(8 bits)
+    val verilatorRandom16 = out UInt(16 bits)
+    val verilatorRandom32 = out UInt(32 bits)
+    val verilatorRandom64 = out UInt(64 bits)
+    val verilatorRandomBool = out Bool()
+
+    // Signals for testing initialization with explicit init values
+    val initReg8 = out UInt(8 bits)
+    val initReg16 = out UInt(16 bits)
+    val initReg32 = out UInt(32 bits)
+    val initReg64 = out UInt(64 bits)
+    val initRegBool = out Bool()
+  }
+
+  // Registers without init() - rely on Verilator VL_RAND_RESET mechanism
+  val randomReg8 = Reg(UInt(8 bits))
+  val randomReg16 = Reg(UInt(16 bits))
+  val randomReg32 = Reg(UInt(32 bits))
+  val randomReg64 = Reg(UInt(64 bits))
+  val randomRegBool = Reg(Bool())
+
+  // Simple assignment logic to avoid compilation errors while preserving Verilator initialization
+  when(io.enable) {
+    randomReg8 := randomReg8
+    randomReg16 := randomReg16
+    randomReg32 := randomReg32
+    randomReg64 := randomReg64
+    randomRegBool := randomRegBool
+  }
+
+  // Registers with explicit init() values for comparison
+  val initReg8 = Reg(UInt(8 bits)) init(0)
+  val initReg16 = Reg(UInt(16 bits)) init(0)
+  val initReg32 = Reg(UInt(32 bits)) init(0)
+  val initReg64 = Reg(UInt(64 bits)) init(0)
+  val initRegBool = Reg(Bool()) init(False)
+
+  // Simple counter logic to avoid simulation warnings
+  when(io.enable) {
+    initReg8 := initReg8 + 1
+    initReg16 := initReg16 + 1
+    initReg32 := initReg32 + 1
+    initReg64 := initReg64 + 1
+    initRegBool := !initRegBool
+  }
+
+  // Output connections
+  io.verilatorRandom8 := randomReg8
+  io.verilatorRandom16 := randomReg16
+  io.verilatorRandom32 := randomReg32
+  io.verilatorRandom64 := randomReg64
+  io.verilatorRandomBool := randomRegBool
+
+  io.initReg8 := initReg8
+  io.initReg16 := initReg16
+  io.initReg32 := initReg32
+  io.initReg64 := initReg64
+  io.initRegBool := initRegBool
+}
+
+class VerilatorRandomIsolationTester extends SpinalAnyFunSuite {
+  var dut: SimCompiled[VerilatorRandomTestDut] = null
+  val testTimeout = 120.seconds
+
+  test("compile") {
+    dut = SimConfig
+      .withConfig(SpinalConfig(
+        defaultConfigForClockDomains = ClockDomainConfig(resetActiveLevel = HIGH)
+      ))
+      .compile(VerilatorRandomTestDut())
+  }
+
+  /**
+   * Run a single simulation and collect initial values
+   */
+  def runSingleSimulation(instanceName: String, seed: Int): Map[String, Long] = {
+    val verilatorRandomValues = mutable.Map[String, Long]()
+
+    dut.doSim(seed = seed, name = instanceName) { dut =>
+      dut.clockDomain.forkStimulus(10)
+      dut.io.enable #= true
+
+      dut.clockDomain.waitSampling(1)
+
+      // Collect Verilator randomized signal initial values
+      verilatorRandomValues("random8") = dut.io.verilatorRandom8.toLong
+      verilatorRandomValues("random16") = dut.io.verilatorRandom16.toLong
+      verilatorRandomValues("random32") = dut.io.verilatorRandom32.toLong
+      verilatorRandomValues("random64") = dut.io.verilatorRandom64.toBigInt.toLong
+      verilatorRandomValues("randomBool") = if (dut.io.verilatorRandomBool.toBoolean) 1L else 0L
+
+      dut.clockDomain.waitSampling()
+    }
+
+    verilatorRandomValues.toMap
+  }
+
+  test("same seed produces identical Verilator random values") {
+    val testSeed = 12345
+    val numInstances = 3
+
+    // Run multiple instances with the same seed
+    val results = (1 to numInstances).map { i =>
+      runSingleSimulation(s"consistency_$i", testSeed)
+    }
+
+    // Verify all instances produce identical initial values
+    val referenceValues = results.head
+    results.foreach { result =>
+      assert(result == referenceValues,
+        "All instances with same seed should have identical Verilator random values")
+    }
+  }
+
+  test("different seeds produce different Verilator random values") {
+    val seeds = List(11111, 22222, 33333, 44444)
+
+    // Run simulations with different seeds
+    val results = seeds.zipWithIndex.map { case (seed, i) =>
+      runSingleSimulation(s"diffSeed_$i", seed)
+    }
+
+    // Verify different seeds produce different results
+    val allDifferent = results.combinations(2).forall { case List(r1, r2) =>
+      r1 != r2
+    }
+
+    assert(allDifferent, "Different seeds should produce different Verilator random values")
+  }
+
+  test("concurrent simulations maintain isolation") {
+    val testSeed = 55555
+    val numRuns = 3
+
+    // Create concurrent simulation tasks
+    val futures = (1 to numRuns).map { run =>
+      Future {
+        runSingleSimulation(s"concurrent_${testSeed}_$run", testSeed)
+      }
+    }
+
+    // Wait for all simulations to complete
+    val results = Await.result(Future.sequence(futures), testTimeout)
+
+    // Verify consistency - all runs with same seed should produce identical values
+    val firstResult = results.head
+    val allSame = results.forall(_ == firstResult)
+    assert(allSame, s"All concurrent runs with seed $testSeed should produce identical values")
+  }
+
+  test("VerilatedContext architecture validation") {
+    // This test verifies the VerilatedContext isolation mechanism
+    val testSeeds = List(24680, 13579, 97531)
+
+    val results = testSeeds.map { seed =>
+      val result = runSingleSimulation(s"context_arch_$seed", seed)
+      (seed, result)
+    }
+
+    // Verify that each seed produces unique results
+    val seedToValues = results.toMap
+    val allValues = seedToValues.values.toList
+    val uniqueValues = allValues.toSet
+    assert(uniqueValues.size == allValues.size,
+      "Each seed should produce unique values (VerilatedContext isolation working)")
+
+    // Run the same seeds again to verify reproducibility
+    val reproducibilityResults = testSeeds.map { seed =>
+      val result = runSingleSimulation(s"context_repro_$seed", seed)
+      (seed, result)
+    }
+
+    // Verify reproducibility
+    reproducibilityResults.foreach { case (seed, values) =>
+      assert(seedToValues(seed) == values,
+        s"Seed $seed should produce identical values on repeated runs")
+    }
+  }
+}


### PR DESCRIPTION
- Introduced SpinalSimRandomIsolationTester to verify isolation and consistency of SpinalHDL's random number generation.
- Added VerilatorRandomIsolationTester to test VL_RAND_RESET mechanism and ensure randomization isolation in Verilator.
- Both test suites include checks for seed consistency, reproducibility, and concurrent simulation behavior.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
I found that SpinalHDL does not currently perform a complete ci test on the randomizer, so I added this part of the content, including the randomizer test at the SpinalHDL level and the Verilator level.
<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
zero
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
