### PR TITLE
feat: optionally include the call-site location (file and line) in the report output

### DIFF
--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -220,6 +220,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         var printFilelist              : Boolean = true,
                         var emitFullComponentBindings  : Boolean = true,
                         var reportIncludeSourceLocation: Boolean = false,
+                        var reportSourceLocationFormat : String = SpinalConfig.defaultReportSourceLocationFormat,
                         var svInterface                : Boolean = false
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)
@@ -326,6 +327,8 @@ object SpinalConfig{
   }
 
   var defaultTargetDirectory: String = System.getenv().getOrDefault("SPINAL_TARGET_DIR", ".")
+  var defaultReportSourceLocationFormat: String =
+    System.getenv().getOrDefault("SPINAL_REPORT_SOURCE_LOCATION_FORMAT", "$SEVERITY($FILE:$LINE) ")
 }
 
 

--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -219,6 +219,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         var withTimescale              : Boolean = true,
                         var printFilelist              : Boolean = true,
                         var emitFullComponentBindings  : Boolean = true,
+                        var reportIncludeSourceLocation: Boolean = false,
                         var svInterface                : Boolean = false
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -43,6 +43,18 @@ object FAILURE  extends AssertNodeSeverity
 
 object REPORT_TIME
 
+object ReportSourceLocation {
+  def prefix(loc: Location): String = {
+    val file0 = loc.file
+    val file1 = if (file0.startsWith("file:")) file0.stripPrefix("file:") else file0
+    val fileWithExt0 =
+      if (file1.endsWith(".scala") || file1.endsWith(".sc")) file1
+      else file1 + ".scala"
+    val fileWithExt = fileWithExt0.replace('\\', '/')
+    s"$fileWithExt:${loc.line}: "
+  }
+}
+
 /** Min max base function */
 trait MinMaxProvider {
   def minValue: BigInt
@@ -843,6 +855,7 @@ object unusedTag                     extends SpinalTag
 object noCombinatorialLoopCheck      extends SpinalTag
 object noLatchCheck                  extends SpinalTag
 object noBackendCombMerge            extends SpinalTag
+object reportIncludeSourceLocation   extends SpinalTag{ override def allowMultipleInstance = false }
 
 /** Tag for clock crossing signals
   * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/clock_domain.html#clock-domain-crossing Clock domain crossing documentation]]

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -44,14 +44,27 @@ object FAILURE  extends AssertNodeSeverity
 object REPORT_TIME
 
 object ReportSourceLocation {
-  def prefix(loc: Location): String = {
+  private def severityString(severity: AssertNodeSeverity): String = severity match {
+    case `NOTE`    => "NOTE"
+    case `WARNING` => "WARNING"
+    case `ERROR`   => "ERROR"
+    case `FAILURE` => "FAILURE"
+  }
+
+  private def fileWithExt(loc: Location): String = {
     val file0 = loc.file
     val file1 = if (file0.startsWith("file:")) file0.stripPrefix("file:") else file0
     val fileWithExt0 =
       if (file1.endsWith(".scala") || file1.endsWith(".sc")) file1
       else file1 + ".scala"
-    val fileWithExt = fileWithExt0.replace('\\', '/')
-    s"$fileWithExt:${loc.line}: "
+    fileWithExt0.replace('\\', '/')
+  }
+
+  def prefix(format: String, loc: Location, severity: AssertNodeSeverity): String = {
+    format
+      .replace("$FILE", fileWithExt(loc))
+      .replace("$LINE", loc.line.toString)
+      .replace("$SEVERITY", severityString(severity))
   }
 }
 
@@ -856,6 +869,9 @@ object noCombinatorialLoopCheck      extends SpinalTag
 object noLatchCheck                  extends SpinalTag
 object noBackendCombMerge            extends SpinalTag
 object reportIncludeSourceLocation   extends SpinalTag{ override def allowMultipleInstance = false }
+case class reportSourceLocationFormatTag(format: String) extends SpinalTag{
+  override def allowMultipleInstance = false
+}
 
 /** Tag for clock crossing signals
   * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/clock_domain.html#clock-domain-crossing Clock domain crossing documentation]]

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -44,27 +44,8 @@ object FAILURE  extends AssertNodeSeverity
 object REPORT_TIME
 
 object ReportSourceLocation {
-  private def severityString(severity: AssertNodeSeverity): String = severity match {
-    case `NOTE`    => "NOTE"
-    case `WARNING` => "WARNING"
-    case `ERROR`   => "ERROR"
-    case `FAILURE` => "FAILURE"
-  }
-
-  private def fileWithExt(loc: Location): String = {
-    val file0 = loc.file
-    val file1 = if (file0.startsWith("file:")) file0.stripPrefix("file:") else file0
-    val fileWithExt0 =
-      if (file1.endsWith(".scala") || file1.endsWith(".sc")) file1
-      else file1 + ".scala"
-    fileWithExt0.replace('\\', '/')
-  }
-
   def prefix(format: String, loc: Location, severity: AssertNodeSeverity): String = {
-    format
-      .replace("$FILE", fileWithExt(loc))
-      .replace("$LINE", loc.line.toString)
-      .replace("$SEVERITY", severityString(severity))
+    spinal.core.internals.ReportFormatting.renderPrefix(format, loc, severity)
   }
 }
 

--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -565,11 +565,27 @@ package object core extends BaseTypeFactory with BaseTypeCast {
 //    if(cond.dlcIsEmpty || !cond.head.source.isInstanceOf[Operator.Formal.InitState])
 //      cond.setName("when_" + loc.file + "_l" + loc.line, Nameable.REMOVABLE)
 
-  def report(message: String)   = assert(False, message, NOTE)
-  def report(message: Seq[Any]) = assert(False, message, NOTE)
+  private def reportDefaultIncludeSourceLocation: Boolean = {
+    val gd = GlobalData.get
+    gd != null && gd.config.reportIncludeSourceLocation
+  }
 
-  def report(message: String,   severity: AssertNodeSeverity) = assert(False, message, severity)
-  def report(message: Seq[Any], severity: AssertNodeSeverity) = assert(False, message, severity)
+  private def reportTagIfNeeded(statement: AssertStatement, includeSourceLocation: Boolean): AssertStatement = {
+    if (includeSourceLocation) statement.addTag(reportIncludeSourceLocation)
+    statement
+  }
+
+  def report(message: String)(implicit loc: Location)   = reportTagIfNeeded(assert(False, message, NOTE), reportDefaultIncludeSourceLocation)
+  def report(message: Seq[Any])(implicit loc: Location) = reportTagIfNeeded(assert(False, message, NOTE), reportDefaultIncludeSourceLocation)
+
+  def report(message: String, includeSourceLocation: Boolean)(implicit loc: Location)   = reportTagIfNeeded(assert(False, message, NOTE), includeSourceLocation)
+  def report(message: Seq[Any], includeSourceLocation: Boolean)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, NOTE), includeSourceLocation)
+
+  def report(message: String,   severity: AssertNodeSeverity)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, severity), reportDefaultIncludeSourceLocation)
+  def report(message: Seq[Any], severity: AssertNodeSeverity)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, severity), reportDefaultIncludeSourceLocation)
+
+  def report(message: String,   severity: AssertNodeSeverity, includeSourceLocation: Boolean)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, severity), includeSourceLocation)
+  def report(message: Seq[Any], severity: AssertNodeSeverity, includeSourceLocation: Boolean)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, severity), includeSourceLocation)
 
 
   class TuplePimperBase(product: Product){

--- a/core/src/main/scala/spinal/core/core.scala
+++ b/core/src/main/scala/spinal/core/core.scala
@@ -570,22 +570,39 @@ package object core extends BaseTypeFactory with BaseTypeCast {
     gd != null && gd.config.reportIncludeSourceLocation
   }
 
-  private def reportTagIfNeeded(statement: AssertStatement, includeSourceLocation: Boolean): AssertStatement = {
-    if (includeSourceLocation) statement.addTag(reportIncludeSourceLocation)
+  private def reportTagIfNeeded(statement: AssertStatement, includeSourceLocation: Boolean, sourceLocationFormat: String): AssertStatement = {
+    if (includeSourceLocation) {
+      statement.addTag(reportIncludeSourceLocation)
+      if (sourceLocationFormat != null) statement.addTag(reportSourceLocationFormatTag(sourceLocationFormat))
+    }
     statement
   }
 
-  def report(message: String)(implicit loc: Location)   = reportTagIfNeeded(assert(False, message, NOTE), reportDefaultIncludeSourceLocation)
-  def report(message: Seq[Any])(implicit loc: Location) = reportTagIfNeeded(assert(False, message, NOTE), reportDefaultIncludeSourceLocation)
+  def report(message: String)(implicit loc: Location)   = reportTagIfNeeded(assert(False, message, NOTE), reportDefaultIncludeSourceLocation, null)
+  def report(message: Seq[Any])(implicit loc: Location) = reportTagIfNeeded(assert(False, message, NOTE), reportDefaultIncludeSourceLocation, null)
 
-  def report(message: String, includeSourceLocation: Boolean)(implicit loc: Location)   = reportTagIfNeeded(assert(False, message, NOTE), includeSourceLocation)
-  def report(message: Seq[Any], includeSourceLocation: Boolean)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, NOTE), includeSourceLocation)
+  def report(message: String, includeSourceLocation: Boolean)(implicit loc: Location)   = reportTagIfNeeded(assert(False, message, NOTE), includeSourceLocation, null)
+  def report(message: Seq[Any], includeSourceLocation: Boolean)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, NOTE), includeSourceLocation, null)
 
-  def report(message: String,   severity: AssertNodeSeverity)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, severity), reportDefaultIncludeSourceLocation)
-  def report(message: Seq[Any], severity: AssertNodeSeverity)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, severity), reportDefaultIncludeSourceLocation)
+  def report(message: String, includeSourceLocation: Boolean, sourceLocationFormat: String)(implicit loc: Location) =
+    reportTagIfNeeded(assert(False, message, NOTE), includeSourceLocation, sourceLocationFormat)
+  def report(message: Seq[Any], includeSourceLocation: Boolean, sourceLocationFormat: String)(implicit loc: Location) =
+    reportTagIfNeeded(assert(False, message, NOTE), includeSourceLocation, sourceLocationFormat)
 
-  def report(message: String,   severity: AssertNodeSeverity, includeSourceLocation: Boolean)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, severity), includeSourceLocation)
-  def report(message: Seq[Any], severity: AssertNodeSeverity, includeSourceLocation: Boolean)(implicit loc: Location) = reportTagIfNeeded(assert(False, message, severity), includeSourceLocation)
+  def report(message: String,   severity: AssertNodeSeverity)(implicit loc: Location) =
+    reportTagIfNeeded(assert(False, message, severity), reportDefaultIncludeSourceLocation, null)
+  def report(message: Seq[Any], severity: AssertNodeSeverity)(implicit loc: Location) =
+    reportTagIfNeeded(assert(False, message, severity), reportDefaultIncludeSourceLocation, null)
+
+  def report(message: String,   severity: AssertNodeSeverity, includeSourceLocation: Boolean)(implicit loc: Location) =
+    reportTagIfNeeded(assert(False, message, severity), includeSourceLocation, null)
+  def report(message: Seq[Any], severity: AssertNodeSeverity, includeSourceLocation: Boolean)(implicit loc: Location) =
+    reportTagIfNeeded(assert(False, message, severity), includeSourceLocation, null)
+
+  def report(message: String,   severity: AssertNodeSeverity, includeSourceLocation: Boolean, sourceLocationFormat: String)(implicit loc: Location) =
+    reportTagIfNeeded(assert(False, message, severity), includeSourceLocation, sourceLocationFormat)
+  def report(message: Seq[Any], severity: AssertNodeSeverity, includeSourceLocation: Boolean, sourceLocationFormat: String)(implicit loc: Location) =
+    reportTagIfNeeded(assert(False, message, severity), includeSourceLocation, sourceLocationFormat)
 
 
   class TuplePimperBase(product: Product){

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -767,9 +767,8 @@ class ComponentEmitterVerilog(
 
             val includeLocation = assertStatement.hasTag(reportIncludeSourceLocation)
             val locationPrefix = if (includeLocation) {
-              val formatOverride = assertStatement.getTag(classOf[reportSourceLocationFormatTag]).map(_.format)
-              val format = formatOverride.getOrElse(spinalConfig.reportSourceLocationFormat)
-              ReportSourceLocation.prefix(format, assertStatement.loc, assertStatement.severity)
+              val format = ReportFormatting.resolveFormat(assertStatement, spinalConfig)
+              ReportFormatting.renderPrefix(format, assertStatement.loc, assertStatement.severity)
             } else {
               ""
             }
@@ -796,12 +795,7 @@ class ComponentEmitterVerilog(
             }
 
             if (!systemVerilog) {
-              val severity = assertStatement.severity match {
-                case `NOTE` => "NOTE"
-                case `WARNING` => "WARNING"
-                case `ERROR` => "ERROR"
-                case `FAILURE` => "FAILURE"
-              }
+              val severity = ReportFormatting.severityLabel(assertStatement.severity)
 
               b ++= s"${tab}`ifndef SYNTHESIS\n"
               b ++= s"${tab}  `ifdef FORMAL\n"

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -746,10 +746,13 @@ class ComponentEmitterVhdl(
               val cond = emitExpression(assertStatement.cond)
 
               val messageInput =
-                if (assertStatement.hasTag(reportIncludeSourceLocation))
-                  ReportSourceLocation.prefix(assertStatement.loc) +: assertStatement.message
-                else
+                if (assertStatement.hasTag(reportIncludeSourceLocation)) {
+                  val formatOverride = assertStatement.getTag(classOf[reportSourceLocationFormatTag]).map(_.format)
+                  val format = formatOverride.getOrElse(spinalConfig.reportSourceLocationFormat)
+                  ReportSourceLocation.prefix(format, assertStatement.loc, assertStatement.severity) +: assertStatement.message
+                } else {
                   assertStatement.message
+                }
 
               val message = messageInput
                 .map {

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -745,7 +745,13 @@ class ComponentEmitterVhdl(
             if (!spinalConfig.formalAsserts) {
               val cond = emitExpression(assertStatement.cond)
 
-              val message = assertStatement.message
+              val messageInput =
+                if (assertStatement.hasTag(reportIncludeSourceLocation))
+                  ReportSourceLocation.prefix(assertStatement.loc) +: assertStatement.message
+                else
+                  assertStatement.message
+
+              val message = messageInput
                 .map {
                   case m: String =>
                     "\"" +

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -747,9 +747,8 @@ class ComponentEmitterVhdl(
 
               val messageInput =
                 if (assertStatement.hasTag(reportIncludeSourceLocation)) {
-                  val formatOverride = assertStatement.getTag(classOf[reportSourceLocationFormatTag]).map(_.format)
-                  val format = formatOverride.getOrElse(spinalConfig.reportSourceLocationFormat)
-                  ReportSourceLocation.prefix(format, assertStatement.loc, assertStatement.severity) +: assertStatement.message
+                  val format = ReportFormatting.resolveFormat(assertStatement, spinalConfig)
+                  ReportFormatting.renderPrefix(format, assertStatement.loc, assertStatement.severity) +: assertStatement.message
                 } else {
                   assertStatement.message
                 }
@@ -779,12 +778,7 @@ class ComponentEmitterVhdl(
                 }
                 .mkString(" & ")
   
-              val severity = "severity " +  (assertStatement.severity match{
-                case `NOTE`     => "NOTE"
-                case `WARNING`  => "WARNING"
-                case `ERROR`    => "ERROR"
-                case `FAILURE`  => "FAILURE"
-              })
+              val severity = "severity " + ReportFormatting.severityLabel(assertStatement.severity)
               if (message.length > 0) {
                 b ++= s"""${tab}assert $cond = '1' report ($message) $severity;\n"""
               } else {

--- a/core/src/main/scala/spinal/core/internals/ReportFormatting.scala
+++ b/core/src/main/scala/spinal/core/internals/ReportFormatting.scala
@@ -1,0 +1,35 @@
+package spinal.core.internals
+
+import spinal.core._
+import spinal.idslplugin.Location
+
+object ReportFormatting {
+
+  def severityLabel(severity: AssertNodeSeverity): String = severity match {
+    case `NOTE`    => "NOTE"
+    case `WARNING` => "WARNING"
+    case `ERROR`   => "ERROR"
+    case `FAILURE` => "FAILURE"
+  }
+
+  def fileWithExt(loc: Location): String = {
+    val file0 = loc.file
+    val file1 = if (file0.startsWith("file:")) file0.stripPrefix("file:") else file0
+    val fileWithExt0 =
+      if (file1.endsWith(".scala") || file1.endsWith(".sc")) file1
+      else file1 + ".scala"
+    fileWithExt0.replace('\\', '/')
+  }
+
+  def renderPrefix(format: String, loc: Location, severity: AssertNodeSeverity): String = {
+    format
+      .replace("$FILE", fileWithExt(loc))
+      .replace("$LINE", loc.line.toString)
+      .replace("$SEVERITY", severityLabel(severity))
+  }
+
+  def resolveFormat(statement: AssertStatement, spinalConfig: SpinalConfig): String = {
+    statement.getTag(classOf[reportSourceLocationFormatTag]).map(_.format).getOrElse(spinalConfig.reportSourceLocationFormat)
+  }
+}
+

--- a/tester/src/test/scala/spinal/core/ReportSourceLocationTester.scala
+++ b/tester/src/test/scala/spinal/core/ReportSourceLocationTester.scala
@@ -1,0 +1,59 @@
+package spinal.core
+
+import spinal.tester.scalatest.SpinalAnyFunSuite
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+class ReportSourceLocationTester extends SpinalAnyFunSuite {
+
+  private def displayFormatStrings(rtl: String): List[String] = {
+    def displayFormatString(line: String): Option[String] = {
+      val start = line.indexOf("$display(\"")
+      if (start < 0) return None
+      val from = start + "$display(\"".length
+      val end = line.indexOf("\"", from)
+      if (end < 0) None else Some(line.substring(from, end))
+    }
+
+    rtl.linesIterator.flatMap(displayFormatString).toList
+  }
+
+  test("report can opt-in to print Scala source location") {
+    val outDir = Files.createTempDirectory("spinalhdl_report_source_location_").toFile
+
+    val spinalReport = SpinalConfig(targetDirectory = outDir.getAbsolutePath)
+      .generateVerilog(new Component {
+        report("HELLO_NO_LOC")
+          report("HELLO_WITH_LOC", includeSourceLocation = true)
+      })
+
+    val rtlPath = spinalReport.generatedSourcesPaths.find(_.endsWith(".v")).getOrElse {
+      fail(s"No Verilog file generated, got: ${spinalReport.generatedSourcesPaths.mkString(", ")}")
+    }
+
+    val rtl = new String(Files.readAllBytes(Paths.get(rtlPath)), StandardCharsets.UTF_8)
+
+    val formats = displayFormatStrings(rtl)
+    assert(formats.exists(s => s.contains("HELLO_WITH_LOC") && s.matches(""".*ReportSourceLocationTester\.scala:\d+: NOTE HELLO_WITH_LOC.*""")))
+    assert(formats.exists(_.contains("HELLO_NO_LOC")))
+    assert(!formats.filter(_.contains("HELLO_NO_LOC")).exists(_.matches(""".*\.scala:\d+:.*""")))
+  }
+
+  test("report can enable source location globally") {
+    val outDir = Files.createTempDirectory("spinalhdl_report_source_location_global_").toFile
+
+    val spinalReport = SpinalConfig(targetDirectory = outDir.getAbsolutePath, reportIncludeSourceLocation = true)
+      .generateVerilog(new Component {
+        report("HELLO_GLOBAL_LOC")
+      })
+
+    val rtlPath = spinalReport.generatedSourcesPaths.find(_.endsWith(".v")).getOrElse {
+      fail(s"No Verilog file generated, got: ${spinalReport.generatedSourcesPaths.mkString(", ")}")
+    }
+
+    val rtl = new String(Files.readAllBytes(Paths.get(rtlPath)), StandardCharsets.UTF_8)
+    val formats = displayFormatStrings(rtl)
+    assert(formats.exists(s => s.contains("HELLO_GLOBAL_LOC") && s.matches(""".*ReportSourceLocationTester\.scala:\d+: NOTE HELLO_GLOBAL_LOC.*""")))
+  }
+}


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1737

# Context, Motivation & Description

This PR adds an opt-in way to include the Scala call-site source location (file + line) in `report(...)` messages, so IDEs/terminals can hyperlink simulation logs and jump directly to the code.

Two non-breaking opt-in mechanisms are provided:
- Per-call: `report("msg", includeSourceLocation = true)` (also available on the `severity` overloads)
- Global: `SpinalConfig(reportIncludeSourceLocation = true)` to apply to all `report(...)` calls during elaboration

When enabled, the emitted simulation print string is prefixed by a configurable format string.
The default format is: `SEVERITY($FILE:$LINE) `, e.g. `NOTE(path/to/File.scala:123) `.

Users can override the format globally via `SpinalConfig.reportSourceLocationFormat` or the `SPINAL_REPORT_SOURCE_LOCATION_FORMAT` environment variable.

A regression test is included to ensure the prefix is present only when requested and that the location points to the call site (not to `core.scala`).

<img width="662" height="258" alt="image" src="https://github.com/user-attachments/assets/473edcf4-c558-484b-ad97-678f73b5d97b" />

# Impact on code generation

- Verilog/SystemVerilog: when enabled, the simulation print format string is prefixed with `reportSourceLocationFormat`; when disabled, generated code is unchanged.
- VHDL: when enabled, the `report(...)` message expression is prefixed with `reportSourceLocationFormat`; when disabled, generated code is unchanged.
- This feature only affects simulation-time messages; synthesis output is unchanged.

# Checklist

- [x] Unit tests were added
- [x] API changes are documented [here](https://github.com/SpinalHDL/SpinalDoc-RTD/pull/285)
