### PR TITLE
AFix round() variants

### DIFF
--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -422,9 +422,13 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
           (false, 3, -4, 2, RoundType.CEIL, 2, 2),
         )
         for ((ignoreExpand, maxRaw, minRaw, roundBits, roundType, resultBits, resultExp) <- EXAMPLES) {
-          val rounded = new AFix(maxRaw, minRaw, 0).round(roundBits bits, roundType, ignoreExpand)
+          val original = new AFix(maxRaw, minRaw, 0)
+          val rounded = original.round(roundBits bits, roundType, ignoreExpand)
           assert(rounded.getBitsWidth == resultBits)
           assert(rounded.exp == resultExp)
+          val roundedOff = original.roundOffBits(original.getBitsWidth - roundBits bits, roundType, ignoreExpand)
+          assert(roundedOff.getBitsWidth == resultBits)
+          assert(roundedOff.exp == resultExp)
         }
       }
     })

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -386,50 +386,48 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
   test("round_bits") {
     SimConfig.compile(new Component {
       // tuples: ignore expansion?, maxRaw, minRaw, round bits, round type, expected bits, expected resolution
-      {
-        val EXAMPLES = List(
-          (true, 6, 0, 3, RoundType.FLOOR, 3, 0),
-          (true, 6, 0, 3, RoundType.CEIL, 3, 0),
-          (true, 7, 0, 3, RoundType.FLOOR, 3, 0),
-          (true, 7, 0, 3, RoundType.CEIL, 3, 0),
-          (true, 6, 0, 2, RoundType.FLOOR, 2, 1),
-          (true, 6, 0, 2, RoundType.CEIL, 2, 1),
-          (true, 7, 0, 2, RoundType.FLOOR, 2, 1),
-          (true, 7, 0, 2, RoundType.CEIL, 3, 1),
-          (true, 2, -4, 3, RoundType.FLOOR, 3, 0),
-          (true, 2, -4, 3, RoundType.CEIL, 3, 0),
-          (true, 3, -4, 3, RoundType.FLOOR, 3, 0),
-          (true, 3, -4, 3, RoundType.CEIL, 3, 0),
-          (true, 2, -4, 2, RoundType.FLOOR, 2, 1),
-          (true, 2, -4, 2, RoundType.CEIL, 2, 1),
-          (true, 3, -4, 2, RoundType.FLOOR, 2, 1),
-          (true, 3, -4, 2, RoundType.CEIL, 3, 1),
-          (false, 6, 0, 3, RoundType.FLOOR, 3, 0),
-          (false, 6, 0, 3, RoundType.CEIL, 3, 0),
-          (false, 7, 0, 3, RoundType.FLOOR, 3, 0),
-          (false, 7, 0, 3, RoundType.CEIL, 3, 0),
-          (false, 6, 0, 2, RoundType.FLOOR, 2, 1),
-          (false, 6, 0, 2, RoundType.CEIL, 2, 1),
-          (false, 7, 0, 2, RoundType.FLOOR, 2, 1),
-          (false, 7, 0, 2, RoundType.CEIL, 2, 2),
-          (false, 2, -4, 3, RoundType.FLOOR, 3, 0),
-          (false, 2, -4, 3, RoundType.CEIL, 3, 0),
-          (false, 3, -4, 3, RoundType.FLOOR, 3, 0),
-          (false, 3, -4, 3, RoundType.CEIL, 3, 0),
-          (false, 2, -4, 2, RoundType.FLOOR, 2, 1),
-          (false, 2, -4, 2, RoundType.CEIL, 2, 1),
-          (false, 3, -4, 2, RoundType.FLOOR, 2, 1),
-          (false, 3, -4, 2, RoundType.CEIL, 2, 2),
-        )
-        for ((ignoreExpand, maxRaw, minRaw, roundBits, roundType, resultBits, resultExp) <- EXAMPLES) {
-          val original = new AFix(maxRaw, minRaw, 0)
-          val rounded = original.round(roundBits bits, roundType, ignoreExpand)
-          assert(rounded.getBitsWidth == resultBits)
-          assert(rounded.exp == resultExp)
-          val roundedOff = original.roundOffBits(original.getBitsWidth - roundBits bits, roundType, ignoreExpand)
-          assert(roundedOff.getBitsWidth == resultBits)
-          assert(roundedOff.exp == resultExp)
-        }
+      val EXAMPLES = List(
+        (true, 6, 0, 3, RoundType.FLOOR, 3, 0),
+        (true, 6, 0, 3, RoundType.CEIL, 3, 0),
+        (true, 7, 0, 3, RoundType.FLOOR, 3, 0),
+        (true, 7, 0, 3, RoundType.CEIL, 3, 0),
+        (true, 6, 0, 2, RoundType.FLOOR, 2, 1),
+        (true, 6, 0, 2, RoundType.CEIL, 2, 1),
+        (true, 7, 0, 2, RoundType.FLOOR, 2, 1),
+        (true, 7, 0, 2, RoundType.CEIL, 3, 1),
+        (true, 2, -4, 3, RoundType.FLOOR, 3, 0),
+        (true, 2, -4, 3, RoundType.CEIL, 3, 0),
+        (true, 3, -4, 3, RoundType.FLOOR, 3, 0),
+        (true, 3, -4, 3, RoundType.CEIL, 3, 0),
+        (true, 2, -4, 2, RoundType.FLOOR, 2, 1),
+        (true, 2, -4, 2, RoundType.CEIL, 2, 1),
+        (true, 3, -4, 2, RoundType.FLOOR, 2, 1),
+        (true, 3, -4, 2, RoundType.CEIL, 3, 1),
+        (false, 6, 0, 3, RoundType.FLOOR, 3, 0),
+        (false, 6, 0, 3, RoundType.CEIL, 3, 0),
+        (false, 7, 0, 3, RoundType.FLOOR, 3, 0),
+        (false, 7, 0, 3, RoundType.CEIL, 3, 0),
+        (false, 6, 0, 2, RoundType.FLOOR, 2, 1),
+        (false, 6, 0, 2, RoundType.CEIL, 2, 1),
+        (false, 7, 0, 2, RoundType.FLOOR, 2, 1),
+        (false, 7, 0, 2, RoundType.CEIL, 2, 2),
+        (false, 2, -4, 3, RoundType.FLOOR, 3, 0),
+        (false, 2, -4, 3, RoundType.CEIL, 3, 0),
+        (false, 3, -4, 3, RoundType.FLOOR, 3, 0),
+        (false, 3, -4, 3, RoundType.CEIL, 3, 0),
+        (false, 2, -4, 2, RoundType.FLOOR, 2, 1),
+        (false, 2, -4, 2, RoundType.CEIL, 2, 1),
+        (false, 3, -4, 2, RoundType.FLOOR, 2, 1),
+        (false, 3, -4, 2, RoundType.CEIL, 2, 2)
+      )
+      for ((ignoreExpand, maxRaw, minRaw, roundBits, roundType, resultBits, resultExp) <- EXAMPLES) {
+        val original = new AFix(maxRaw, minRaw, 0)
+        val rounded = original.round(roundBits bits, roundType, ignoreExpand)
+        assert(rounded.getBitsWidth == resultBits)
+        assert(rounded.exp == resultExp)
+        val roundedOff = original.roundOffBits(original.getBitsWidth - roundBits bits, roundType, ignoreExpand)
+        assert(roundedOff.getBitsWidth == resultBits)
+        assert(roundedOff.exp == resultExp)
       }
     })
   }

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -382,6 +382,53 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
         if (-c % 2 < 1) c.setScale(0, RoundingMode.HALF_UP) else c.setScale(0, RoundingMode.HALF_DOWN)
     }
   }
+
+  test("round_bits") {
+    SimConfig.compile(new Component {
+      // tuples: ignore expansion?, maxRaw, minRaw, round bits, round type, expected bits, expected resolution
+      {
+        val EXAMPLES = List(
+          (true, 6, 0, 3, RoundType.FLOOR, 3, 0),
+          (true, 6, 0, 3, RoundType.CEIL, 3, 0),
+          (true, 7, 0, 3, RoundType.FLOOR, 3, 0),
+          (true, 7, 0, 3, RoundType.CEIL, 3, 0),
+          (true, 6, 0, 2, RoundType.FLOOR, 2, 1),
+          (true, 6, 0, 2, RoundType.CEIL, 2, 1),
+          (true, 7, 0, 2, RoundType.FLOOR, 2, 1),
+          (true, 7, 0, 2, RoundType.CEIL, 3, 1),
+          (true, 2, -4, 3, RoundType.FLOOR, 3, 0),
+          (true, 2, -4, 3, RoundType.CEIL, 3, 0),
+          (true, 3, -4, 3, RoundType.FLOOR, 3, 0),
+          (true, 3, -4, 3, RoundType.CEIL, 3, 0),
+          (true, 2, -4, 2, RoundType.FLOOR, 2, 1),
+          (true, 2, -4, 2, RoundType.CEIL, 2, 1),
+          (true, 3, -4, 2, RoundType.FLOOR, 2, 1),
+          (true, 3, -4, 2, RoundType.CEIL, 3, 1),
+          (false, 6, 0, 3, RoundType.FLOOR, 3, 0),
+          (false, 6, 0, 3, RoundType.CEIL, 3, 0),
+          (false, 7, 0, 3, RoundType.FLOOR, 3, 0),
+          (false, 7, 0, 3, RoundType.CEIL, 3, 0),
+          (false, 6, 0, 2, RoundType.FLOOR, 2, 1),
+          (false, 6, 0, 2, RoundType.CEIL, 2, 1),
+          (false, 7, 0, 2, RoundType.FLOOR, 2, 1),
+          (false, 7, 0, 2, RoundType.CEIL, 2, 2),
+          (false, 2, -4, 3, RoundType.FLOOR, 3, 0),
+          (false, 2, -4, 3, RoundType.CEIL, 3, 0),
+          (false, 3, -4, 3, RoundType.FLOOR, 3, 0),
+          (false, 3, -4, 3, RoundType.CEIL, 3, 0),
+          (false, 2, -4, 2, RoundType.FLOOR, 2, 1),
+          (false, 2, -4, 2, RoundType.CEIL, 2, 1),
+          (false, 3, -4, 2, RoundType.FLOOR, 2, 1),
+          (false, 3, -4, 2, RoundType.CEIL, 2, 2),
+        )
+        for ((ignoreExpand, maxRaw, minRaw, roundBits, roundType, resultBits, resultExp) <- EXAMPLES) {
+          val rounded = new AFix(maxRaw, minRaw, 0).round(roundBits bits, roundType, ignoreExpand)
+          assert(rounded.getBitsWidth == resultBits)
+          assert(rounded.exp == resultExp)
+        }
+      }
+    })
+  }
 }
 
 class AFixTester extends Component {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Related to ideas in #1476 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

This adds a variant of `round()` to `AFix`, which allows specifying the `RoundType`. It also adds two bit-oriented variants; one which allows the result to have a specified width, and `roundOffBits`, which rounds off the specified number of least significant bits.

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?