### PR TITLE
lib: spinal: bus: wishbone: Fix Output to Slave Assignment

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
@@ -1,4 +1,3 @@
-/** @todo: change <> with the corrispective >> and <<*/
 package spinal.lib.bus.wishbone
 
 import spinal.core._
@@ -7,7 +6,7 @@ import spinal.lib.bus.misc._
 import scala.collection.Seq
 
 /** Factory for [[spinal.lib.bus.wishbone.WishboneDecoder]] instances. */
-object WishboneDecoder{
+object WishboneDecoder {
   /** Create a istance of a wishbone decoder/multiplexer
   * @param config it will use for configuring all the input/output wishbone port
   * @param decodings it will use for configuring the partial address decoder
@@ -23,8 +22,8 @@ object WishboneDecoder{
   def apply(master: Wishbone, slaves: Seq[(Wishbone, AddressMapping)]): WishboneDecoder = {
     val decoder = new WishboneDecoder(master.config, slaves.map(_._2))
     decoder.io.input <> master
-    (slaves.map(_._1), decoder.io.outputs).zipped.map(_ <> _)
-    decoder.setPartialName(master,"decoder")
+    (slaves.map(_._1), decoder.io.outputs).zipped.map(_ << _)
+    decoder.setPartialName(master, "decoder")
   }
 }
 
@@ -35,7 +34,7 @@ object WishboneDecoder{
 class WishboneDecoder(config : WishboneConfig, decodings : Seq[AddressMapping]) extends Component {
   val io = new Bundle {
     val input = slave(Wishbone(config))
-    val outputs = Vec(master(Wishbone(config)),decodings.size)
+    val outputs = Vec(master(Wishbone(config)), decodings.size)
   }
 
   //permanently drive some slave iunput signal to save on logic usage


### PR DESCRIPTION
Assign each decoder output with the '<<' assignment to each slave. This allows tod downgrade the bus width, which is helpful when connecting slaves with a smaller address range.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
