### PR TITLE
Nested PackedWordBundle unpack fix

### DIFF
--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -168,7 +168,13 @@ class PackedBundle extends Bundle {
       * @return Self
       */
     def packFrom(pos: Int): T = {
-      t.pack(pos + t.getBitsWidth - 1 downto pos)
+      // Need to consider if this is a PackedBundle or not
+      t match {
+        case pb: PackedBundle =>
+          t.pack(pos + pb.getPackedWidth - 1 downto pos)
+        case d: Data =>
+          t.pack(pos + d.getBitsWidth - 1 downto pos)
+      }
     }
 
     /** Packs data ending (MSB) at the bit position
@@ -176,7 +182,13 @@ class PackedBundle extends Bundle {
       * @return Self
       */
     def packTo(pos: Int): T = {
-      t.pack(pos downto pos - t.getBitsWidth + 1)
+      // Need to consider if this is a PackedBundle or not
+      t match {
+        case pb: PackedBundle =>
+          t.pack(pos downto pos - pb.getPackedWidth + 1)
+        case d: Data =>
+          t.pack(pos downto pos - d.getBitsWidth + 1)
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1770

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
This issue stems from PackedWordBundle (or really PackedBundle) needing to call to `packed`/`getPackedWidth` instead of `asBits`/`getBitWidth` to get the intended bits and their bit width.

The `packed` and `unpack` methods were neglecting to call `getPackedWidth` on all nested PackedBundles. This PR adds awareness of PackedBundles when `pack`ing and `unpack`ing

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
Fixes some unintended verbosity when using nested PackedBundles. Example:

```scala
  case class TestNestPb() extends PackedWordBundle(32 bits) {
    val pb  = TestPb().packFrom(0).inWord(0)
    val u32 = Bits(32 bits).packFrom(0).inWord(3)
  } // BitsWidth = 72 , PackedWidth = 128
```
Before this PR:
```vhdl
  zz_tnpb_pb_u8 <= pkg_cat(pkg_extract(bits,39,0),pkg_stdLogicVector("00000000000000000000000000000000000000000000000000000000"));
  tnpb_pb_u8 <= unsigned(pkg_extract(zz_tnpb_pb_u8,42,35));
```
After this PR:
```vhdl
  zz_tnpb_pb_u8 <= pkg_extract(bits,95,0);
  tnpb_pb_u8 <= unsigned(pkg_extract(zz_tnpb_pb_u8,42,35));
```

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
