### PR TITLE
add simSetAll method for simulation.

### DIFF
--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -554,6 +554,18 @@ package object sim {
     def toBigInt: BigInt = getBigInt(bt)
     def toBytes: Array[Byte] = SimEquivBitVectorBytesPimper(bt).getSim
     def toBooleans : Array[Boolean] = SimEquivBitVectorBooleansPimper(bt).getSim
+
+    /** Set all bits of the BitVector to 1 during simulation
+      *
+      * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Simulation/signal.html#read-and-write-signals Simulation documentation]]
+      */
+    def simSetAll(): Unit = {
+      val width = bt.getBitsWidth
+      if (width <= 0) return
+
+      val allOnesValue = (BigInt(1) << width) - 1
+      bt #= allOnesValue
+    }
   }
 
   object SimUnionElementPimper {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

Add set all method to simulation.

There are two concerns:
1. If it is okay to mix the simulation function with design.
2. It will report fail while assign 255 to SInt, I think it should be act like that due to the method name is set all.



<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were not added, but have been tested internally.
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
