### PR TITLE
Fix `asReversedBits`

### DIFF
--- a/core/src/main/scala/spinal/core/MultiData.scala
+++ b/core/src/main/scala/spinal/core/MultiData.scala
@@ -55,6 +55,20 @@ abstract class MultiData extends Data {
     ret
   }
 
+  /** Concatenate the bits of the elements in reverse order.
+    *
+    * This does not recurse, so elements which are composite will appear in forward order.
+    */
+  def asReversedBits: Bits = {
+    var ret: Bits = null
+    for ((_, e) <- elements) {
+      if (ret == null.asInstanceOf[Object]) ret = e.asBits
+      else ret = ret ## e.asBits
+    }
+    if (ret.asInstanceOf[Object] == null) ret = Bits(0 bits)
+    ret
+  }
+
   override def getBitsWidth: Int = {
     var accumulateWidth = 0
     for ((_, e) <- elements) {

--- a/core/src/main/scala/spinal/core/TupleBundle.scala
+++ b/core/src/main/scala/spinal/core/TupleBundle.scala
@@ -12,15 +12,6 @@ class TupleBundleBase extends Bundle {
 
   @deprecated("misspelled method will be removed", "???")
   def asRevertedBits: Bits = asReversedBits
-  def asReversedBits: Bits = {
-    var ret: Bits = null
-    for ((_, e) <- elements) {
-      if (ret == null.asInstanceOf[Object]) ret = e.asBits
-      else ret = ret ## e.asBits
-    }
-    if (ret.asInstanceOf[Object] == null) ret = Bits(0 bits)
-    ret
-  }
 
   override def elements: ArrayBuffer[(String, Data)] = elementsCache.reverse
 }

--- a/core/src/main/scala/spinal/core/TupleBundle.scala
+++ b/core/src/main/scala/spinal/core/TupleBundle.scala
@@ -16,7 +16,7 @@ class TupleBundleBase extends Bundle {
     var ret: Bits = null
     for ((_, e) <- elements) {
       if (ret == null.asInstanceOf[Object]) ret = e.asBits
-      else ret = e.asBits ## ret
+      else ret = ret ## e.asBits
     }
     if (ret.asInstanceOf[Object] == null) ret = Bits(0 bits)
     ret


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

At the time of my last PR ( #1832 ) , I did not realize that `asReversedBits` was broken and had the same behavior as `asBits`. This PR fixes that, and also moves the method from `TupleBundle` to `MultiData`, so that it can be used with `Vec`s etc.

# Checklist

- [ ] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?