### PR TITLE
feat(sv interface): sv interface can be set to blackbox. add header comment when oneFilePerComponent

### DIFF
--- a/core/src/main/scala/spinal/core/Interface.scala
+++ b/core/src/main/scala/spinal/core/Interface.scala
@@ -32,6 +32,7 @@ object IsInterface extends SpinalTag {}
   *
   */
 class Interface extends Bundle {
+  var isBlackBox = false
   var definitionName: String = this.getClass.getSimpleName
   var thisIsNotSVIF = false
   /** Set the definition name of the component */

--- a/core/src/main/scala/spinal/core/internals/BackendUtils.scala
+++ b/core/src/main/scala/spinal/core/internals/BackendUtils.scala
@@ -63,6 +63,32 @@ object VhdlVerilogBase{
     buffer ++= "\n"
     buffer.toString()
   }
+  def getIntfHeader(commentSymbol: String, header: String, name: String, withDate : Boolean, withRepoHash : Boolean): String = {
+    var buffer = new StringBuilder()
+    buffer ++= s"$commentSymbol Generator : SpinalHDL ${Spinal.version}    git head : ${spinal.core.Info.gitHash}\n"
+    buffer ++= s"$commentSymbol Interface : ${name}\n"
+    if(withRepoHash) {
+      import sys.process._
+      try {
+        Console.withErr(new OutputStream {
+          override def write(i: Int): Unit = {}
+        }) {
+          val hash = "git rev-parse HEAD".!!(new ProcessLogger {
+            override def out(s: => String): Unit = {}
+            override def err(s: => String): Unit = {}
+            override def buffer[T](f: => T): T = f
+          }).linesIterator.next()
+          buffer ++=  s"$commentSymbol Git hash  : ${hash}\n"
+        }
+      } catch{
+        case e : Exception =>
+      }
+    }
+    if(withDate) buffer ++= s"$commentSymbol Date      : ${new SimpleDateFormat("dd/MM/yyyy, HH:mm:ss").format(Calendar.getInstance().getTime)}\n"
+    if(header != null) buffer ++= header.split("\n").map(line => s"$commentSymbol $line").mkString("\n") + "\n"
+    buffer ++= "\n"
+    buffer.toString()
+  }
 }
 
 

--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -98,6 +98,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
         for ((name, interface) <- svInterface) {
           val ifFileName = pc.config.targetDirectory + "/" + name + (if(pc.config.isSystemVerilog) ".sv" else ".v")
           val ifFile = new java.io.FileWriter(ifFileName)
+          ifFile.write(VhdlVerilogBase.getIntfHeader("//", pc.config.rtlHeader, name, config.headerWithDate, config.headerWithRepoHash))
           ifFile.write("\n")
           ifFile.write(interface.result())
           ifFile.flush()
@@ -456,7 +457,7 @@ class PhaseInterface(pc: PhaseContext) extends PhaseNetlist{
                 globalScope.lock = true
                 insertIFmap()
               }
-              case None => svInterface += interface.definitionName -> interfaceString
+              case None => if(!interface.isBlackBox) svInterface += interface.definitionName -> interfaceString
             }
           }
         }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description



# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
