### PR TITLE
Add APLIC and IMSIC device support

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/misc/args/Args.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/args/Args.scala
@@ -4,7 +4,7 @@ import spinal.core
 import spinal.core._
 import spinal.lib._
 import spinal.lib.com.i2c.{I2cMasterMemoryMappedGenerics, I2cSlaveGenerics, I2cSlaveMemoryMappedGenerics, TilelinkI2cCtrlFiber}
-import spinal.lib.misc.plic.InterruptCtrlFiber
+import spinal.lib.misc.InterruptCtrlFiber
 
 import scala.collection.mutable.ArrayBuffer
 

--- a/lib/src/main/scala/spinal/lib/misc/InterruptCtrlFiber.scala
+++ b/lib/src/main/scala/spinal/lib/misc/InterruptCtrlFiber.scala
@@ -1,0 +1,46 @@
+package spinal.lib.misc
+
+import spinal.core._
+import spinal.core.fiber._
+import spinal.lib._
+
+import scala.collection.mutable
+
+sealed trait InterruptMode
+object EDGE_RISING extends InterruptMode
+object EDGE_FALLING extends InterruptMode
+object LEVEL_HIGH extends InterruptMode
+object LEVEL_LOW extends InterruptMode
+object SPURIOUS extends InterruptMode
+
+trait InterruptCtrlFiber extends Nameable{
+  val lock = Lock()
+
+  def defaultInterruptMode: InterruptMode
+
+  def createInterruptMaster(id: Int): InterruptNode
+  def createInterruptSlave(id: Int, mode: InterruptMode): InterruptNode
+
+  def createInterruptSlave(id: Int): InterruptNode = createInterruptSlave(id, defaultInterruptMode)
+
+  val mappedInterrupts = mutable.LinkedHashMap[InterruptNode, InterruptNode]()
+
+  def mapUpInterrupt(id: Int, node: InterruptNode): Unit = mapUpInterrupt(id, node, defaultInterruptMode)
+
+  def mapUpInterrupt(id: Int, node: InterruptNode, mode: InterruptMode): Unit = {
+    val local = createInterruptSlave(id, mode)
+    local.setLambdaName(node.isNamed && this.isNamed)(s"${this.getName()}_from_${node.getName}")
+    local << node
+    mappedInterrupts(node) = local
+  }
+
+  def mapDownInterrupt(id: Int, node: InterruptNode): Unit = {
+    val local = createInterruptMaster(id)
+    local.setLambdaName(node.isNamed && this.isNamed)(s"${this.getName()}_to_${node.getName}")
+    node << local
+    mappedInterrupts(node) = local
+  }
+
+  def retain() = lock.retain()
+  def release() = lock.release()
+}

--- a/lib/src/main/scala/spinal/lib/misc/aia/APlic.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/APlic.scala
@@ -1,0 +1,176 @@
+package spinal.lib.misc.aia
+
+import spinal.core._
+import spinal.lib._
+
+case class APlicMsiParam(
+  base: BigInt = 0,
+  hhxs: Int = 0,
+  lhxs: Int = 0,
+  hhxw: Int = 0,
+  lhxw: Int = 0
+)
+
+case class APlicGenParam(withDirect: Boolean,
+                         withMSI: Boolean,
+                         genIEP: Boolean = true,
+                         withIForce: Boolean = false,
+                         var _MMsiParams: APlicMsiParam = APlicMsiParam(),
+                         var _SMsiParams: APlicMsiParam = APlicMsiParam(),
+                         var _withMsiAddrcfg: Boolean = false,
+                         var _lockMSI: Boolean = false) {
+
+  def lockMSI(): this.type = {
+    this._lockMSI = true
+    this
+  }
+
+  def withMsiAddrcfg(): this.type = {
+    this._withMsiAddrcfg = true
+    this
+  }
+
+  def withMachineMsiParams(param: APlicMsiParam): this.type = {
+    this._MMsiParams = param
+    this
+  }
+
+  def withMachineMsiParams(address: BigInt = 0, hhxs: Int = 0, lhxs: Int = 0, hhxw: Int = 0, lhxw: Int = 0): this.type = {
+    withMachineMsiParams(APlicMsiParam(base = address, hhxs = hhxs, lhxs = lhxs, hhxw = hhxw, lhxw = lhxw))
+  }
+
+  def withSupervisorMsiParams(param: APlicMsiParam): this.type = {
+    this._SMsiParams = param
+    this
+  }
+
+  def withSupervisorMsiParams(address: BigInt = 0, lhxs: Int = 0): this.type = {
+    withSupervisorMsiParams(APlicMsiParam(base = address, lhxs = lhxs))
+  }
+}
+
+object APlicGenParam {
+  def test = APlicGenParam(
+    withDirect  = true,
+    withMSI     = true,
+    genIEP      = true,
+    withIForce  = true
+  )
+
+  def full = APlicGenParam(
+    withDirect  = true,
+    withMSI     = true,
+    genIEP      = true
+  )
+
+  def msi = APlicGenParam(
+    withDirect  = false,
+    withMSI     = true
+  )
+
+  def direct = APlicGenParam(
+    withDirect  = true,
+    withMSI     = false
+  )
+}
+
+case class APlicDomainParam(isRoot: Boolean,
+                            isMDomain: Boolean,
+                            genParam: APlicGenParam)
+
+object APlicDomainParam {
+  def root(genParam: APlicGenParam) = APlicDomainParam(
+    isRoot    = true,
+    isMDomain = true,
+    genParam  = genParam
+  )
+
+  def M(genParam: APlicGenParam) = APlicDomainParam(
+    isRoot    = false,
+    isMDomain = true,
+    genParam  = genParam
+  )
+
+  def S(genParam: APlicGenParam) = APlicDomainParam(
+    isRoot    = false,
+    isMDomain = false,
+    genParam  = genParam
+  )
+}
+
+case class APlicChildInfo(childIdx: Int, sourceIds: Seq[Int])
+
+case class APlicMsiPayload() extends Bundle {
+  val address = UInt(64 bits)
+  val data = UInt(32 bits)
+}
+
+trait APlicMsiProducerFiber extends Nameable{
+  def createMsiStreamProducer(): Stream[APlicMsiPayload]
+}
+
+trait APlicMsiConsumerFiber extends Nameable{
+  def createMsiStreamConsumer(): Stream[APlicMsiPayload]
+}
+
+case class APlic(p: APlicDomainParam,
+                 sourceParams: Seq[APlicSourceParam],
+                 hartIds: Seq[Int],
+                 childInfos: Seq[APlicChildInfo]) extends Area {
+  val sourceIds = sourceParams.map(_.id)
+  require(sourceIds.distinct.size == sourceIds.size, "APlic requires no duplicate interrupt source")
+  require(hartIds.distinct.size == hartIds.size, "APlic requires no duplicate harts")
+
+  val sources = Bits(sourceIds.size bits)
+  val childSources = Vec(childInfos.map(childInfo => Bits(childInfo.sourceIds.size bits)))
+  val mmsiaddrcfg = UInt(64 bits)
+  val smsiaddrcfg = UInt(64 bits)
+
+  val childInterruptIds = childInfos.flatMap(childInfo => childInfo.sourceIds).distinct
+  val interruptDelegatable = for (sourceId <- sourceIds) yield childInterruptIds.find(_ == sourceId).isDefined
+
+  val deliveryEnable = RegInit(False)
+  val isMSI = False
+  val bigEndian = False
+
+  val interrupts: Seq[APlicSource] = for (((param, delegatable), i) <- sourceParams.zip(interruptDelegatable).zipWithIndex)
+    yield APlicSource(param, APlicSourceState(delegatable, isMSI, sources(i)))
+
+  val childMappings = for ((childInfo, childSource) <- childInfos.zip(childSources)) yield new Area {
+    for ((childSourceId, idx) <- childInfo.sourceIds.zipWithIndex) yield new Area {
+      interrupts.find(_.id == childSourceId).map(interrupt => new Area {
+        when(interrupt.delegated && (Bool(childInfos.size == 1) || interrupt.childIdx === childInfo.childIdx)) {
+          childSource(idx) := interrupt.input
+        } otherwise {
+          childSource(idx) := False
+        }
+      })
+    }
+  }
+
+  val direct = new Area {
+    val gateways = for (hartId <- hartIds) yield new APlicDirectGateway(interrupts, hartId, p.genParam.withIForce)
+
+    val targets = Mux(isMSI, B(0), gateways.map(_.iep && deliveryEnable).asBits())
+  }
+}
+
+object APlic {
+  def doWhenMatch(interrupts: Seq[APlicSource], id: UInt, func: APlicSource => Unit) = new Area {
+    switch(id) {
+      for (interrupt <- interrupts) {
+        is (interrupt.id) {
+          func(interrupt)
+        }
+      }
+    }
+  }
+
+  def doClaim(interrupts: Seq[APlicSource], id: UInt) = doWhenMatch(interrupts, id, _.doClaim())
+
+  def doSet(interrupts: Seq[APlicSource], id: UInt) = doWhenMatch(interrupts, id, _.doSet())
+
+  def doEnable(interrupts: Seq[APlicSource], id: UInt) = doWhenMatch(interrupts, id, _.doEnable())
+
+  def doDisable(interrupts: Seq[APlicSource], id: UInt) = doWhenMatch(interrupts, id, _.doDisable())
+}

--- a/lib/src/main/scala/spinal/lib/misc/aia/APlicGateway.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/APlicGateway.scala
@@ -1,0 +1,42 @@
+package spinal.lib.misc.aia
+
+import spinal.core._
+import spinal.lib._
+
+case class APlicDirectGateway(interrupts: Seq[APlicSource], hartId: Int, allowSpuriousInterrupt: Boolean) extends Area {
+  val maxSource = (interrupts.map(_.id) ++ Seq(0)).max + 1
+  val priorityWidth = (interrupts.map(i => widthOf(i.direct.prio))).max
+  val idWidth = log2Up(maxSource)
+
+  val idelivery = RegInit(False)
+  val ithreshold = RegInit(U(0, 8 bits))
+  val iforce = allowSpuriousInterrupt generate RegInit(False)
+
+  val iforceRequest = allowSpuriousInterrupt generate {
+    val value = new APlicDirectRequest(idWidth, priorityWidth)
+    value.id := 0
+    value.valid := iforce
+    value.prio := 0
+    value
+  }
+
+  val spuriousRequest = if (allowSpuriousInterrupt) Seq(iforceRequest) else Seq()
+
+  val requests = spuriousRequest ++ interrupts.sortBy(_.id).map(_.asDirectRequest(idWidth, hartId))
+
+  val resultRequest = RegNext(requests.reduceBalancedTree((a, b) => {
+    val takeA = a.prioritize(b)
+    takeA ? a | b
+  }))
+
+  val valid = resultRequest.pending(ithreshold)
+  val bestRequest = resultRequest.verify(valid)
+  val iep = valid && idelivery
+
+  def doBestClaim() = new Area {
+    when (idelivery) {
+      APlic.doClaim(interrupts, bestRequest.id)
+      if (allowSpuriousInterrupt) iforce := False
+    }
+  }
+}

--- a/lib/src/main/scala/spinal/lib/misc/aia/APlicMapper.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/APlicMapper.scala
@@ -1,0 +1,167 @@
+package spinal.lib.misc.aia
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.{BusSlaveFactory, AllMapping, SingleMapping}
+import scala.collection.mutable.ArrayBuffer
+
+object APlicMapping {
+  val domaincfgOffset     = 0x0000
+  val sourcecfgOffset     = 0x0004
+  val mmsiaddrcfgOffset   = 0x1BC0
+  val mmsiaddrcfghOffset  = 0x1BC4
+  val smsiaddrcfgOffset   = 0x1BC8
+  val smsiaddrcfghOffset  = 0x1BCC
+  val setipOffset         = 0x1C00
+  val setipnumOffset      = 0x1CDC
+  val in_clripOffset      = 0x1D00
+  val clripnumOffset      = 0x1DDC
+  val setieOffset         = 0x1E00
+  val setienumOffset      = 0x1EDC
+  val clrieOffset         = 0x1F00
+  val clrienumOffset      = 0x1FDC
+  val setipnum_leOffset   = 0x2000
+  val setipnum_beOffset   = 0x2004
+  val genmsiOffset        = 0x3000
+  val targetOffset        = 0x3004
+
+  val idcOffset           = 0x4000
+  val idcGroupSize        = 0x20
+  val ideliveryOffset     = 0x00
+  val iforceOffset        = 0x04
+  val ithresholdOffset    = 0x08
+  val topiOffset          = 0x18
+  val claimiOffset        = 0x1c
+}
+
+case class APlicGenMsiPayload() extends Bundle {
+  val hartId = UInt(14 bits)
+  val eiid = UInt(11 bits)
+}
+
+object APlicMapper {
+  def apply(bus: BusSlaveFactory)(aplic: APlic) = new Area{
+    import APlicMapping._
+
+    val p = aplic.p
+
+    val domaincfg = new Area {
+      bus.read(U(0x80, 8 bits), address = domaincfgOffset, bitOffset = 24)
+      bus.readAndWrite(aplic.deliveryEnable, address = domaincfgOffset, bitOffset = 8)
+      bus.read(aplic.isMSI, address = domaincfgOffset, bitOffset = 2)
+      bus.readAndWrite(aplic.bigEndian, address = domaincfgOffset, bitOffset = 0)
+    }
+
+    // mapping SETIPNUM, CLRIPNUM, SETIENUM, CLRIPNUM
+    val numOPs = new Area {
+      def mapNumArea(offset: Int, func: UInt => Unit, doc: String = null) = new Area {
+        val numFlow = bus.createAndDriveFlow(UInt(32 bits), address = offset, documentation = doc)
+        when(numFlow.valid) {
+          func(numFlow.payload)
+        }
+      }
+
+      val setipnum = mapNumArea(setipnumOffset, APlic.doSet(aplic.interrupts, _))
+      val setipnum_le = mapNumArea(setipnum_leOffset, APlic.doSet(aplic.interrupts, _))
+      val clripnum = mapNumArea(clripnumOffset, APlic.doClaim(aplic.interrupts, _))
+      val setienum = mapNumArea(setienumOffset, APlic.doEnable(aplic.interrupts, _))
+      val clrienum = mapNumArea(clrienumOffset, APlic.doDisable(aplic.interrupts, _))
+    }
+
+    bus.read(B(0), address = setipOffset, bitOffset = 0)
+    bus.read(B(0), address = setieOffset, bitOffset = 0)
+    bus.read(B(0), address = clrieOffset, bitOffset = 0)
+    bus.read(B(0), address = in_clripOffset, bitOffset = 0)
+
+    // mapping SOURCECFG, TARGET, SETIE, SETIP for interrupt
+    val interruptMapping = for(interrupt <- aplic.interrupts) yield new Area {
+      val interruptOffset = (interrupt.id / bus.busDataWidth) * bus.busDataWidth / 8
+      val interruptBitOffset = interrupt.id % bus.busDataWidth
+      val configOffset = (interrupt.id - 1) * 4
+
+      val source = new Area {
+        val configFlow = bus.createAndDriveFlow(UInt(11 bits), sourcecfgOffset + configOffset)
+        when(configFlow.valid) {
+          interrupt.setConfig(configFlow.payload)
+        }
+      }
+
+      val target = new Area {
+        val configFlow = bus.createAndDriveFlow(UInt(18 bits), address = targetOffset + configOffset, bitOffset = 0)
+
+        when(configFlow.valid && interrupt.isActive) {
+          if(p.genParam.withDirect) {
+            when(!aplic.isMSI) {
+              val prio = configFlow.payload(7 downto 0)
+              interrupt.direct.prio := (prio === 0) ? U(1) | prio
+            }
+          }
+        }
+
+        val configViewList = ArrayBuffer[(Bool, Bits)]()
+        if (p.genParam.withDirect) {
+          val view = B(18 bits, (7 downto 0) -> interrupt.direct.prio.asBits,
+                                default -> False)
+          configViewList.addRet((False, view))
+        }
+        val configView = aplic.isMSI.muxListDc(configViewList)
+
+        bus.read(configView, address = targetOffset + configOffset, bitOffset = 0)
+
+        val targetFlow = bus.createAndDriveFlow(interrupt.targetId, address = targetOffset + configOffset, bitOffset = 18)
+
+        when(targetFlow.valid && interrupt.isActive) {
+          interrupt.targetId := targetFlow.payload
+        }
+
+        bus.read(interrupt.targetId, address = targetOffset + configOffset, bitOffset = 18)
+      }
+
+      val iep = p.genParam.genIEP generate new Area {
+        bus.readAndWrite(interrupt.ie, address = setieOffset + interruptOffset, bitOffset = interruptBitOffset)
+
+        bus.read(interrupt.ip, address = setipOffset + interruptOffset, bitOffset = interruptBitOffset)
+        val ipDrive = bus.createAndDriveFlow(Bool(), address = setipOffset + interruptOffset, bitOffset = interruptBitOffset)
+        when(ipDrive.valid) {
+          interrupt.doPendingUpdate(ipDrive.payload)
+        }
+
+        bus.read(interrupt.rectified, address = in_clripOffset + interruptOffset, bitOffset = interruptBitOffset)
+        val clripDrive = bus.createAndDriveFlow(Bool(), address = in_clripOffset + interruptOffset, bitOffset = interruptBitOffset)
+        when(clripDrive.valid && clripDrive.payload === True) {
+          interrupt.doClaim()
+        }
+
+        val clrieDrive = bus.createAndDriveFlow(Bool(), address = clrieOffset + interruptOffset, bitOffset = interruptBitOffset)
+        when(clrieDrive.valid && clrieDrive.payload === True) {
+          interrupt.doDisable()
+        }
+      }
+    }
+
+    // mapping interrupt delivery control for each gateway
+    val direct = p.genParam.withDirect generate new Area {
+      val idcs =  for(idc <- aplic.direct.gateways) yield new Area {
+        val idcThisOffset = idcOffset + (idc.hartId * idcGroupSize)
+        val nowRequest = idc.bestRequest.asInstanceOf[APlicDirectRequest]
+
+        bus.readAndWrite(idc.idelivery, address = idcThisOffset + ideliveryOffset)
+        if (p.genParam.withIForce) {
+          bus.readAndWrite(idc.iforce, address = idcThisOffset + iforceOffset)
+        }
+        bus.readAndWrite(idc.ithreshold, address = idcThisOffset + ithresholdOffset)
+
+        // topi readonly
+        bus.read(nowRequest.prio, address = idcThisOffset + topiOffset, bitOffset = 0)
+        bus.read(nowRequest.id, address = idcThisOffset + topiOffset, bitOffset = 16)
+
+        // reading claimi trigger clean the top interrupt
+        bus.read(nowRequest.prio, address = idcThisOffset + claimiOffset, bitOffset = 0)
+        bus.read(nowRequest.id, address = idcThisOffset + claimiOffset, bitOffset = 16)
+        bus.onRead(address = idcThisOffset + claimiOffset) {
+          idc.doBestClaim()
+        }
+      }
+    }
+  }
+}

--- a/lib/src/main/scala/spinal/lib/misc/aia/APlicSource.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/APlicSource.scala
@@ -1,0 +1,457 @@
+package spinal.lib.misc.aia
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.misc._
+
+import scala.collection.mutable.LinkedHashMap
+
+abstract class APlicGenericRequest(idWidth: Int) extends Bundle {
+  val id = UInt(idWidth bits)
+  val valid = Bool()
+
+  def prioritize(other: APlicGenericRequest): Bool
+  def pending(threshold: UInt): Bool
+  def dummy(): APlicGenericRequest
+  def verify(cond: Bool): APlicGenericRequest = {
+    Mux(cond, this, dummy())
+  }
+}
+
+/**
+ * Trigger mode for interrupt source
+ */
+object APlicSourceMode extends SpinalEnum {
+  val INACTIVE, DETACHED, EDGE1, EDGE0, LEVEL1, LEVEL0 = newElement()
+  val RESERVED2, RESERVED3 = newElement()
+  defaultEncoding = SpinalEnumEncoding("sm")(
+    INACTIVE -> 0,
+    DETACHED -> 1,
+    RESERVED2 -> 2,
+    RESERVED3 -> 3,
+    EDGE1 -> 4,
+    EDGE0 -> 5,
+    LEVEL1 -> 6,
+    LEVEL0 -> 7)
+}
+
+case class APlicDirectRequest(idWidth: Int, priorityWidth: Int) extends APlicGenericRequest(idWidth) {
+  val prio = UInt(priorityWidth bits)
+
+  override def prioritize(other: APlicGenericRequest): Bool = {
+    val x = other.asInstanceOf[APlicDirectRequest]
+    val prioCheck = (prio < x.prio) || ((prio === x.prio) && (id <= x.id))
+
+    // !x.valid || (valid && prioCheck)
+    !x.valid || (valid && ((x.id === 0) || ((id =/= 0) && prioCheck)))
+  }
+
+  override def pending(threshold: UInt): Bool = {
+    val prioCheck = (threshold === 0) || (prio < threshold)
+
+    // vaild && prioCheck
+    valid && ((id === 0) || ((id =/= 0) && prioCheck ))
+  }
+
+  override def dummy(): APlicGenericRequest = {
+    val tmp = APlicDirectRequest(idWidth, priorityWidth)
+    tmp.id := 0
+    tmp.valid := False
+    tmp.prio := 0
+    tmp
+  }
+}
+
+case class APlicMSITarget() extends Bundle {
+  val hartId = UInt(14 bits)
+  val guestId = UInt(6 bits)
+  val eiid = UInt(11 bits)
+}
+
+case class APlicSourceParam(id: Int, mode: InterruptMode)
+
+case class APlicSourceState(
+  withDelegation: Boolean,
+  msiState: Bool,
+  input: Bool
+)
+
+abstract class APlicSource(sourceId: Int, state: APlicSourceState) extends Area {
+  import APlicSourceMode._
+
+  val id = sourceId
+  val input = state.input
+  val ie = RegInit(False)
+  val ip = RegInit(False)
+  val isMSI = state.msiState
+  val config = RegInit(U(0, 11 bits))
+  val delegated = config(10)
+  val childIdx = config(9 downto 0)
+  val modeBit = delegated ? APlicSourceMode.INACTIVE.asBits | config(2 downto 0).asBits
+  val mode = APlicSourceMode()
+
+  mode.assignFromBits(modeBit)
+
+  /* target field */
+  val targetId = RegInit(U(0x0, 14 bits))
+  val direct = new Area {
+    val prio = RegInit(U(1, 8 bits))
+  }
+
+  val rectified = Bool()
+  val rectifiedCtx = WhenBuilder()
+  driveRectifiedCtx(rectifiedCtx)
+  rectifiedCtx.otherwise{
+    rectified := False
+  }
+  val allowSet = Bool()
+  val allowClear = Bool()
+  val allowCtx = WhenBuilder()
+  driveAllowCtx(allowCtx)
+  allowCtx.otherwise{
+    allowSet := False
+    allowClear := False
+  }
+
+  val iepCtx = WhenBuilder()
+  driveIepCtx(iepCtx)
+  iepCtx.otherwise {
+    ip := False
+    ie := False
+  }
+
+  def driveAllowCtx(ctx: WhenBuilder): Unit
+  def driveIepCtx(ctx: WhenBuilder): Unit
+  def driveRectifiedCtx(ctx: WhenBuilder): Unit
+  def driveConfigUpdateCtx(ctx: WhenBuilder): Unit
+  def supportModes(): Seq[APlicSourceMode.E]
+
+  def asDirectRequest(idWidth: Int, targetHart: Int): APlicGenericRequest = {
+    val ret = new APlicDirectRequest(idWidth, direct.prio.getWidth)
+    val enable = ie && !isMSI
+    ret.id := U(id)
+    ret.valid := ip && enable && (targetId === targetHart)
+    ret.prio := direct.prio
+    ret
+  }
+
+  def doClaim(): Unit = {
+    ip.clearWhen(allowClear)
+  }
+
+  def doSet(): Unit = {
+    ip.setWhen(allowSet)
+  }
+
+  def doPendingUpdate(pending: Bool): Unit = {
+    when(pending) {
+      doSet()
+    } otherwise {
+      doClaim()
+    }
+  }
+
+  def doEnable(): Unit = {
+    ie := True
+  }
+
+  def doDisable(): Unit = {
+    ie := False
+  }
+
+  def doEnableUpdate(enabled: Bool): Unit = {
+    when(enabled) {
+      doEnable()
+    } otherwise {
+      doDisable()
+    }
+  }
+
+  def isActive: Bool = mode =/= INACTIVE
+
+  def doConfigIpUpdate(modeB: Bits) {
+    val mode = APlicSourceMode()
+    val ctx = WhenBuilder()
+
+    mode.assignFromBits(modeB)
+
+    ctx.when(mode === INACTIVE) {
+      ip := False
+    }
+
+    driveConfigUpdateCtx(ctx)
+  }
+
+  def setConfig(payload: UInt): Unit = {
+    val _delegated = payload(10)
+
+    when (_delegated) {
+      if (state.withDelegation) {
+        config := payload
+      } else {
+        config := 0
+      }
+    } otherwise {
+      val _mode = payload(2 downto 0)
+
+      switch (_mode) {
+        for (state <- supportModes()) {
+          is(state.asBits.asUInt) {
+            config := payload(2 downto 0).resized
+            doConfigIpUpdate(state.asBits)
+          }
+        }
+
+        default {
+          config := 0
+        }
+      }
+    }
+  }
+}
+
+object APlicSource {
+  def apply(param: APlicSourceParam, state: APlicSourceState): APlicSource = {
+    val sourceId = param.id
+
+    param.mode match {
+      case EDGE_FALLING => new APlicSourceActiveFalling(sourceId, state)
+      case EDGE_RISING  => new APlicSourceActiveRising(sourceId, state)
+      case LEVEL_HIGH   => new APlicSourceActiveHigh(sourceId, state)
+      case LEVEL_LOW    => new APlicSourceActiveLow(sourceId, state)
+      case SPURIOUS     => new APlicSourceActiveSpurious(sourceId, state)
+    }
+  }
+}
+
+case class APlicFullSource(sourceId: Int, state: APlicSourceState) extends APlicSource(sourceId, state) {
+  import APlicSourceMode._
+
+  override def supportModes(): Seq[E] = Seq(INACTIVE, EDGE0, EDGE1, LEVEL0, LEVEL1, DETACHED)
+
+  override def driveRectifiedCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === EDGE1) {
+      rectified := input.rise()
+    }
+    ctx.when(mode === EDGE0) {
+      rectified := input.fall()
+    }
+    ctx.when(mode === LEVEL1) {
+      rectified := input
+    }
+    ctx.when(mode === LEVEL0) {
+      rectified := ~input
+    }
+  }
+
+  override def driveAllowCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === DETACHED) {
+      allowSet := True
+      allowClear := True
+    }
+    ctx.when(mode === EDGE1) {
+      allowSet := True
+      allowClear := True
+    }
+    ctx.when(mode === EDGE0) {
+      allowSet := True
+      allowClear := True
+    }
+    ctx.when(mode === LEVEL1) {
+      allowSet := Mux(isMSI, rectified, False)
+      allowClear := Mux(isMSI, True, False)
+    }
+    ctx.when(mode === LEVEL0) {
+      allowSet := Mux(isMSI, rectified, False)
+      allowClear := Mux(isMSI, True, False)
+    }
+  }
+
+  override def driveIepCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === DETACHED) {
+    }
+    ctx.when(mode === EDGE1) {
+      ip.setWhen(input.rise())
+    }
+    ctx.when(mode === EDGE0) {
+      ip.setWhen(input.fall())
+    }
+    ctx.when(mode === LEVEL1 && !isMSI) {
+      ip := input
+    }
+    ctx.when(mode === LEVEL1 && isMSI) {
+      ip.setWhen(input.rise())
+      ip.clearWhen(!input)
+    }
+    ctx.when(mode === LEVEL0 && !isMSI) {
+      ip := ~input
+    }
+    ctx.when(mode === LEVEL0 && isMSI) {
+      ip.setWhen(input.fall())
+      ip.clearWhen(input)
+    }
+  }
+
+  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(List(EDGE1, LEVEL1).map(mode === _).orR) {
+      ip := input
+    }
+    ctx.when(List(EDGE0, LEVEL0).map(mode === _).orR) {
+      ip := ~input
+    }
+  }
+}
+
+case class APlicSourceActiveHigh(sourceId: Int, state: APlicSourceState) extends APlicSource(sourceId, state) {
+  import APlicSourceMode._
+
+  override def supportModes(): Seq[E] = Seq(INACTIVE, LEVEL1)
+
+  override def driveRectifiedCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === LEVEL1) {
+      rectified := input
+    }
+  }
+
+  override def driveAllowCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === LEVEL1) {
+      allowSet := Mux(isMSI, rectified, False)
+      allowClear := Mux(isMSI, True, False)
+    }
+  }
+
+  override def driveIepCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === LEVEL1 && !isMSI) {
+      ip := input
+    }
+    ctx.when(mode === LEVEL1 && isMSI) {
+      ip.setWhen(input.rise())
+      ip.clearWhen(!input)
+    }
+  }
+
+  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === LEVEL1) {
+      ip := input
+    }
+  }
+}
+
+case class APlicSourceActiveLow(sourceId: Int, state: APlicSourceState) extends APlicSource(sourceId, state) {
+  import APlicSourceMode._
+
+  override def supportModes(): Seq[E] = Seq(INACTIVE, LEVEL0)
+
+  override def driveRectifiedCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === LEVEL0) {
+      rectified := ~input
+    }
+  }
+
+  override def driveAllowCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === LEVEL0) {
+      allowSet := Mux(isMSI, rectified, False)
+      allowClear := Mux(isMSI, True, False)
+    }
+  }
+
+  override def driveIepCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === LEVEL0 && !isMSI) {
+      ip := ~input
+    }
+    ctx.when(mode === LEVEL0 && isMSI) {
+      ip.setWhen(input.fall())
+      ip.clearWhen(input)
+    }
+  }
+
+  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === LEVEL0) {
+      ip := ~input
+    }
+  }
+}
+
+case class APlicSourceActiveRising(sourceId: Int, state: APlicSourceState) extends APlicSource(sourceId, state) {
+  import APlicSourceMode._
+
+  override def supportModes(): Seq[E] = Seq(INACTIVE, EDGE1)
+
+  override def driveRectifiedCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === EDGE1) {
+      rectified := input.rise()
+    }
+  }
+
+  override def driveAllowCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === EDGE1) {
+      allowSet := True
+      allowClear := True
+    }
+  }
+
+  override def driveIepCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === EDGE1) {
+      ip.setWhen(input.rise())
+    }
+  }
+
+  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === EDGE1) {
+      ip := input
+    }
+  }
+}
+
+case class APlicSourceActiveFalling(sourceId: Int, state: APlicSourceState) extends APlicSource(sourceId, state) {
+  import APlicSourceMode._
+
+  override def supportModes(): Seq[E] = Seq(INACTIVE, EDGE0)
+
+  override def driveRectifiedCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === EDGE0) {
+      rectified := input.fall()
+    }
+  }
+
+  override def driveAllowCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === EDGE0) {
+      allowSet := True
+      allowClear := True
+    }
+  }
+
+  override def driveIepCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === EDGE0) {
+      ip.setWhen(input.fall())
+    }
+  }
+
+  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === EDGE0) {
+      ip := ~input
+    }
+  }
+}
+
+case class APlicSourceActiveSpurious(sourceId: Int, state: APlicSourceState) extends APlicSource(sourceId, state) {
+  import APlicSourceMode._
+
+  override def supportModes(): Seq[E] = Seq(INACTIVE, DETACHED)
+
+  override def driveRectifiedCtx(ctx: WhenBuilder): Unit = {}
+
+  override def driveAllowCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === DETACHED) {
+      allowSet := True
+      allowClear := True
+    }
+  }
+
+  override def driveIepCtx(ctx: WhenBuilder): Unit = {
+    ctx.when(mode === DETACHED) {
+    }
+  }
+
+  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {}
+}

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
@@ -1,0 +1,85 @@
+package spinal.lib.misc.aia
+
+import spinal.core._
+import spinal.lib._
+
+case class ImsicFileInfo(
+  hartId        : Int,
+  guestId       : Int,
+  sourceIds     : Seq[Int],
+  groupId       : Int,
+  groupHartId   : Int
+)
+
+object ImsicFileInfo {
+  def apply(hartId: Int, guestId: Int, sourceIds: Seq[Int]): ImsicFileInfo = ImsicFileInfo(
+    hartId = hartId,
+    guestId = guestId,
+    sourceIds = sourceIds,
+    groupId = 0,
+    groupHartId = hartId
+  )
+
+  def apply(hartId: Int, sourceIds: Seq[Int]): ImsicFileInfo = ImsicFileInfo(
+    hartId = hartId,
+    guestId = 0,
+    sourceIds = sourceIds,
+    groupId = 0,
+    groupHartId = hartId
+  )
+}
+
+case class ImsicFile(hartId: Int, guestId: Int, sourceIds: Seq[Int]) extends Area {
+  val idWidth = log2Up((sourceIds ++ Seq(0)).max + 1)
+
+  val triggers = Bits(sourceIds.size bits)
+  val threshold = RegInit(U(0, idWidth bits))
+
+  val interrupts = for ((sourceId, idx) <- sourceIds.zipWithIndex) yield new Area {
+    val id = sourceId
+    val trigger = triggers(idx)
+    val ie = RegInit(False)
+    val ip = RegInit(False) setWhen(trigger)
+  }
+
+  case class ImsicRequest() extends Bundle {
+    val id = UInt(idWidth bits)
+    val iep = Bool()
+  }
+
+  val requests = interrupts.map{i =>
+    val request = ImsicRequest()
+    request.id := i.id
+    request.iep := i.ie && i.ip
+    request
+  }
+
+  val result = RegNext(requests.reduceBalancedTree((a, b) => {
+    val takeA = !b.iep || (a.iep && a.id < b.id)
+    takeA ? a | b
+  }))
+
+  val identity = (result.iep && (threshold === 0 || result.id < threshold)) ? result.id | U(0, idWidth bits)
+
+  def claim(id: UInt) = new Area {
+    switch(id) {
+      for (i <- interrupts) {
+        is (i.id) {
+          i.ip.clear()
+        }
+      }
+    }
+  }
+
+  def asImsicFileInfo(hartPerGroup: Int = 0): ImsicFileInfo = ImsicFileInfo(
+    hartId      = hartId,
+    guestId     = guestId,
+    sourceIds   = sourceIds,
+    groupId     = if (hartPerGroup == 0) 0 else (hartId / hartPerGroup),
+    groupHartId = if (hartPerGroup == 0) hartId else (hartId % hartPerGroup)
+  )
+}
+
+object ImsicFile {
+  def apply(hartId: Int, sourceIds: Seq[Int]): ImsicFile = ImsicFile(hartId, 0, sourceIds)
+}

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicTrigger.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicTrigger.scala
@@ -1,0 +1,159 @@
+package spinal.lib.misc.aia
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc._
+
+case class ImsicTriggerMapper(sourceIds: Seq[Int], hartId: Int, guestId: Int) extends Component {
+  val registerWidth = 32
+
+  val idWidth = log2Up((sourceIds ++ Seq(0)).max + 1)
+  require(idWidth <= registerWidth)
+
+  val io = new Bundle {
+    val drivers = in Vec(Flow(UInt(registerWidth bits)), Flow(UInt(registerWidth bits)))
+    val triggers = out(Bits(sourceIds.size bits))
+  }
+
+  case class ImsicSource(sourceId: Int) extends Area {
+    val id = U(sourceId, registerWidth bits)
+    val trigger = Bool()
+
+    trigger := False
+  }
+
+  val sources = for (sourceId <- sourceIds) yield new ImsicSource(sourceId)
+
+  io.triggers := sources.map(_.trigger).asBits()
+
+  /* Main work, mapping the irq set */
+  val triggers = for (driver <- io.drivers) yield new Area {
+    when(driver.valid) {
+      for (source <- sources) {
+        when (driver.payload === source.id) {
+          source.trigger := True
+        }
+      }
+    }
+  }
+
+  def driveFrom(bus: BusSlaveFactory, baseAddress: BigInt) = new Area {
+    val SETEIPNUM_LE_ADDR = 0x000
+    val SETEIPNUM_BE_ADDR = 0x004
+
+    val busWithOffset = new BusSlaveFactoryAddressWrapper(bus, baseAddress)
+    val targetDriveLE = busWithOffset.createAndDriveFlow(UInt(registerWidth bits), address = SETEIPNUM_LE_ADDR, documentation = "Set External Interrupt-Pending bit for %s of hart %d by Little-Endian Number".format(if (guestId == 0) "non-guest" else s"guest ${guestId}", hartId))
+
+    val targetDriveBE = busWithOffset.createAndDriveFlow(UInt(registerWidth bits), address = SETEIPNUM_BE_ADDR, documentation = "Set External Interrupt-Pending bit for %s of hart %d by Big-Endian Number".format(if (guestId == 0) "non-guest" else s"guest ${guestId}", hartId))
+
+    io.drivers := Vec(targetDriveLE, targetDriveBE.map(EndiannessSwap(_)))
+  }
+}
+
+/**
+ * ImsicMapping: IMSIC interrupt file mapping info
+ *
+ * Each interrupt file address should be calcuated as below:
+ * g * 2^E + B + h * 2^D
+ *
+ * g is the IMSIC group id and the h is the hart id in the group
+ *
+ * @interruptFileHartSize:
+ *   The interrupt file size for one hart, for IMSIC supports guest
+ *   interrupt file, this size should cover all guest interrupt
+ *   file. This argument is 2^D in the address formula.
+ * @interruptFileHartOffset:
+ *   The offset of the interrupt file size for one hart. This
+ *   argument is B in the address formula.
+ * @interruptFileGroupSize:
+ *   The group size for one interrupt file group, This argument is
+ *   2^E in the address formula.
+ *
+ * For convenient, all the arguments could be set to zero for auto
+ * calcuation. But when `interruptFileHartOffset` is not zero,
+ * `interruptFileGroupSize` must be set non-zero, or the calcuation
+ * will fail.
+ *
+ */
+case class ImsicMapping(
+  interruptFileHartSize       : BigInt = 0,
+  interruptFileHartOffset     : BigInt = 0,
+  interruptFileGroupSize      : BigInt = 0
+)
+
+object ImsicTrigger {
+  val interruptFileSize: BigInt = 4096
+
+  def mappingCalibrate(mapping: ImsicMapping, maxGuestId: Int, maxGroupHartId: Int, maxGroupId: Int): ImsicMapping = {
+    import mapping._
+
+    require(interruptFileHartSize == 0 || isPow2(interruptFileHartSize), "interruptFileHartSize should be power of 2")
+    require(interruptFileGroupSize == 0 || isPow2(interruptFileGroupSize), "interruptFileGroupSize should be power of 2")
+    require(!(interruptFileHartOffset != 0 && interruptFileGroupSize == 0), "Can not auto calcuate interruptFileGroupSize when interruptFileHartOffset != 0")
+
+    require(maxGuestId < 16, "Per hart can only have max 15 guest interrupt files.")
+
+    val intFileNumber = 1 << log2Up(maxGuestId + 1)
+    val minIntFileHartSize = interruptFileSize * intFileNumber
+    val realIntFileHartSize = if (interruptFileHartSize != 0) interruptFileHartSize else minIntFileHartSize
+    require(realIntFileHartSize >= minIntFileHartSize)
+
+    val intFileGroupHarts = 1 << log2Up(maxGroupHartId + 1)
+    val minIntFileGroupSize = realIntFileHartSize * intFileGroupHarts
+    val realIntFileGroupSize = if (interruptFileGroupSize != 0) interruptFileGroupSize else minIntFileGroupSize
+    require(realIntFileGroupSize >= minIntFileGroupSize)
+
+    val intFileGroupMask = minIntFileGroupSize - 1
+    val intFileGroupIdMask = 1 << log2Up(maxGroupId + 1) - 1
+    val intFileTestMask = intFileGroupMask + realIntFileGroupSize * intFileGroupIdMask
+    require((interruptFileHartOffset & intFileTestMask) == 0, "interruptFileHartOffset should not cover any interrupt file")
+
+    return ImsicMapping(
+      interruptFileHartSize   = realIntFileHartSize,
+      interruptFileHartOffset = interruptFileHartOffset,
+      interruptFileGroupSize  = realIntFileGroupSize
+    )
+  }
+
+  def imsicOffset(mapping: ImsicMapping, groupId: Int, groupHartId: Int, guestId: Int) = {
+    import mapping._
+
+    val offset = groupId * interruptFileGroupSize +
+                 groupHartId * interruptFileHartSize +
+                 interruptFileHartOffset +
+                 guestId * interruptFileSize
+
+    offset
+  }
+
+  def apply(bus: BusSlaveFactory, mapping: ImsicMapping)(infos: Seq[ImsicFileInfo]) = new Area {
+    val maxGuestId = infos.map(_.guestId).max
+    val maxGroupHartId = infos.map(_.groupHartId).max
+    val maxGroupId = infos.map(_.groupId).max
+
+    val realMapping = mappingCalibrate(mapping, maxGuestId, maxGroupHartId, maxGroupId)
+
+    val mappers = for (info <- infos) yield new Area {
+      val mapper = ImsicTriggerMapper(info.sourceIds, info.hartId, info.guestId)
+      val offset = imsicOffset(realMapping, info.groupId, info.groupHartId, info.guestId)
+
+      mapper.driveFrom(bus, offset)
+
+      setName(f"trigger_g${info.groupId}h${info.groupHartId}v${info.guestId}")
+    }
+
+    val triggers = Vec(mappers.map(_.mapper.io.triggers))
+  }
+
+  def addressWidth(mapping: ImsicMapping, maxGuestId: Int, maxGroupHartId: Int, maxGroupId: Int): Int = {
+    val realMapping = mappingCalibrate(mapping, maxGuestId, maxGroupHartId, maxGroupId)
+
+    val intFileNumber = 1 << log2Up(maxGuestId + 1)
+    val intFileGroupHarts = 1 << log2Up(maxGroupHartId + 1)
+    val intFileGroupMax = 1 << log2Up(maxGroupId + 1)
+
+    val ImsicSize = imsicOffset(realMapping, maxGroupId, maxGroupHartId, maxGuestId + 1)
+
+    return log2Up(ImsicSize)
+  }
+}

--- a/lib/src/main/scala/spinal/lib/misc/aia/TilelinkAPlic.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/TilelinkAPlic.scala
@@ -1,0 +1,241 @@
+package spinal.lib.misc.aia
+
+import spinal.core._
+import spinal.core.fiber._
+import spinal.lib._
+import spinal.lib.bus.misc._
+import spinal.lib.bus.tilelink
+import spinal.lib.misc._
+import spinal.lib.misc.slot.{Slot, SlotPool}
+
+import scala.collection.mutable.ArrayBuffer
+
+class MappedAPlic[T <: spinal.core.Data with IMasterSlave](
+  sourceParams: Seq[APlicSourceParam],
+  hartIds: Seq[Int],
+  childInfos: Seq[APlicChildInfo],
+  p: APlicDomainParam,
+  busType: HardType[T],
+  factoryGen: T => BusSlaveFactory
+) extends Component {
+  val io = new Bundle {
+    val bus = slave(busType())
+    val sources = in Bits (sourceParams.size bits)
+    val mmsiaddrcfg = (if (p.isRoot) out else in) UInt (64 bits)
+    val smsiaddrcfg = (if (p.isRoot) out else in) UInt (64 bits)
+    val targets = p.genParam.withDirect generate (out Bits (hartIds.size bits))
+    val childSources = out Vec(childInfos.map(childInfo => Bits(childInfo.sourceIds.size bits)))
+    val msiMsg = p.genParam.withMSI generate master(Stream(APlicMsiPayload()))
+  }
+
+  if (p.isRoot && (p.genParam.withMSI || p.genParam._withMsiAddrcfg)) {
+    io.mmsiaddrcfg.assignDontCare()
+    io.smsiaddrcfg.assignDontCare()
+  }
+
+  val aplic = APlic(p, sourceParams, hartIds, childInfos)
+
+  aplic.sources := io.sources
+  if (p.genParam.withDirect) {
+    io.targets := aplic.direct.targets
+  }
+  io.childSources := aplic.childSources
+
+  if (p.isRoot) {
+    io.mmsiaddrcfg := aplic.mmsiaddrcfg
+    io.smsiaddrcfg := aplic.smsiaddrcfg
+  } else {
+    aplic.mmsiaddrcfg := io.mmsiaddrcfg
+    aplic.smsiaddrcfg := io.smsiaddrcfg
+  }
+
+  if (p.genParam.withMSI) {
+    io.msiMsg << aplic.msi.msiStream
+  }
+
+  val factory = factoryGen(io.bus)
+  val mapping = APlicMapper(factory)(aplic)
+}
+
+case class TilelinkAPlic(sourceParams: Seq[APlicSourceParam], hartIds: Seq[Int],
+                         childInfos: Seq[APlicChildInfo],
+                         domainParam: APlicDomainParam, params: tilelink.BusParameter)
+                         extends MappedAPlic[tilelink.Bus](
+  sourceParams,
+  hartIds,
+  childInfos,
+  domainParam,
+  new tilelink.Bus(params),
+  new tilelink.SlaveFactory(_, true)
+)
+
+case class TilelinkAPlicMsiSender(pendingSize: Int, busParams: tilelink.BusParameter) extends Component {
+  val io = new Bundle {
+    val msiMsg = slave(Stream(APlicMsiPayload()))
+    val bus = master(tilelink.Bus(busParams))
+  }
+
+  val slots = new SlotPool(pendingSize, true)(new Slot)
+
+  val out = io.msiMsg.map(payload => {
+    val channelA = cloneOf(io.bus.a.payloadType)
+    channelA.opcode   := tilelink.Opcode.A.PUT_FULL_DATA
+    channelA.size     := 2
+    channelA.source   := slots.allocate.id
+    channelA.address  := payload.address.resized
+    channelA.data     := payload.data.asBits.resized
+    channelA.debugId  := 0
+    channelA.mask     := 0xf
+    channelA
+  }).haltWhen(slots.allocate.full)
+
+  when(out.fire) {
+    slots.allocate{s => {}}
+  }
+
+  io.bus.a <-< out
+  io.bus.d.ready := True
+
+  val slotReader = slots.slots.reader(io.bus.d.source)
+  when (io.bus.d.fire && io.bus.d.isLast()) {
+    slots.free(io.bus.d.source)
+  }
+}
+
+object TilelinkAPlic {
+  def getTilelinkSlaveSupport(proposed: bus.tilelink.M2sSupport, addressWidth: Int = 20) = bus.tilelink.SlaveFactory.getSupported(
+    addressWidth = addressWidth,
+    dataWidth = 32,
+    allowBurst = false,
+    proposed
+  )
+
+  def addressWidth(maxTargetId: Int): Int = {
+    import APlicMapping._
+    val aplicSize = idcOffset + maxTargetId * idcGroupSize
+    return log2Up(aplicSize)
+  }
+}
+
+object TilelinkAPlicMsiSenderFiber {
+  def getTilelinkMasterSupport(pendingSize: Int, addressWidth: Int, name: Nameable) = bus.tilelink.M2sParameters(
+    addressWidth = addressWidth,
+    dataWidth = 32,
+    masters = List(
+      tilelink.M2sAgent(
+        name = name,
+        mapping = List(
+          tilelink.M2sSource(
+            id = SizeMapping(0, pendingSize),
+            emits = tilelink.M2sTransfers(
+              putFull = tilelink.SizeRange(4)
+            )
+          )
+        )
+      )
+    )
+  )
+}
+
+case class TilelinkAPlicMsiSenderFiber(pendingSize: Int = 4, addressWidth: Int = 64) extends Area with APlicMsiConsumerFiber {
+  val node = tilelink.fabric.Node.down()
+  var msiStream: Option[Stream[APlicMsiPayload]] = None
+
+  override def createMsiStreamConsumer(): Stream[APlicMsiPayload] = {
+    if (msiStream.isEmpty) {
+      msiStream = Some(Stream(APlicMsiPayload()))
+    }
+
+    msiStream.get
+  }
+
+  val thread = Fiber build new Area {
+    val busParams = TilelinkAPlicMsiSenderFiber.getTilelinkMasterSupport(pendingSize, addressWidth, TilelinkAPlicMsiSenderFiber.this)
+
+    node.m2s forceParameters busParams
+    node.s2m.supported load tilelink.S2mSupport.none()
+
+    val core = TilelinkAPlicMsiSender(pendingSize, node.bus.p)
+
+    core.io.bus <> node.bus
+    core.io.msiMsg << msiStream.get
+  }
+}
+
+case class TilelinkAPlicFiber(domainParam: APlicDomainParam) extends Area with InterruptCtrlFiber with APlicMsiProducerFiber {
+  val node = tilelink.fabric.Node.up()
+  val core = Handle[TilelinkAPlic]()
+
+  case class SourceSpec(node: InterruptNode, param: APlicSourceParam)
+  case class TargetSpec(node: InterruptNode, id: Int)
+  case class APlicSlaveBundle(childInfo: APlicChildInfo) extends Area {
+    val flags = childInfo.sourceIds.map(_ => InterruptNode.master())
+  }
+
+  val sources = ArrayBuffer[SourceSpec]()
+  val targets = ArrayBuffer[TargetSpec]()
+  var msiStream: Option[Stream[APlicMsiPayload]] = None
+  val mmsiaddrcfg = UInt (64 bits)
+  val smsiaddrcfg = UInt (64 bits)
+
+  override def defaultInterruptMode = LEVEL_HIGH
+
+  override def createMsiStreamProducer(): Stream[APlicMsiPayload] = {
+    if (msiStream.isEmpty) {
+      msiStream = Some(Stream(APlicMsiPayload()))
+    }
+
+    msiStream.get
+  }
+
+  override def createInterruptMaster(id: Int) : InterruptNode = {
+    val spec = node.clockDomain on TargetSpec(InterruptNode.master(), id)
+    targets += spec
+    spec.node
+  }
+
+  override def createInterruptSlave(id: Int, mode: InterruptMode) : InterruptNode = {
+    val param = APlicSourceParam(id, mode)
+    val spec = node.clockDomain on SourceSpec(InterruptNode.slave(), param)
+    sources += spec
+    spec.node
+  }
+
+  val childSources = ArrayBuffer[APlicSlaveBundle]()
+  def createInterruptDelegation(childInfo: APlicChildInfo) = {
+    childSources.addRet(APlicSlaveBundle(childInfo))
+  }
+
+  val thread = Fiber build new Area {
+    lock.await()
+
+    node.m2s.supported.load(TilelinkAPlic.getTilelinkSlaveSupport(node.m2s.proposed, TilelinkAPlic.addressWidth(targets.map(_.id).max + 1)))
+    node.s2m.none()
+
+    val aplic = TilelinkAPlic(sources.map(_.param).toSeq, targets.map(_.id).toSeq, childSources.map(_.childInfo).toSeq, domainParam, node.bus.p)
+
+    core.load(aplic)
+
+    if (domainParam.genParam.withMSI) {
+      msiStream.get << core.io.msiMsg
+    }
+
+    core.io.bus <> node.bus
+    core.io.sources := sources.map(_.node.flag).asBits()
+    if (domainParam.genParam.withDirect) {
+      Vec(targets.map(_.node.flag)) := core.io.targets.asBools
+    }
+
+    if (domainParam.isRoot) {
+      mmsiaddrcfg := core.io.mmsiaddrcfg
+      smsiaddrcfg := core.io.smsiaddrcfg
+    } else {
+      core.io.mmsiaddrcfg := mmsiaddrcfg
+      core.io.smsiaddrcfg := smsiaddrcfg
+    }
+
+    for ((childSource, ioSlaveSource) <- childSources.zip(core.io.childSources)) {
+      Vec(childSource.flags.map(_.flag)) := ioSlaveSource.asBools
+    }
+  }
+}

--- a/lib/src/main/scala/spinal/lib/misc/aia/TilelinkImsicTrigger.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/TilelinkImsicTrigger.scala
@@ -1,0 +1,88 @@
+package spinal.lib.misc.aia
+
+import spinal.core._
+import spinal.core.fiber.{Fiber, Lock}
+import spinal.lib._
+import spinal.lib.bus.misc._
+import spinal.lib.bus.tilelink
+
+import scala.collection.mutable.ArrayBuffer
+
+class MappedImsicTrigger[T <: spinal.core.Data with IMasterSlave](infos: Seq[ImsicFileInfo],
+                                                           mapping: ImsicMapping,
+                                                           busType: HardType[T],
+                                                           factoryGen: T => BusSlaveFactory) extends Component {
+  val io = new Bundle {
+    val bus = slave(busType())
+    val triggers = out Vec(infos.map(info => Bits(info.sourceIds.size bits)))
+  }
+
+  val factory = factoryGen(io.bus)
+
+  val logic = ImsicTrigger(factory, mapping)(infos)
+
+  io.triggers := logic.triggers
+}
+
+case class TilelinkImsicTrigger(infos: Seq[ImsicFileInfo],
+                                mapping: ImsicMapping,
+                                p: bus.tilelink.BusParameter) extends MappedImsicTrigger[bus.tilelink.Bus](
+  infos,
+  mapping,
+  new bus.tilelink.Bus(p),
+  new bus.tilelink.SlaveFactory(_, true)
+)
+
+object TilelinkImsicTrigger {
+  def getTilelinkSupport(transfers: tilelink.M2sTransfers, addressWidth: Int = 20) = bus.tilelink.SlaveFactory.getSupported(
+    addressWidth = addressWidth,
+    dataWidth = 32,
+    allowBurst = false,
+    proposed = tilelink.M2sSupport(
+      addressWidth = addressWidth,
+      dataWidth = 32,
+      transfers = transfers
+    )
+  )
+  def getTilelinkSupport(transfers: tilelink.M2sTransfers, mapping: ImsicMapping, infos: Seq[ImsicFileInfo]): tilelink.M2sSupport = getTilelinkSupport(transfers, addressWidth(mapping, infos))
+
+  def addressWidth(mapping: ImsicMapping, infos: Seq[ImsicFileInfo]): Int = {
+    val maxGuestId = infos.map(_.guestId).max
+    val maxGroupHartId = infos.map(_.groupHartId).max
+    val maxGroupId = infos.map(_.groupId).max
+
+    ImsicTrigger.addressWidth(mapping, maxGuestId, maxGroupHartId, maxGroupId)
+  }
+}
+
+case class TilelinkImsicTriggerFiber(mapping: ImsicMapping = ImsicMapping()) extends Area {
+  val node = bus.tilelink.fabric.Node.slave()
+  val lock = Lock()
+
+  case class ImsicFileSource(info: ImsicFileInfo) {
+    val trigger = Bits(info.sourceIds.size bits)
+  }
+
+  var infos = ArrayBuffer[ImsicFileSource]()
+  def addImsicFileinfo(info: ImsicFileInfo) = {
+    val source = infos.addRet(ImsicFileSource(info))
+    source.trigger
+  }
+
+  val thread = Fiber build new Area {
+    lock.await()
+
+    val imsicInfos = infos.map(_.info).toSeq
+
+    node.m2s.supported.load(TilelinkImsicTrigger.getTilelinkSupport(node.m2s.proposed.transfers, mapping, imsicInfos))
+    node.s2m.none()
+
+    val core = TilelinkImsicTrigger(imsicInfos, mapping, node.bus.p)
+
+    core.io.bus <> node.bus
+
+    for ((info, trigger) <- infos.zip(core.io.triggers)) {
+      info.trigger := trigger
+    }
+  }
+}


### PR DESCRIPTION
# Context, Motivation & Description

Introduce APLIC ande IMSIC device based on the [RISC-V AIA spec](https://github.com/riscv/riscv-aia).

## InterruptCtrlFiber

Introduce a new function that allows user to set the interrupt trigger mode.

## APLIC:

- [x] Interrupt Delegation
- [x] Direct delivery mode
- [x] MSI delivery mode
- [ ] Big Endian (no plan for it)

The implementation includes three parts: 
1. `APlicSource`: this is used for interrupt source, including five modes: level high, level low, edge rising, edge falling, spurious.
2. `APlicGateway`: this is used for interrupt delivery, including both direct and MSI mode. The direct mode is similar with PLIC.
3. `APlicMapper`: this is used for mapping the APLIC device

A tilelink based implementation is also provided (`TilelinkAPlic`).

## IMSIC

The implementation includes two parts: 
1. `ImsicTrigger`: this is used for mapping IMSIC MMIO file and convert the bus write to interrupt line.
2. `ImsicFile` this is used for providing in CPU implementation related to `ImsicTrigger`.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
