### PR TITLE
AFix `resize()` bug

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -666,8 +666,12 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
     ret
   }
 
+  /** Changes the resolution of the AFix without changing its represented value, by adding low bits. */
   def resize(newExp : ExpNumber): AFix ={
-    assert(newExp.value < exp, s"AFix resize loses precision -- use a rounding function instead") //for now
+    assert(newExp.value <= exp, s"AFix resize loses precision -- use a rounding function instead") //for now
+    if (newExp.value == exp) {  // no-op
+        return CombInit(this)
+    }
     val dif = exp - newExp.value
     val ret = new AFix(
       this.maxRaw * (BigInt(1) << dif),

--- a/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimAFixTester.scala
@@ -109,6 +109,17 @@ class SpinalSimAFixTester extends SpinalAnyFunSuite {
     }
   }
 
+  test("resize_no_op") {
+    SimConfig.compile(new Component {
+      val original = AFix.U(3 exp, 0 exp)
+      val resized = original.resize(0 exp)
+      assert(original.getBitsWidth == resized.getBitsWidth)
+      assert(original.exp == resized.exp)
+      assert(original.maxRaw == resized.maxRaw)
+      assert(original.minRaw == resized.minRaw)
+    })
+  }
+
   test("arithmetic_shift") {
     // there is nothing special to the values used for testing here; i just picked some
     SimConfig.compile(new Component {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

It was previously impossible for `AFix.resize()` to be a no-op -- there was a check that it always strictly resized. That seemed non-obvious and needlessly restrictive, so I have changed it.

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented