### PR TITLE
Enhance the plugin system

### DIFF
--- a/lib/src/main/scala/spinal/lib/misc/plugin/Fiber.scala
+++ b/lib/src/main/scala/spinal/lib/misc/plugin/Fiber.scala
@@ -94,5 +94,27 @@ class FiberPlugin extends Area with Hostable {
         }
       }
     }
+
+    def patch[T: ClassTag](body: => T): Handle[T] = spinal.core.fiber.Fiber patch {
+      pluginEnabled generate {
+        hostLock.await()
+        val onCreate = OnCreateStack.getOrElse(null)
+        host.rework {
+          OnCreateStack.set(onCreate)
+          body
+        }
+      }
+    }
+
+    def check[T: ClassTag](body: => T): Handle[T] = spinal.core.fiber.Fiber check {
+      pluginEnabled generate {
+        hostLock.await()
+        val onCreate = OnCreateStack.getOrElse(null)
+        host.rework {
+          OnCreateStack.set(onCreate)
+          body
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

All build phases predefined in spinal.core.fiber are allowed.
This should be able to reduce the use of explicit locks.
Example:
1. In the patch phase, pipeline.build() can be called to simplify the negotiation of the calling timing.
2. In the check phase, reports can be printed to check whether the negotiation was successful.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
