### PR TITLE
Add `RoundType.NONE`

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -329,6 +329,11 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
             _roundFixedBigInt(i, exp, ROUNDUP)
           }
         }
+      case NONE => {
+        assert(exp <= 0, "RoundType is NONE but rounding requires losing precision")
+        i
+      }
+
     }
   }
 

--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -1084,7 +1084,11 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
       case RoundType.ROUNDTOINF  => this.roundToInf(exp, align)
       case RoundType.ROUNDTOEVEN => this.roundToEven(exp, align)
       case RoundType.ROUNDTOODD  => this.roundToOdd(exp, align)
-      case RoundType.SCRAP        => this.scrap(exp)
+      case RoundType.SCRAP       => this.scrap(exp)
+      case RoundType.NONE        => {
+        assert(exp <= this.exp, "RoundType is NONE but rounding requires losing precision")
+        CombInit(this)
+      }
     }
   }
 

--- a/core/src/main/scala/spinal/core/FixedPoint.scala
+++ b/core/src/main/scala/spinal/core/FixedPoint.scala
@@ -39,7 +39,8 @@ object RoundType {
   case object ROUNDTOINF     extends RoundType ;// Wikipedia name: RoundHalfToInf
   case object ROUNDTOEVEN    extends RoundType ;// Wikipedia name: RoundHalfToEven; Have not been implemented yet
   case object ROUNDTOODD     extends RoundType ;// Wikipedia name: RoundHalfToOdd ; Have not been implemented yet
-  case object SCRAP           extends RoundType ;// If any bitsthrown is set, then LSB will be set
+  case object SCRAP          extends RoundType ;// If any bitsthrown is set, then LSB will be set
+  case object NONE           extends RoundType ;// Only allow no-ops and right-padding; throw an error otherwise
 }
 
 case class FixPointConfig(roundType: RoundType,

--- a/core/src/main/scala/spinal/core/SInt.scala
+++ b/core/src/main/scala/spinal/core/SInt.scala
@@ -399,6 +399,10 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
       case RoundType.ROUNDTOINF    => this.roundToInf(roundN, false).sat(satN + 1)
       case RoundType.ROUNDTOEVEN   => this.roundToEven(roundN, false).sat(satN + 1)
       case RoundType.ROUNDTOODD    => this.roundToOdd(roundN, false).sat(satN + 1)
+      case RoundType.NONE          => {
+        assert(roundN <= 0, "RoundType is NONE but rounding requires losing precision")
+        this << -roundN
+      }.sat(satN)
     }
   }
 

--- a/core/src/main/scala/spinal/core/UInt.scala
+++ b/core/src/main/scala/spinal/core/UInt.scala
@@ -281,6 +281,10 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
       case RoundType.ROUNDTOINF    => this.roundToInf(roundN, false).sat(satN + 1)
       case RoundType.ROUNDTOEVEN   => this.roundToEven(roundN, false).sat(satN + 1)
       case RoundType.ROUNDTOODD    => this.roundToOdd(roundN, false).sat(satN + 1)
+      case RoundType.NONE          => {
+        assert(roundN <= 0, "RoundType is NONE but rounding requires losing precision")
+        this << -roundN
+      }.sat(satN)
     }
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Related to ideas in #1476 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

Sometimes a function will have a `RoundType` argument that decides how rounding is done, but you want to make sure that you don't actually lose any bits. This adds a new `RoundType` which enforces that by throwing an error if bits are lost.

 This is pretty much done except for tests, but I wanted to get some thoughts on it before I bother to figure out how to write a test that checks for an error :P

# Checklist

- [ ] Unit tests were added - not yet
- [ ] API changes are or will be documented - needs a new row on rounding modes table [here](https://github.com/SpinalHDL/SpinalDoc-RTD/blob/master/source/SpinalHDL/Data%20types/Int.rst) ; I will make a PR if people like this idea.
