### PR TITLE
Add clear input signal to StreamShiftChain

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1925,13 +1925,14 @@ class StreamShiftChain[T <: Data](dataType: HardType[T], length: Int) extends Co
     val push          = slave  Stream(dataType)
     val pop           = master Stream(dataType)
     val states        = Vec(master Flow(dataType), length)
+    val clear         = in Bool() default(False)
   }
 
   def builder(prev: Stream[T], left: Int): List[Stream[T]] = {
     left match {
       case 0 => Nil
       case 1 => prev :: Nil
-      case _ => prev :: builder(prev.stage(), left - 1)
+      case _ => prev :: builder(prev.m2sPipe(flush = io.clear), left - 1)
     }
   }
   val connections = Vec(builder(io.push, length))


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->


# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

I was using StreamShiftChain in order to implement a sliding window on a Fragment-based stream. In that case, you want to clear out the shift chain after the last fragment comes into it. Since otherwise you will be mixing elements from two different packets.

Without this, you would need to wait for the shift chain to be flushed out, which could be a serious cost if packets are relatively small, and also requires more logic.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
