### PR TITLE
add AFix contructors from width and resolution

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -85,7 +85,7 @@ object AFix {
   def UQ(integerWidth: BitCount, fractionWidth: BitCount): AFix = AFix(integerWidth.value exp, -fractionWidth.value exp, signed = false)
   def U(amplitude: ExpNumber, width: BitCount): AFix = AFix(amplitude, (amplitude.value - width.value) exp, false)
   def U(amplitude: ExpNumber, resolution: ExpNumber): AFix = AFix(amplitude, resolution, false)
-//  def U(wholeBits: BitCount, exp: ExpNumber): AFix = AFix(wholeBits, -exp bit, false)
+  def U(width: BitCount, resolution: ExpNumber): AFix = AFix((resolution.value + width.value) exp, resolution, signed = false)
 //  def U(maximum: BigInt, resolution: ExpNumber): AFix = {
 //    assert(maximum >= 0, s"AFix.U maxRaw must be non-negative! (${maximum} is not >= 0)")
 //    new AFix(maximum*BigInt(2).pow(-resolution.value)+(BigInt(2).pow(-resolution.value)-1), 0, resolution)
@@ -102,7 +102,7 @@ object AFix {
   def SQ(integerWidth: BitCount, fractionWidth: BitCount): AFix = AFix(integerWidth.value exp, -fractionWidth.value exp, signed = true)
   def S(amplitude: ExpNumber, width: BitCount): AFix = AFix(amplitude, (amplitude.value - width.value + 1) exp, true)
   def S(amplitude: ExpNumber, resolution: ExpNumber): AFix = AFix(amplitude, resolution, signed = true)
-//  def S(wholeBits: BitCount, exp: ExpNumber): AFix = AFix(wholeBits+(1 bit), -exp bit, signed = true)
+  def S(width: BitCount, resolution: ExpNumber): AFix = AFix((resolution.value + width.value - 1) exp, resolution, signed = true)
 //  def S(maximum: BigInt, resolution: ExpNumber): AFix =
 //    new AFix(maximum.max(0)*BigInt(2).pow(-resolution.value)+(BigInt(2).pow(-resolution.value)*maximum.signum-maximum.signum),
 //      maximum.min(0)*BigInt(2).pow(-resolution.value)+(BigInt(2).pow(-resolution.value)*maximum.signum-maximum.signum), resolution)

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -18,6 +18,7 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
       check(4095,0,0)(AFix.U(12 bits)) //Q12.0
       check(4095,0,-4)(AFix.U(8 exp, 12 bits)) //Q8.4
       check(4095,0,-4)(AFix.U(8 exp, -4 exp)) //Q8.4
+      check(4095,0,-4)(AFix.U(12 bits, -4 exp)) //Q8.4
       check(4095,0,-4)(AFix.UQ(8 bits, 4 bits)) //Q8.4
 //      check(4095,0,-4)(AFix.U(255, -4 exp)) //Q8.4
 //      check(4095,2048,-4)(AFix.U(255, 128, -4 exp)) //Q8.4
@@ -26,6 +27,7 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
       check(2047,-2048,0)(AFix.S(12 bits)) //Q11.0 + sign bit
       check(2047,-2048,-4)(AFix.S(7 exp, 12 bits)) //Q7.4  + sign bit
       check(2047,-2048,-4)(AFix.S(7 exp, -4 exp)) //Q7.4  + sign bit
+      check(2047,-2048,-4)(AFix.S(12 bits, -4 exp)) //Q7.4  + sign bit
       check(2047,-2048,-4)(AFix.SQ(7 bits, 4 bits)) //Q8.4 + sign bit
 //      check(2047,-2048,-4)(AFix.S(127, -128, -4 exp)) //Q7.4 + sign bit
       check(2047, -2048, 0)(AFix(QFormat(12, 0, true))) // 12 bits wide, 11 integral bits, 0 fractional bits, 1 sign bit


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Related to ideas in #1476 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

Adds a variant of each of `AFix.S` and `AFix.U` based on the width and resolution of the `AFix`.

It seems like there was a commented-out variant with the same parameter types, but which used the first `BitCount` to specify the number of bits in the integer part of the fixed-point. That seems inconsistent with the other variants of the same name, so I thought it would be best to get rid of it.

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?