### PR TITLE
remove unused signals of FSM to improve RTL code quality

### DIFF
--- a/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
+++ b/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
@@ -230,14 +230,16 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
       }
     }
 
-    for(state <- states){
-      when(!isActive(state)){
+    for(state <- states) {
+      when(!isActive(state)) {
         state.whenInactiveTasks.foreach(_())
       }
-      val exit = Bool().setLambdaName(this.isNamed && state.isNamed)(this.getName +  "_onExit_" + enumOf(state).getName)
-      exit := isExiting(state)
-      when(exit){
-        state.onExitTasks.foreach(_())
+      if(state.onExitTasks.nonEmpty) {
+        val exit = Bool().setLambdaName(this.isNamed && state.isNamed)(this.getName +  "_onExit_" + enumOf(state).getName)
+        exit := isExiting(state)
+        when(exit) {
+          state.onExitTasks.foreach(_())
+        }
       }
     }
 
@@ -251,11 +253,13 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
       }
     }
 
-    for(state <- states){
-      val entry = Bool().setLambdaName(this.isNamed && state.isNamed)(this.getName + "_onEntry_" + enumOf(state).getName)
-      entry := isEntering(state) 
-      when(entry) {
-        state.onEntryTasks.foreach(_())
+    for(state <- states) {
+      if(state.onEntryTasks.nonEmpty) {
+        val entry = Bool().setLambdaName(this.isNamed && state.isNamed)(this.getName + "_onEntry_" + enumOf(state).getName)
+        entry := isEntering(state)
+        when(entry) {
+          state.onEntryTasks.foreach(_())
+        }
       }
     }
 
@@ -283,11 +287,13 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
           corruptedState := True
         }
       }
-      for(state <- states){
-        val entry = Bool().setLambdaName(this.isNamed && state.isNamed)(this.getName + "onEntry_" + enumOf(state).getName)
-        entry := isEntering(state)
-        when(entry) {
-          state.onEntryTasks.foreach(_())
+      for(state <- states) {
+        if(state.onEntryTasks.nonEmpty) {
+          val entry = Bool().setLambdaName(this.isNamed && state.isNamed)(this.getName + "onEntry_" + enumOf(state).getName)
+          entry := isEntering(state)
+          when(entry) {
+            state.onEntryTasks.foreach(_())
+          }
         }
       }
     }

--- a/tester/src/test/scala/spinal/core/ChecksTester.scala
+++ b/tester/src/test/scala/spinal/core/ChecksTester.scala
@@ -535,7 +535,7 @@ class RepeatabilityTester extends SpinalAnyFunSuite{
 
   test("Apb3I2cCtrlGraph"){
     val dut = SpinalConfig(defaultClockDomainFrequency = FixedFrequency(50 MHz)).generateVerilog(new Apb3I2cCtrl(configI2C)).toplevel
-    assert(GraphUtils.countNames(dut) == 278)
+    assert(GraphUtils.countNames(dut) == 260)
   }
 
   test("UartGraph"){


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description
Currently, Spinal always generates below signals for any FSM, even these signals are unused, which could cause some lint/code coverage issue.
This update aims to mitigate these issues.
```verilog
  wire                fsm_onEntry_BOOT;
  wire                fsm_onEntry_stateA;
  wire                fsm_onEntry_stateB;
  wire                fsm_onEntry_stateC;

  assign fsm_onEntry_BOOT = ((fsm_stateNext == fsm_BOOT) && (fsm_stateReg != fsm_BOOT));
  assign fsm_onEntry_stateA = ((fsm_stateNext == fsm_stateA) && (fsm_stateReg != fsm_stateA));
  assign fsm_onEntry_stateB = ((fsm_stateNext == fsm_stateB) && (fsm_stateReg != fsm_stateB));
  assign fsm_onEntry_stateC = ((fsm_stateNext == fsm_stateC) && (fsm_stateReg != fsm_stateC));
```
<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
All unused signals of FSM, including *\*onEntry_stateXXX, \*onExit_stateXXX*, will be removed to improve RTL code quality.
No any function modification.
# Checklistof FSM 

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
