### PR TITLE
Fix SInt exclusion checking when using a negative number literal

### DIFF
--- a/core/src/main/scala/spinal/core/internals/Statement.scala
+++ b/core/src/main/scala/spinal/core/internals/Statement.scala
@@ -551,7 +551,7 @@ class SwitchStatement(var value: Expression) extends TreeStatement{
       val occupancy = new Array[Boolean](size.toInt)
 
       def allocate(id_ : BigInt): Boolean ={
-        val id = id_.toInt
+        val id = if (id_ < 0) (size + id_).toInt else id_.toInt
 
         if(id_ >= size){
           println("???")

--- a/tester/src/test/scala/spinal/core/SpinalSimSwitchTester.scala
+++ b/tester/src/test/scala/spinal/core/SpinalSimSwitchTester.scala
@@ -1,0 +1,32 @@
+package spinal.core
+
+import spinal.core.sim._
+import spinal.tester.scalatest.SpinalSimFunSuite
+
+class SwitchTest extends Component {
+  val io = new Bundle {
+    val input = in SInt(3 bits)
+    val output = out SInt(3 bits)
+  }
+
+  switch (io.input) {
+    is (1, 2, 3) {
+      io.output := 1
+    }
+    is (0) {
+      io.output := 0
+    }
+    is (-1, -2, -3) {
+      io.output := -1
+    }
+    default {
+      io.output := -2
+    }
+  }
+}
+
+class SpinalSimSwitchTester extends SpinalSimFunSuite {
+  test("compile") {
+    SimConfig.withFstWave.compile(new SwitchTest)
+  }
+}


### PR DESCRIPTION

# Context, Motivation & Description

When using `switch` with a `SInt`, a negative number literal will caused the following

```
[info] - verilator_compile *** FAILED ***
[info]   java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 8
[info]   at spinal.core.internals.SwitchStatement$ExclusionByArray$1.allocate(Statement.scala:561)
[info]   at spinal.core.internals.SwitchStatement.$anonfun$isFullyCoveredWithoutDefault$2(Statement.scala:585)
[info]   at spinal.core.internals.SwitchStatement.$anonfun$isFullyCoveredWithoutDefault$2$adapted(Statement.scala:579)
[info]   at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
[info]   at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
[info]   at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
[info]   at spinal.core.internals.SwitchStatement.$anonfun$isFullyCoveredWithoutDefault$1(Statement.scala:579)
[info]   at spinal.core.internals.SwitchStatement.$anonfun$isFullyCoveredWithoutDefault$1$adapted(Statement.scala:579)
[info]   at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
[info]   at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
[info]   ...
```
# Impact on code generation

The switch statement of `SInt` will compile with a negative number literal.

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
