### PR TITLE
Fix spelling mistakes

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Misc.scala
+++ b/core/src/main/scala/spinal/core/internals/Misc.scala
@@ -269,12 +269,12 @@ object GraphUtils{
     root.children.foreach(walkAllComponents(_, func))
   }
   def countNames(topLevel : Component) ={
-    var named, unamed = 0
+    var named, unnamed = 0
     GraphUtils.walkAllComponents(topLevel, c => c.dslBody.walkStatements{
-      case s : Nameable => if(s.getName().contains("zz"))  unamed += 1 else named += 1
+      case s : Nameable => if(s.getName().contains("zz"))  unnamed += 1 else named += 1
       case _ =>
     })
-    println(s"Named=$named Unamed=$unamed")
+    println(s"Named=$named Unnamed=$unnamed")
     named
   }
 

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -1199,7 +1199,7 @@ class PhaseMemBlackBoxingGeneric(policy: MemBlackboxingPolicy) extends PhaseMemB
 object classNameOf{
   def apply(that : Any): String = {
     val name = that.getClass.getSimpleName.replace("$",".").split("\\.").head
-    if(name.nonEmpty) name else "unamed"
+    if(name.nonEmpty) name else "unnamed"
   }
 }
 
@@ -2884,13 +2884,13 @@ class PhasePropagateNames(pc: PhaseContext) extends PhaseMisc {
     import pc._
     val algoId = globalData.allocateAlgoIncrementale() //Allows to avoid chaining allocated names
 
-    // All unamed signals are cleaned up to avoid composite / partial name side effects
+    // All unnamed signals are cleaned up to avoid composite / partial name side effects
     walkStatements{
       case bt : BaseType if bt.isUnnamed => bt.unsetName()
       case _ =>
     }
 
-    // propagate all named signals names to their unamed drivers
+    // propagate all named signals names to their unnamed drivers
     walkStatements{
       case dst : BaseType => if (dst.isNamed && dst.algoIncrementale != algoId) {
         def explore(bt: BaseType, depth : Int): Unit = {

--- a/tester/src/test/scala/spinal/tester/code/Debug.scala
+++ b/tester/src/test/scala/spinal/tester/code/Debug.scala
@@ -43,7 +43,7 @@ object DebugInOut extends App{
       val subIo = inout(Analog(Bits(8 bits)))
     }
     io := sub.subIo
-    setDefinitionName("unamed")
+    setDefinitionName("unnamed")
   })
 }
 

--- a/tester/src/test/scala/spinal/tester/code/p1/Rawrr.scala
+++ b/tester/src/test/scala/spinal/tester/code/p1/Rawrr.scala
@@ -139,7 +139,7 @@ class MyToplevel8() extends Component {
     val tmp = Bool() // Automaticaly tmp.setName("logic1_tmp")
   }
   def func1() = {
-    val tmp = Bool() //Unamed signal
+    val tmp = Bool() //Unnamed signal
   }
   def func2() = new Area {
     val tmp = Bool() //Automatic a.setCompositeName(this, "tmp")


### PR DESCRIPTION
This replaces some spelling mistakes of "unamed" with the correct spelling "unnamed".

I tried to ignore this for a while but it's grinding my gears. Apparently I am not the first one: 8abe10d267578ab157ba5a2186e26e6021cf4138