### PR TITLE
Fix Floating.abs

### DIFF
--- a/lib/src/main/scala/spinal/lib/experimental/math/FloatingUtils.scala
+++ b/lib/src/main/scala/spinal/lib/experimental/math/FloatingUtils.scala
@@ -13,6 +13,8 @@ object FloatingAbs {
     */
   def apply(that: Floating): Floating = {
     val x = cloneOf(that)
+    x.mantissa := that.mantissa
+    x.exponent := that.exponent
     x.sign := False
     x
   }
@@ -24,6 +26,8 @@ object FloatingAbs {
     */
   def apply(that: RecFloating): RecFloating = {
     val x = cloneOf(that)
+    x.mantissa := that.mantissa
+    x.exponent := that.exponent
     x.sign := False
     x
   }

--- a/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester.scala
+++ b/tester/src/test/scala/spinal/lib/experimental/math/FloatingTester.scala
@@ -13,6 +13,7 @@ class FloatingTester extends Component {
     val snan = out Bool()
     val positive = out Bool()
     val infinite = out Bool()
+    val abs = out(Floating32())
     val recoded_sign = out Bool()
     val recoded_exp = out Bits(9 bits)
     val recoded_mantissa = out Bits(23 bits)
@@ -48,6 +49,7 @@ class FloatingTester extends Component {
   io.snan := rec.isSNaN
   io.positive := rec.isPositive
   io.infinite := rec.isInfinite
+  io.abs := io.inp.abs
 
   // FP to recoded
   io.recoded_sign := rec.sign


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

`FloatingAbs` did not actually assign `exponent` and `mantissa`. This fixes that.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
