### PR TITLE
Replace hardcoded 32 with width parameter in extendedMantissa

### DIFF
--- a/lib/src/main/scala/spinal/lib/experimental/math/FloatingUtils.scala
+++ b/lib/src/main/scala/spinal/lib/experimental/math/FloatingUtils.scala
@@ -47,7 +47,7 @@ object FloatingToSInt {
     */
   def apply(input: RecFloating, width: Int, offset: Int): SInt = {
     val isNotZero = input.exponent(input.exponentSize - 1 downto input.exponentSize - 3).orR
-    val extendedMantissa = Bits(32 bits)
+    val extendedMantissa = Bits(width bits)
     extendedMantissa := (isNotZero ## input.mantissa).resizeLeft(width)
     val exponentOffset = input.exponent.asUInt - U(input.getExponentZero + input.getExponentBias)
     val shift = width - 1 - exponentOffset - offset


### PR DESCRIPTION
# Context, Motivation & Description
Replaced hardcoded 32-bit width with the `width` parameter in `extendedMantissa` 
to make the function more flexible and consistent with the input width.

# Impact on code generation
No impact on code generation behavior. This is a code cleanup that makes 
the mantissa size properly match the width parameter instead of being 
hardcoded to 32 bits.

# Checklist
- [ ] Unit tests were added
- [ ] API changes are or will be documented