### PR TITLE
Fix for Issue 1736 VHDL assertions without a report clause.

### DIFF
--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -776,7 +776,11 @@ class ComponentEmitterVhdl(
                 case `ERROR`    => "ERROR"
                 case `FAILURE`  => "FAILURE"
               })
-              b ++= s"""${tab}assert $cond = '1' report ($message) $severity;\n"""
+              if (message.length > 0) {
+                b ++= s"""${tab}assert $cond = '1' report ($message) $severity;\n"""
+              } else {
+                 b ++= s"""${tab}assert $cond = '1' $severity;\n"""
+              }
            }
         }
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -779,7 +779,7 @@ class ComponentEmitterVhdl(
               if (message.length > 0) {
                 b ++= s"""${tab}assert $cond = '1' report ($message) $severity;\n"""
               } else {
-                 b ++= s"""${tab}assert $cond = '1' $severity;\n"""
+                b ++= s"""${tab}assert $cond = '1' $severity;\n"""
               }
            }
         }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

VHDL syntax fix for assertions without a report clause.
Closes #1736

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
FIxes a bug with VHDL assertions.
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
