### PR TITLE
Fix simulator waveform paths for GHDL and IVerilog

### DIFF
--- a/sim/src/main/scala/spinal/sim/GhdlBackend.scala
+++ b/sim/src/main/scala/spinal/sim/GhdlBackend.scala
@@ -103,8 +103,8 @@ class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
     val thread = new Thread(new Runnable {
       val iface = sharedMemIface
       def run(): Unit = {
-        val waveFileDir = Paths.get(System.getProperty("user.dir"), config.testPath.replace("$TEST",testName)).toAbsolutePath.normalize()
-        val waveFile = f"${waveFileDir}/wave.${config.waveFormat.ext}"
+        val waveFilePath = Paths.get(config.testPath.replace("$TEST",testName)).toAbsolutePath.normalize()
+        val waveFile = f"${waveFilePath}/wave.${config.waveFormat.ext}"
         var waveArgString = ""
         if (!(Array(WaveFormat.DEFAULT, WaveFormat.NONE) contains format)) {
           if (format == WaveFormat.GHW) {
@@ -114,7 +114,7 @@ class GhdlBackend(config: GhdlBackendConfig) extends VpiBackend(config) {
           }
         }
         if (waveArgString != "") {
-          FileUtils.forceMkdirParent(new File(waveFileDir.toString, "."))
+          FileUtils.forceMkdirParent(new File(waveFilePath.toString, "."))
         }
 
         val retCode = Process(

--- a/sim/src/main/scala/spinal/sim/IVerilogBackend.scala
+++ b/sim/src/main/scala/spinal/sim/IVerilogBackend.scala
@@ -155,7 +155,7 @@ class IVerilogBackend(config: IVerilogBackendConfig) extends VpiBackend(config) 
       else (pluginsPath + "/" + vpiModuleName).replaceAll("/C", raw"C:").replaceAll(raw"/", raw"\\")
 
     val pathStr = if (!isWindows) sys.env("PATH")
-    val waveFilePath = Paths.get(System.getProperty("user.dir"), config.testPath.replace("$TEST",testName)).toAbsolutePath.normalize()
+    val waveFilePath = Paths.get(config.testPath.replace("$TEST",testName)).toAbsolutePath.normalize()
 
     val thread = new Thread(new Runnable {
       val iface = sharedMemIface


### PR DESCRIPTION
The waveform path for IVerilog and GHDL is a concatenation of the user's home directory and the absolute version path of the testPath.

This patch ensures the waveforms get stored together with the rest of the simulation data for these backends, bringing them in line with the Verilator backend.