### PR TITLE
Fix Fragment.reduce accumulator not initialized

### DIFF
--- a/lib/src/main/scala/spinal/lib/Fragment.scala
+++ b/lib/src/main/scala/spinal/lib/Fragment.scala
@@ -67,7 +67,7 @@ class StreamFragmentPimped[T <: Data](pimped: Stream[Fragment[T]]) {
  */
   def reduce[U <: Data](identity: U, accumulator: (U, U, T) => Unit): Stream[U] = {
     val next = new Stream(identity).setCompositeName(pimped, "reduced", true)
-    val acc = Reg(identity)
+    val acc = RegInit(identity)
     
     accumulator(next.payload, acc, pimped.fragment)
     

--- a/tester/src/test/scala/spinal/lib/SpinalSimStreamFragmentReduceTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimStreamFragmentReduceTester.scala
@@ -1,0 +1,39 @@
+package spinal.lib
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib.sim._
+import spinal.tester.SpinalSimFunSuite
+
+class SpinalSimStreamFragmentReduceTester extends SpinalSimFunSuite {
+  test("reduce") {
+    SimConfig.compile {
+      new Component {
+        val input = slave(Stream(Fragment(UInt(8 bits))))
+        val output = master(input.reduce(U(0, 8 bits), (next: UInt, acc: UInt, frag: UInt) => next := acc + frag))
+      }
+    }.doSimUntilVoid { dut =>
+      SimTimeout(100000)
+      dut.clockDomain.forkStimulus(10)
+
+      val scoreboard = ScoreboardInOrder[Int]()
+      var acc = 0
+      StreamDriver(dut.input, dut.clockDomain) { p =>
+        val v = simRandom.nextInt(256)
+        val last = simRandom.nextInt(5) == 0
+        p.fragment #= v
+        p.last #= last
+        acc = (acc + v) & 0xFF
+        if (last) { scoreboard.pushRef(acc); acc = 0 }
+        true
+      }
+      StreamReadyRandomizer(dut.output, dut.clockDomain)
+      StreamMonitor(dut.output, dut.clockDomain) { p =>
+        scoreboard.pushDut(p.toInt)
+      }
+      dut.clockDomain.onSamplings {
+        if (scoreboard.matches >= 100) simSuccess()
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

I was using Fragment.reduce in one of my designs but found a bug with it. The accumulator register is not initialized, so the first time reduction is done the output will be garbage.

I also added a unit test, and checked it failed before the fix while working after the fix..

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
