### PR TITLE
Implement automatic initial reset and signal analysis in Verilator ba…

### DIFF
--- a/.github/workflows/mill-tests.yml
+++ b/.github/workflows/mill-tests.yml
@@ -133,7 +133,7 @@ jobs:
     lib-test:
         needs: compile
         runs-on: ubuntu-latest
-        timeout-minutes: 90
+        timeout-minutes: 120
         container:
           image: ghcr.io/spinalhdl/docker:latest
         steps:

--- a/.github/workflows/sbt-tests.yml
+++ b/.github/workflows/sbt-tests.yml
@@ -139,7 +139,7 @@ jobs:
   lib-test:
     needs: compile
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     container:
       image: ghcr.io/spinalhdl/docker:${{ inputs.docker_image_version }}
     env:

--- a/core/src/main/scala/spinal/core/Reg.scala
+++ b/core/src/main/scala/spinal/core/Reg.scala
@@ -20,6 +20,7 @@
 \*                                                                           */
 package spinal.core
 
+import spinal.core.internals.Expression
 import spinal.idslplugin.Location
 
 
@@ -88,4 +89,13 @@ object RegInit {
   def apply[T <: Data](init: T): T = Reg(init, init)
 
   def apply[T <: SpinalEnum](init : SpinalEnumElement[T]) : SpinalEnumCraft[T] = apply(init())
+}
+
+
+/**
+ * SimInit tag for register simulation initialization
+ * Sets simulation-only initial values via Verilog initial blocks
+ */
+case class SimInitTag(value: Expression) extends SpinalTag {
+  override def allowMultipleInstance = false
 }

--- a/lib/src/main/scala/spinal/lib/CrossClock.scala
+++ b/lib/src/main/scala/spinal/lib/CrossClock.scala
@@ -267,12 +267,14 @@ object ResetCtrl{
 
     val solvedOutputPolarity = if(outputPolarity == null) clockDomain.config.resetActiveLevel else outputPolarity
     val falsePathAttrs = List(crossClockFalsePath(Some(input), destType = TimingEndpointType.RESET))
-    samplerCD(BufferCC(
+  val ret = samplerCD(BufferCC(
       input       = ((if(solvedOutputPolarity == HIGH) False else True) ^ inputSync).setCompositeName(input, "asyncAssertSyncDeassert", true),
       init        = if(solvedOutputPolarity == HIGH) True  else False,
       bufferDepth = bufferDepth,
       allBufAttributes = falsePathAttrs)
     )
+    ret.getDrivingReg().simInit(if(solvedOutputPolarity == HIGH) False else True)
+    ret
   }
 
   /**

--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -556,7 +556,6 @@ JNIEXPORT void API JNICALL ${jniPrefix}disableWave_1${uniqueId}
        | --output-split-ctrace 500
        | -Wno-WIDTH -Wno-UNOPTFLAT -Wno-CMPCONST -Wno-UNSIGNED
        | --x-assign unique
-       | --x-initial-edge
        | --trace-depth ${config.waveDepth}
        | -O3
        | -CFLAGS -O${config.optimisationLevel}

--- a/tester/src/test/scala/spinal/core/SimInitTest.scala
+++ b/tester/src/test/scala/spinal/core/SimInitTest.scala
@@ -1,0 +1,252 @@
+package spinal.core
+
+import spinal.core.sim._
+import spinal.tester.SpinalAnyFunSuite
+
+/**
+ * Test suite for SpinalHDL simInit functionality
+ * 
+ * Tests simInit method which provides simulation-only register initialization
+ * covering basic functionality, data type compatibility, chaining with init(),
+ * composite types, reset type compatibility, and error conditions.
+ */
+class SimInitTest_copy extends SpinalAnyFunSuite {
+
+  test("basic simInit functionality") {
+    class BasicSimInitComponent extends Component {
+      val counter8  = Reg(UInt(8 bits)).simInit(0x42)
+      val counter16 = Reg(UInt(16 bits)).simInit(0x1234)
+      val sintReg = Reg(SInt(8 bits)).simInit(-5)
+      val bitsReg = Reg(Bits(8 bits)).simInit(0xF0)
+      val boolReg = Reg(Bool()).simInit(True)
+      val minReg = Reg(UInt(8 bits)).simInit(0)
+      val maxReg = Reg(UInt(8 bits)).simInit(255)
+      val singleBit = Reg(UInt(1 bit)).simInit(1)
+      
+      val counter8Out = out(counter8)
+      val counter16Out = out(counter16)
+      val sintRegOut = out(sintReg)
+      val bitsRegOut = out(bitsReg)
+      val boolRegOut = out(boolReg)
+      val minRegOut = out(minReg)
+      val maxRegOut = out(maxReg)
+      val singleBitOut = out(singleBit)
+      
+      counter8  := counter8 + 1
+      counter16 := counter16 + 1
+      sintReg := sintReg + 1
+      bitsReg := bitsReg.rotateLeft(1)
+      boolReg := !boolReg
+      minReg := minReg + 1
+      maxReg := maxReg - 1
+      singleBit := ~singleBit
+    }
+    
+    // Verify Verilog generation
+    val component = SpinalVerilog(new BasicSimInitComponent())
+    val verilogContent = scala.io.Source.fromFile(s"./simWorkspace/${component.toplevel.definitionName}.v").mkString
+    
+    assert(verilogContent.contains("initial begin"))
+    assert(verilogContent.contains("counter8 = 8'h42"))
+    assert(verilogContent.contains("counter16 = 16'h1234"))
+    assert(verilogContent.contains("sintReg = 8'hfb"))
+    assert(verilogContent.contains("bitsReg = 8'hf0"))
+    assert(verilogContent.contains("boolReg = 1'b1"))
+    assert(verilogContent.contains("singleBit = 1'b1"))
+    
+    // Verify simulation behavior
+    SimConfig.doSim(new BasicSimInitComponent) { dut =>
+      dut.clockDomain.forkStimulus(10)
+      
+      def toSignedInt(value: Int, bitWidth: Int): Int = {
+        val mask = (1 << bitWidth) - 1
+        val maskedValue = value & mask
+        if ((maskedValue & (1 << (bitWidth - 1))) != 0) {
+          maskedValue - (1 << bitWidth)
+        } else {
+          maskedValue
+        }
+      }
+      
+      // Verify initial values
+      assert(dut.counter8Out.toInt == 0x42)
+      assert(dut.counter16Out.toInt == 0x1234)
+      assert(toSignedInt(dut.sintRegOut.toInt, 8) == -5)
+      assert(dut.bitsRegOut.toInt == 0xF0)
+      assert(dut.boolRegOut.toBoolean == true)
+      assert(dut.minRegOut.toInt == 0)
+      assert(dut.maxRegOut.toInt == 255)
+      assert(dut.singleBitOut.toInt == 1)
+      
+      // Verify logic after one clock cycle
+      dut.clockDomain.waitRisingEdge()
+      sleep(0)
+      
+      assert(dut.counter8Out.toInt == 0x43)
+      assert(dut.counter16Out.toInt == 0x1235)
+      assert(toSignedInt(dut.sintRegOut.toInt, 8) == -4)
+      assert(dut.bitsRegOut.toInt == 0xE1)
+      assert(dut.boolRegOut.toBoolean == false)
+      assert(dut.minRegOut.toInt == 1)
+      assert(dut.maxRegOut.toInt == 254)
+      assert(dut.singleBitOut.toInt == 0)
+    }
+  }
+
+  test("chained calls and composite types") {
+    class TestBundle extends Bundle {
+      val field1 = UInt(8 bits)
+      val field2 = Bool()
+    }
+    
+    class ChainedComponent extends Component {
+      val reg1 = Reg(UInt(8 bits)).init(0x00).simInit(0x55)
+      val reg2 = Reg(UInt(8 bits)).simInit(0xAA).init(0xFF)
+      
+      val bundleReg = Reg(new TestBundle())
+      bundleReg.field1.simInit(0x11)
+      bundleReg.field2.simInit(False)
+      
+      val hexReg = Reg(UInt(8 bits)).simInit(0xFF)
+      val decReg = Reg(UInt(8 bits)).simInit(42)
+      val spinalReg = Reg(UInt(8 bits)).simInit(U(0x33, 8 bits))
+      
+      val reg1Out = out(reg1)
+      val reg2Out = out(reg2)
+      val bundleRegOut = out(bundleReg)
+      val hexRegOut = out(hexReg)
+      val decRegOut = out(decReg)
+      val spinalRegOut = out(spinalReg)
+      
+      reg1 := reg1 + 1
+      reg2 := reg2 + 1
+      bundleReg.field1 := bundleReg.field1 + 1
+      bundleReg.field2 := !bundleReg.field2
+      hexReg := hexReg + 1
+      decReg := decReg + 1
+      spinalReg := spinalReg + 1
+    }
+    
+    // Verify simulation behavior
+    SimConfig.doSim(new ChainedComponent) { dut =>
+      dut.clockDomain.forkStimulus(10)
+      
+      // Test simInit values without reset
+      assert(dut.reg1Out.toInt == 0x55)
+      assert(dut.reg2Out.toInt == 0xAA)
+      assert(dut.bundleRegOut.field1.toInt == 0x11)
+      assert(dut.bundleRegOut.field2.toBoolean == false)
+      assert(dut.hexRegOut.toInt == 0xFF)
+      assert(dut.decRegOut.toInt == 42)
+      assert(dut.spinalRegOut.toInt == 0x33)
+      
+      // Test reset behavior
+      dut.clockDomain.assertReset()
+      dut.clockDomain.waitRisingEdge()
+      dut.clockDomain.deassertReset()
+      
+      assert(dut.reg1Out.toInt == 0x00)
+      assert(dut.reg2Out.toInt == 0xFF)
+      
+      // Test logic after reset
+      dut.clockDomain.waitRisingEdge()
+      assert(dut.reg1Out.toInt == 0x01)
+      assert(dut.reg2Out.toInt == 0x00) // 0xFF + 1 = 0x00 (overflow)
+    }
+  }
+
+  test("reset type compatibility") {
+    // Test 1: Sync reset registers
+    class SyncResetComponent extends Component {
+      implicit val syncResetConfig = ClockDomainConfig(resetKind = SYNC)
+      val reg1 = Reg(UInt(8 bits)).init(0x11).simInit(0xAA)
+      val reg2 = Reg(UInt(8 bits)).simInit(0xBB)
+      val reg1Out = out(reg1)
+      val reg2Out = out(reg2)
+      reg1 := reg1 + 1
+      reg2 := reg2 + 1
+    }
+    
+    // Test 2: Async reset registers
+    class AsyncResetComponent extends Component {
+      implicit val asyncResetConfig = ClockDomainConfig(resetKind = ASYNC)
+      val reg1 = Reg(UInt(8 bits)).init(0x22).simInit(0xCC)
+      val reg2 = Reg(UInt(8 bits)).simInit(0xDD)
+      val reg1Out = out(reg1)
+      val reg2Out = out(reg2)
+      reg1 := reg1 + 1
+      reg2 := reg2 + 1
+    }
+    
+    // Test 3: No reset registers
+    class NoResetComponent extends Component {
+      implicit val noResetConfig = ClockDomainConfig(resetKind = BOOT)
+      val reg1 = Reg(UInt(8 bits)).simInit(0xEE)
+      val reg2 = Reg(UInt(8 bits)).simInit(0xFF)
+      val reg1Out = out(reg1)
+      val reg2Out = out(reg2)
+      reg1 := reg1 + 1
+      reg2 := reg2 + 1
+    }
+    
+    // Verify Verilog generation (quick check)
+    val syncComponent = SpinalVerilog(new SyncResetComponent())
+    val asyncComponent = SpinalVerilog(new AsyncResetComponent())
+    val noResetComponent = SpinalVerilog(new NoResetComponent())
+    
+    SimConfig.doSim(new SyncResetComponent) { dut =>
+      dut.clockDomain.forkStimulus(10)
+      assert(dut.reg1Out.toInt == 0xAA)
+      assert(dut.reg2Out.toInt == 0xBB)
+      
+      // Simple reset test
+      dut.clockDomain.assertReset()
+      dut.clockDomain.waitRisingEdge()
+      assert(dut.reg1Out.toInt == 0x11)
+    }
+    
+    SimConfig.doSim(new AsyncResetComponent) { dut =>
+      dut.clockDomain.forkStimulus(10)
+      assert(dut.reg1Out.toInt == 0xCC)
+      assert(dut.reg2Out.toInt == 0xDD)
+      
+      // Simple reset test
+      dut.clockDomain.assertReset()
+      sleep(1)
+      dut.clockDomain.deassertReset()
+      sleep(0)
+      assert(dut.reg1Out.toInt == 0x22, s"after async reset should be 0x22, actual is ${dut.reg1Out.toInt}")
+    }
+    
+    SimConfig.doSim(new NoResetComponent) { dut =>
+      dut.clockDomain.forkStimulus(10)
+      assert(dut.reg1Out.toInt == 0xEE, s"no reset reg1 initial value should be 0xEE, actual is ${dut.reg1Out.toInt}")
+      assert(dut.reg2Out.toInt == 0xFF, s"no reset reg2 initial value should be 0xFF, actual is ${dut.reg2Out.toInt}")
+      
+      // Verify continued operation
+      val reg1Before = dut.reg1Out.toInt
+      dut.clockDomain.waitRisingEdge()
+      sleep(0)
+      assert(dut.reg1Out.toInt == ((reg1Before + 1) & 0xFF), "no reset register should continue incrementing")
+    }
+  }
+
+  test("error conditions") {
+    // Test simInit on wire should fail
+    assertThrows[java.lang.IllegalArgumentException] {
+      SpinalVerilog(new Component {
+        val wire = UInt(8 bits)
+        wire.simInit(42)
+        wire := 0
+      })
+    }
+    
+    // Test simInit on input port should fail
+    assertThrows[java.lang.IllegalArgumentException] {
+      SpinalVerilog(new Component {
+        val input = in port UInt(8 bits)
+        input.simInit(42)
+      })
+    }
+  }
+}


### PR DESCRIPTION
…ckend

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes 
#1777 
#1259 


# Context, Motivation & Description

This PR implements a comprehensive RTL-based auto-reset sequence for the Verilator backend, replacing Verilator's "--x-initial-edge" option with a SpinalHDL native solution, which changed its behavior in version 5.x. The PR also implements a comprehensive RTL-based auto-reset sequence for the Verilator backend.

The current Verilator backend relies on the `--x-initial-edge` option for initial reset, which:
- In verilator version v5.x there is an unintended signal jumping behavior, which leads to some unintended errors.
- Doesn't provide precise control over reset sequences
- Trigger assertion judgment at time zero
[ref](https://github.com/verilator/verilator/issues/6377):

RTL analysis-based automatic reset system that:
1. **Analyzes the entire SpinalHDL design** using `GraphUtils.walkAllComponents` to discover all registers and their clock domains
2. **Extracts precise reset and clock signal information** including:
   - Reset signal polarity (HIGH/LOW active)
   - Reset type (ASYNC/SYNC)
   - Clock edge sensitivity (RISING/FALLING)
3. **Generates C++ reset sequences** that:
   - Properly handle multiple reset signals with different polarities
   - Support both asynchronous and synchronous resets
   - Generate appropriate clock edges for synchronous reset propagation
   - Ensure all registers start from a deterministic state
Can be enabled/disabled via `SpinalSimConfig`

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

No effect-this PR does not modify any Verilog/VHDL/SystemVerilog code generation logic, all improvements are at the simulation tool level.
This PR also not affect the user's subsequent simulation operations, and the auto-reset operation will not be recorded by verilator.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
