### PR TITLE
lib: misc: aia: APlicSource: fix wrong mode access when update sourcecfg

### DIFF
--- a/lib/src/main/scala/spinal/lib/misc/aia/APlicSource.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/APlicSource.scala
@@ -152,7 +152,7 @@ abstract class APlicSource(sourceId: Int, state: APlicSourceState) extends Area 
   def driveAllowCtx(ctx: WhenBuilder): Unit
   def driveIepCtx(ctx: WhenBuilder): Unit
   def driveRectifiedCtx(ctx: WhenBuilder): Unit
-  def driveConfigUpdateCtx(ctx: WhenBuilder): Unit
+  def driveConfigUpdateCtx(ctx: WhenBuilder, nextMode: APlicSourceMode.C): Unit
   def supportModes(): Seq[APlicSourceMode.E]
 
   def asDirectRequest(idWidth: Int, targetHart: Int): APlicGenericRequest = {
@@ -219,7 +219,7 @@ abstract class APlicSource(sourceId: Int, state: APlicSourceState) extends Area 
       ip := False
     }
 
-    driveConfigUpdateCtx(ctx)
+    driveConfigUpdateCtx(ctx, mode)
   }
 
   def setConfig(payload: UInt): Unit = {
@@ -332,11 +332,11 @@ case class APlicFullSource(sourceId: Int, state: APlicSourceState) extends APlic
     }
   }
 
-  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
-    ctx.when(List(EDGE1, LEVEL1).map(mode === _).orR) {
+  override def driveConfigUpdateCtx(ctx: WhenBuilder, nextMode: APlicSourceMode.C): Unit = {
+    ctx.when(List(EDGE1, LEVEL1).map(nextMode === _).orR) {
       ip := input
     }
-    ctx.when(List(EDGE0, LEVEL0).map(mode === _).orR) {
+    ctx.when(List(EDGE0, LEVEL0).map(nextMode === _).orR) {
       ip := ~input
     }
   }
@@ -370,8 +370,8 @@ case class APlicSourceActiveHigh(sourceId: Int, state: APlicSourceState) extends
     }
   }
 
-  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
-    ctx.when(mode === LEVEL1) {
+  override def driveConfigUpdateCtx(ctx: WhenBuilder, nextMode: APlicSourceMode.C): Unit = {
+    ctx.when(nextMode === LEVEL1) {
       ip := input
     }
   }
@@ -405,8 +405,8 @@ case class APlicSourceActiveLow(sourceId: Int, state: APlicSourceState) extends 
     }
   }
 
-  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
-    ctx.when(mode === LEVEL0) {
+  override def driveConfigUpdateCtx(ctx: WhenBuilder, nextMode: APlicSourceMode.C): Unit = {
+    ctx.when(nextMode === LEVEL0) {
       ip := ~input
     }
   }
@@ -436,7 +436,7 @@ case class APlicSourceActiveRising(sourceId: Int, state: APlicSourceState) exten
     }
   }
 
-  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
+  override def driveConfigUpdateCtx(ctx: WhenBuilder, mode: APlicSourceMode.C): Unit = {
     ctx.when(mode === EDGE1) {
       ip := input
     }
@@ -467,8 +467,8 @@ case class APlicSourceActiveFalling(sourceId: Int, state: APlicSourceState) exte
     }
   }
 
-  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {
-    ctx.when(mode === EDGE0) {
+  override def driveConfigUpdateCtx(ctx: WhenBuilder, nextMode: APlicSourceMode.C): Unit = {
+    ctx.when(nextMode === EDGE0) {
       ip := ~input
     }
   }
@@ -493,5 +493,5 @@ case class APlicSourceActiveSpurious(sourceId: Int, state: APlicSourceState) ext
     }
   }
 
-  override def driveConfigUpdateCtx(ctx: WhenBuilder): Unit = {}
+  override def driveConfigUpdateCtx(ctx: WhenBuilder, nextMode: APlicSourceMode.C): Unit = {}
 }

--- a/lib/src/main/scala/spinal/lib/misc/aia/APlicSource.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/APlicSource.scala
@@ -267,14 +267,16 @@ object APlicSource {
 case class APlicFullSource(sourceId: Int, state: APlicSourceState) extends APlicSource(sourceId, state) {
   import APlicSourceMode._
 
+  val trigger = input.edges()
+
   override def supportModes(): Seq[E] = Seq(INACTIVE, EDGE0, EDGE1, LEVEL0, LEVEL1, DETACHED)
 
   override def driveRectifiedCtx(ctx: WhenBuilder): Unit = {
     ctx.when(mode === EDGE1) {
-      rectified := input.rise()
+      rectified := trigger.rise
     }
     ctx.when(mode === EDGE0) {
-      rectified := input.fall()
+      rectified := trigger.fall
     }
     ctx.when(mode === LEVEL1) {
       rectified := input
@@ -311,32 +313,38 @@ case class APlicFullSource(sourceId: Int, state: APlicSourceState) extends APlic
     ctx.when(mode === DETACHED) {
     }
     ctx.when(mode === EDGE1) {
-      ip.setWhen(input.rise())
+      ip.setWhen(trigger.rise)
     }
     ctx.when(mode === EDGE0) {
-      ip.setWhen(input.fall())
+      ip.setWhen(trigger.fall)
     }
     ctx.when(mode === LEVEL1 && !isMSI) {
       ip := input
     }
     ctx.when(mode === LEVEL1 && isMSI) {
-      ip.setWhen(input.rise())
+      ip.setWhen(trigger.rise)
       ip.clearWhen(!input)
     }
     ctx.when(mode === LEVEL0 && !isMSI) {
       ip := ~input
     }
     ctx.when(mode === LEVEL0 && isMSI) {
-      ip.setWhen(input.fall())
+      ip.setWhen(trigger.fall)
       ip.clearWhen(input)
     }
   }
 
   override def driveConfigUpdateCtx(ctx: WhenBuilder, nextMode: APlicSourceMode.C): Unit = {
-    ctx.when(List(EDGE1, LEVEL1).map(nextMode === _).orR) {
+    ctx.when(nextMode === EDGE1) {
+      ip := trigger.rise
+    }
+    ctx.when(nextMode === EDGE0) {
+      ip := trigger.fall
+    }
+    ctx.when(nextMode === LEVEL1) {
       ip := input
     }
-    ctx.when(List(EDGE0, LEVEL0).map(nextMode === _).orR) {
+    ctx.when(nextMode === LEVEL0) {
       ip := ~input
     }
   }
@@ -415,11 +423,13 @@ case class APlicSourceActiveLow(sourceId: Int, state: APlicSourceState) extends 
 case class APlicSourceActiveRising(sourceId: Int, state: APlicSourceState) extends APlicSource(sourceId, state) {
   import APlicSourceMode._
 
+  val trigger = input.rise()
+
   override def supportModes(): Seq[E] = Seq(INACTIVE, EDGE1)
 
   override def driveRectifiedCtx(ctx: WhenBuilder): Unit = {
     ctx.when(mode === EDGE1) {
-      rectified := input.rise()
+      rectified := trigger
     }
   }
 
@@ -432,13 +442,13 @@ case class APlicSourceActiveRising(sourceId: Int, state: APlicSourceState) exten
 
   override def driveIepCtx(ctx: WhenBuilder): Unit = {
     ctx.when(mode === EDGE1) {
-      ip.setWhen(input.rise())
+      ip.setWhen(trigger)
     }
   }
 
   override def driveConfigUpdateCtx(ctx: WhenBuilder, mode: APlicSourceMode.C): Unit = {
     ctx.when(mode === EDGE1) {
-      ip := input
+      ip := trigger
     }
   }
 }
@@ -446,11 +456,13 @@ case class APlicSourceActiveRising(sourceId: Int, state: APlicSourceState) exten
 case class APlicSourceActiveFalling(sourceId: Int, state: APlicSourceState) extends APlicSource(sourceId, state) {
   import APlicSourceMode._
 
+  val trigger = input.fall()
+
   override def supportModes(): Seq[E] = Seq(INACTIVE, EDGE0)
 
   override def driveRectifiedCtx(ctx: WhenBuilder): Unit = {
     ctx.when(mode === EDGE0) {
-      rectified := input.fall()
+      rectified := trigger
     }
   }
 
@@ -463,13 +475,13 @@ case class APlicSourceActiveFalling(sourceId: Int, state: APlicSourceState) exte
 
   override def driveIepCtx(ctx: WhenBuilder): Unit = {
     ctx.when(mode === EDGE0) {
-      ip.setWhen(input.fall())
+      ip.setWhen(trigger)
     }
   }
 
   override def driveConfigUpdateCtx(ctx: WhenBuilder, nextMode: APlicSourceMode.C): Unit = {
     ctx.when(nextMode === EDGE0) {
-      ip := ~input
+      ip := trigger
     }
   }
 }


### PR DESCRIPTION
# Context, Motivation & Description

When split the mode support from APlicSource, the parameter "update mode" of driveConfigUpdateCtx is missing, and the function access the global mode, which is different from the update mode and make the ip detection broken.

Add the mode parameter to fix the detection behavior.

# Impact on code generation

`APlicSource` now will detect interrupt line and update the ip state when updating `config` register.


# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
