### PR TITLE
 fix the path pattern of generating vcd on msys2 environment.

### DIFF
--- a/tester/src/main/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
+++ b/tester/src/main/scala/spinal/tester/scalatest/SpinalTesterCocotbBase.scala
@@ -13,7 +13,7 @@ import scala.sys.process._
 
 abstract class SpinalTesterCocotbBase extends AnyFunSuite /* with BeforeAndAfterAll with ParallelTestExecution*/ {
   def workspaceRoot = "./cocotbWorkspace"
-  def waveFolder = sys.env.getOrElse("WAVES_DIR", new File(workspaceRoot).getAbsolutePath)
+  def waveFolder = sys.env.getOrElse("WAVES_DIR", new File(workspaceRoot).getAbsolutePath.replace('\\', '/'))
   var withWaveform = false
   var spinalMustPass = true
   var cocotbMustPass = true


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

Fix the problem that cocotb test will fail on MSYS2, due to the wrong path separator. Use '/' to solve it. 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
