### PR TITLE
Mark unused data line as dont care; prevents unassigned errors in certain test modes

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ErrorSlave.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4ErrorSlave.scala
@@ -39,6 +39,7 @@ case class Axi4ReadOnlyErrorSlave(axiConfig: Axi4Config) extends Component{
   val io = new Bundle{
     val axi = slave(Axi4ReadOnly(axiConfig))
   }
+  io.axi.r.data.assignDontCare()
 
   val sendRsp       = RegInit(False)
   val id            = if(axiConfig.useId) Reg(UInt(axiConfig.idWidth bits)) else null


### PR DESCRIPTION
# Context, Motivation & Description

WIthout this annotation, when used in a formal test, spinal issues an error that the R data line isn't ever assigned. This fixes this.

The formal test I have inserts instrumentation signals on all streams to verify that the payload data does not change when it is stalled, which causes the signal to be read so it is a niche error and does not trigger in normal usage. But the fix should have no impact on generated code and signals the intent to not set the data so I think the change is a net positive overall. 