### PR TITLE
Add method alternatives with spelling and typo fix

### DIFF
--- a/core/src/main/scala/spinal/core/AFix.scala
+++ b/core/src/main/scala/spinal/core/AFix.scala
@@ -425,7 +425,7 @@ class AFix(val maxRaw: BigInt, val minRaw: BigInt, val exp: Int) extends MultiDa
   }
 
   /**
-   * Mutiplies `this` by the right hand side AFix value expanding ranges as necessary
+   * Multiplies `this` by the right hand side AFix value expanding ranges as necessary
    * @param right Value to multiply `this` by
    * @return Product
    */

--- a/core/src/main/scala/spinal/core/Area.scala
+++ b/core/src/main/scala/spinal/core/Area.scala
@@ -39,7 +39,7 @@ class Composite[T <: Nameable](val self : T, postfix : String = null, weak : Boo
   * For this kind of cases you can use `Area` to define a group of signals/logic.
   *
   * @example {{{
-  *     val tickConter = new Area{
+  *     val tickCounter = new Area {
   *       val tick = Reg(UInt(8 bits) init(0)
   *       tick := tick + 1
   *     }

--- a/core/src/main/scala/spinal/core/BaseType.scala
+++ b/core/src/main/scala/spinal/core/BaseType.scala
@@ -131,7 +131,7 @@ abstract class BaseType extends Data with DeclarationStatement with StatementDou
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.14.0")
+  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.15.0")
   def hasAssignement : Boolean = hasAssignment
 
   def hasAssignment : Boolean = !this.dlcIsEmpty

--- a/core/src/main/scala/spinal/core/BaseType.scala
+++ b/core/src/main/scala/spinal/core/BaseType.scala
@@ -130,7 +130,11 @@ abstract class BaseType extends Data with DeclarationStatement with StatementDou
     false
   }
 
-  def hasAssignement : Boolean = !this.dlcIsEmpty
+  // TODO enable deprecation
+  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.14.0")
+  def hasAssignement : Boolean = hasAssignment
+
+  def hasAssignment : Boolean = !this.dlcIsEmpty
 
   def initialFrom(that: AnyRef, target: AnyRef = this) = {
     compositAssignFrom(that,target,InitialAssign)

--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -193,9 +193,9 @@ abstract class BitVector extends BaseType with Widthable {
   }
 
   /**
-    * Resize the bitVector to width
+    * Resize the BitVector to width
     * @example{{{ val res = myBits.resize(10) }}}
-    * @return a resized bitVector
+    * @return a resized BitVector
     */
   def resize(width: Int): BitVector
   def resize(width: BitCount): BitVector

--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -197,7 +197,7 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
   def edge(): Bool = this ^ RegNext(this)
 
   /**
-    * Detect all edges (falling, rising, toogling)
+    * Detect all edges (falling, rising, toggling)
     * @example{{{
     *         val res = myBool.edges()
     *         when(res.fall){...}
@@ -218,7 +218,7 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
     ret
   }
 
-  /** Edge detection without intial value */
+  /** Edge detection without initial value */
   def edges(): BoolEdges = {
     val ret = BoolEdges()
     val old = RegNext(this)

--- a/core/src/main/scala/spinal/core/Bundle.scala
+++ b/core/src/main/scala/spinal/core/Bundle.scala
@@ -60,7 +60,7 @@ trait ValCallbackRec extends ValCallback {
           for ((e, i) <- seq.zipWithIndex) {
             valCallbackOn(e._2, name + "_" + i, refs)
           }
-        case prod : Tuple2[_,_] if !name.contains("$")=> //$ check to avoid trigerring on val (x,y)
+        case prod : Tuple2[_,_] if !name.contains("$")=> //$ check to avoid triggering on val (x,y)
           for ((e, i) <- prod.productIterator.zipWithIndex) {
             valCallbackOn(e, name + "_" + i, refs)
           }

--- a/core/src/main/scala/spinal/core/ClockDomain.scala
+++ b/core/src/main/scala/spinal/core/ClockDomain.scala
@@ -144,7 +144,7 @@ object ClockDomain {
 
   /** To use when you want to define a new ClockDomain that thank signals outside the toplevel.
     *
-    * It create input clock, reset, clockenable in the toplevel.
+    * It create input clock, reset, clockEnable in the toplevel.
     * 
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Structuring/clock_domain.html#external-clock External clock documentation]]
     */
@@ -173,7 +173,7 @@ object ClockDomain {
     clockDomain
   }
 
-  /** Push a clockdomain on the stack */
+  /** Push a clock domain on the stack */
   def push(c: Handle[ClockDomain]) = ClockDomainStack.set(c)
   def push(c: ClockDomain) = ClockDomainStack.set(Handle.sync(c))
 
@@ -273,7 +273,7 @@ object ClockDomain {
       case None => {
         var sync = scala.collection.immutable.Set[Bool]()
 
-        //Collect all the directly syncronous Bool
+        // Collect all the directly synchronous Bool
         sync += that
         that.foreachTag {
           case tag: ClockSyncTag => sync += tag.a; sync += tag.b
@@ -471,7 +471,7 @@ case class ClockDomain(clock       : Bool,
   def newSlowedClockDomain(freq: HertzNumber): ClockDomain = {
     val currentFreq = frequency.getValue.toBigDecimal
     freq match {
-      case x if x.toBigDecimal > currentFreq => SpinalError("To high frequancy")
+      case x if x.toBigDecimal > currentFreq => SpinalError("To high frequency")
       case x                                 => newClockDomainSlowedBy((currentFreq/freq.toBigDecimal).toBigInt)
     }
   }

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -108,14 +108,21 @@ object OnCreateStack extends ScopeProperty[Nameable => Unit]{
   */
 class GlobalData(val config : SpinalConfig) {
 
-  private var algoIncrementale = 1
+  private var algoIncremental = 1
   var toplevel : Component = null
   var report : SpinalReport[Component] = null
 
+
+  // TODO enable deprecation
+  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.14.0")
   def allocateAlgoIncrementale(): Int = {
-    assert(algoIncrementale != Integer.MAX_VALUE)
-    algoIncrementale += 1
-    return algoIncrementale - 1
+    allocateAlgoIncremental()
+  }
+
+  def allocateAlgoIncremental(): Int = {
+    assert(algoIncremental != Integer.MAX_VALUE)
+    algoIncremental += 1
+    return algoIncremental - 1
   }
 
   var anonymSignalPrefix: String = null

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -114,7 +114,7 @@ class GlobalData(val config : SpinalConfig) {
 
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.14.0")
+  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.15.0")
   def allocateAlgoIncrementale(): Int = {
     allocateAlgoIncremental()
   }

--- a/core/src/main/scala/spinal/core/fiber/AsyncThread.scala
+++ b/core/src/main/scala/spinal/core/fiber/AsyncThread.scala
@@ -80,9 +80,9 @@ class AsyncThread(parent : AsyncThread, engine: EngineContext, body : => Unit) e
   def getLocationShort() : String = {
     done match {
       case true => {
-        val filtred = filterStackTrace(terminatedStackTrace)
-        if(filtred.isEmpty) return terminatedStackTrace(0).toString
-        filtred(0).toString
+        val filtered = filterStackTrace(terminatedStackTrace)
+        if(filtered.isEmpty) return terminatedStackTrace(0).toString
+        filtered(0).toString
       }
     }
   }

--- a/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
+++ b/core/src/main/scala/spinal/core/formal/SymbiYosysBackend.scala
@@ -228,11 +228,11 @@ class SymbiYosysFormalBackendImpl(val config: SymbiYosysFormalBackendConfig) ext
         for (e <- logFileName) analyseLog(workDir.resolve(Paths.get(s"${config.toplevelName}_${name}", "engine_0", e)).toFile())
       }
 
-      val assertedLinesFormated = assertedLines.map{l =>
+      val assertedLinesFormatted = assertedLines.map{l =>
         val splits = l.split(if (!config.withGhdl) "// " else "-- ")
         "(" + splits(1).replace(":L", ":") + ")  "
       }
-      val assertsReport = assertedLinesFormated.map(e => s"\tissue.triggered.from${e}\n").mkString("")
+      val assertsReport = assertedLinesFormatted.map(e => s"\tissue.triggered.from${e}\n").mkString("")
       val proofAt = "\tproof in " + workDir + s"/${config.toplevelName}_${config.modesWithDepths.head._1}/engine_0"
       throw new Exception("SymbiYosys failure\n" + assertsReport + proofAt)
     }

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitter.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitter.scala
@@ -92,13 +92,25 @@ abstract class ComponentEmitter {
     val dataStatements = ArrayBuffer[LeafStatement]()
   }
 
+  // TODO enable deprecation
+  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.14.0")
   def allocateAlgoIncrementale(): Int = {
+    allocateAlgoIncremental()
+  }
+
+  def allocateAlgoIncremental(): Int = {
     val ret = algoIdIncrementalBase + algoIdIncrementalOffset
     algoIdIncrementalOffset += 1
     ret
   }
 
+  // TODO enable deprecation
+  //@deprecated("Use correctly spelled 'isSubComponentInputBound' instead", since = "1.14.0")
   def isSubComponentInputBinded(data: BaseType) = {
+    isSubComponentInputBound(data)
+  }
+
+  def isSubComponentInputBound(data: BaseType) = {
     var hasOtherUse = false
     if(data.isInput && data.isComb && Statement.isFullToFullStatementOrLit(data)) {
       data.component.parent.dslBody.foreachStatements{
@@ -332,9 +344,9 @@ abstract class ComponentEmitter {
 
             val treeStatement = scopePtr.parentStatement
 
-            if(treeStatement.algoIncrementale != algoId) {
+            if(treeStatement.algoIncremental != algoId) {
 
-              treeStatement.algoIncrementale = algoId
+              treeStatement.algoIncremental = algoId
 
               treeStatement match {
                 case w: WhenStatement =>
@@ -360,12 +372,12 @@ abstract class ComponentEmitter {
       }
 
       for (process <- processes) {
-        walker(process.leafStatements, 0, process.scope, allocateAlgoIncrementale())
+        walker(process.leafStatements, 0, process.scope, allocateAlgoIncremental())
       }
 
       syncGroups.valuesIterator.foreach(group => {
-        walker(group.initStatements, 0, group.scope, allocateAlgoIncrementale())
-        walker(group.dataStatements, 0, group.scope, allocateAlgoIncrementale())
+        walker(group.initStatements, 0, group.scope, allocateAlgoIncremental())
+        walker(group.dataStatements, 0, group.scope, allocateAlgoIncremental())
       })
 
       if(!spinalConfig.inlineConditionalExpression) {
@@ -411,10 +423,10 @@ abstract class ComponentEmitter {
             }
           }
         } else if(io.isInput) {
-          var subInputBinded = isSubComponentInputBinded(io)
+          var subInputBound = isSubComponentInputBound(io)
 
-          if(subInputBinded != null) {
-            referencesOverrides(io) = subInputBinded
+          if(subInputBound != null) {
+            referencesOverrides(io) = subInputBound
             subComponentInputToNotBufferize += io
           }else {
             if(!openSubIo.contains(io)) wrapSubInput(io)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitter.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitter.scala
@@ -93,7 +93,7 @@ abstract class ComponentEmitter {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.14.0")
+  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.15.0")
   def allocateAlgoIncrementale(): Int = {
     allocateAlgoIncremental()
   }
@@ -105,7 +105,7 @@ abstract class ComponentEmitter {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'isSubComponentInputBound' instead", since = "1.14.0")
+  //@deprecated("Use correctly spelled 'isSubComponentInputBound' instead", since = "1.15.0")
   def isSubComponentInputBinded(data: BaseType) = {
     isSubComponentInputBound(data)
   }

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -279,7 +279,7 @@ class ComponentEmitterVerilog(
     syncGroups.valuesIterator.foreach(emitSynchronous(component, _))
 
     component.dslBody.walkStatements{
-      case s: TreeStatement => s.algoIncrementale = algoIdIncrementalBase
+      case s: TreeStatement => s.algoIncremental = algoIdIncrementalBase
       case s                =>
     }
   }

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -388,11 +388,11 @@ class ComponentEmitterVerilog(
 
       val instanceAttributes = emitSyntaxAttributes(child.instanceAttributes)
 
-      val istracingOff = child.hasTag(TracingOff)
+      val isTracingOff = child.hasTag(TracingOff)
 
       logics ++= commentTagsToString(child, "  //")
 
-      if(istracingOff){
+      if(isTracingOff) {
         logics ++= s" ${emitCommentAttributes(List(Verilator.tracing_off))} \n"
       }
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -498,7 +498,7 @@ class ComponentEmitterVerilog(
       logics ++= s"  );"
       logics ++= s"\n"
 
-      if(istracingOff){
+      if(isTracingOff){
         logics ++= s" ${emitCommentAttributes(List(Verilator.tracing_on))} \n"
       }
     }

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -265,7 +265,7 @@ class ComponentEmitterVhdl(
     syncGroups.valuesIterator.foreach(emitSynchronous(component, _))
 
     component.dslBody.walkStatements{
-      case s: TreeStatement => s.algoIncrementale = algoIdIncrementalBase
+      case s: TreeStatement => s.algoIncremental = algoIdIncrementalBase
       case s                =>
     }
   }

--- a/core/src/main/scala/spinal/core/internals/Expression.scala
+++ b/core/src/main/scala/spinal/core/internals/Expression.scala
@@ -1315,7 +1315,7 @@ abstract class Multiplexer extends Modifier {
 }
 
 /**
-  * Widtable multiplexer
+  * Widthable multiplexer
   */
 abstract class MultiplexerWidthable extends Multiplexer with Widthable {
   override type T = Expression with WidthProvider
@@ -1430,7 +1430,7 @@ abstract class BinaryMultiplexer extends Modifier {
 }
 
 /**
-  * Widtable Binary multiplexer
+  * Widthable Binary multiplexer
   */
 abstract class BinaryMultiplexerWidthable extends BinaryMultiplexer with Widthable {
   override type T = Expression with WidthProvider
@@ -1546,7 +1546,7 @@ abstract class SubAccess extends Modifier {
 
 
 /**
-  * Base class fot accessing a bit in a bitvector with a fix index
+  * Base class fot accessing a bit in a BitVector with a fix index
   */
 abstract class BitVectorBitAccessFixed extends SubAccess with ScalaLocated {
   var source: Expression with WidthProvider = null

--- a/core/src/main/scala/spinal/core/internals/Misc.scala
+++ b/core/src/main/scala/spinal/core/internals/Misc.scala
@@ -33,7 +33,7 @@ object ScalaUniverse {
 
 
 trait BaseNode extends ScalaLocated{
-  var algoInt, algoIncrementale = 0
+  var algoInt, algoIncremental = 0
 
   private[core] def getClassIdentifier: String = this.getClass.getName.split('.').last.replace("$","")
 

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -894,7 +894,7 @@ case class MemReadBufferTag(reg: BaseType, rs: MemPortStatement, through: List[B
 
 class MemReadBufferPhase extends PhaseNetlist {
   override def impl(pc: PhaseContext): Unit = {
-    val algo = pc.globalData.allocateAlgoIncrementale()
+    val algo = pc.globalData.allocateAlgoIncremental()
     val portsHits = ArrayBuffer[MemPortStatement]()
     pc.walkDeclarations {
       case reg: BaseType if reg.isReg && !reg.hasInit && reg.hasOnlyOneStatement => {
@@ -917,7 +917,7 @@ class MemReadBufferPhase extends PhaseNetlist {
             portsHits += rs
             rs.addTag(new MemReadBufferTag(reg, rs, through))
             through.foreach { bn =>
-              bn.algoIncrementale = algo
+              bn.algoIncremental = algo
               bn.algoInt = hitId
             }
           }
@@ -934,9 +934,9 @@ class MemReadBufferPhase extends PhaseNetlist {
     }
 
     pc.walkStatements { s =>
-      if (s.algoIncrementale != algo) {
+      if (s.algoIncremental != algo) {
         s.walkDrivingExpressions { e =>
-          if (e.algoIncrementale == algo) {
+          if (e.algoIncremental == algo) {
 //            println("Remove it")
             val port = portsHits(e.algoInt)
             clean(port)
@@ -1407,11 +1407,11 @@ class PhaseInferEnumEncodings(pc: PhaseContext, encodingSwap: (SpinalEnumEncodin
     val nodes           = ArrayBuffer[Expression with EnumEncoded]()
     val nodesInferrable = ArrayBuffer[Expression with InferableEnumEncoding]()
     val consumers       = mutable.HashMap[Expression , ArrayBuffer[Expression]]()
-    var algo            = globalData.allocateAlgoIncrementale()
+    var algo            = globalData.allocateAlgoIncremental()
 
     def walkExpression(node: Expression): Unit ={
-      if(node.algoIncrementale != algo) {
-        node.algoIncrementale = algo
+      if(node.algoIncremental != algo) {
+        node.algoIncremental = algo
 
         if (node.isInstanceOf[EnumEncoded]) nodes += node.asInstanceOf[Expression with EnumEncoded]
 
@@ -1458,7 +1458,7 @@ class PhaseInferEnumEncodings(pc: PhaseContext, encodingSwap: (SpinalEnumEncodin
       senum.swapEncoding(encodingSwap(senum.getEncoding))
     })
 
-    algo = globalData.allocateAlgoIncrementale()
+    algo = globalData.allocateAlgoIncremental()
 
     nodes.foreach(senum => {
       if(senum.propagateEncoding){
@@ -1466,9 +1466,9 @@ class PhaseInferEnumEncodings(pc: PhaseContext, encodingSwap: (SpinalEnumEncodin
         def propagateOn(that : Expression): Unit = {
           that match {
             case that: InferableEnumEncoding =>
-              if(that.algoIncrementale == algo) return
+              if(that.algoIncremental == algo) return
 
-              that.algoIncrementale = algo
+              that.algoIncremental = algo
 
               if(that.encodingProposal(senum.getEncoding)) {
                 that match {
@@ -1788,13 +1788,13 @@ class PhaseCheckCombinationalLoops() extends PhaseCheck{
   override def impl(pc: PhaseContext): Unit = {
     import pc._
 
-    val walkingId = GlobalData.get.allocateAlgoIncrementale()
-    val okId      = GlobalData.get.allocateAlgoIncrementale()
+    val walkingId = GlobalData.get.allocateAlgoIncremental()
+    val okId      = GlobalData.get.allocateAlgoIncremental()
 
     def walk(path : List[(BaseNode)], node: BaseNode): Unit = {
       val newPath = node :: path
 
-      if (node.algoIncrementale == walkingId) {
+      if (node.algoIncremental == walkingId) {
         val ordred  = newPath.reverseIterator
         val filtred = ordred.dropWhile((e) => (e != node)).drop(1).toArray
 
@@ -1810,22 +1810,22 @@ class PhaseCheckCombinationalLoops() extends PhaseCheck{
           PendingError(s"COMBINATORIAL LOOP :\n  Partial chain :\n${wellNameLoop}\n  Full chain :${multiLineLoop}")
         }
 
-      }else if (node.algoIncrementale != okId) {
-        node.algoIncrementale = walkingId
+      }else if (node.algoIncremental != okId) {
+        node.algoIncremental = walkingId
         node match {
           case node: BaseType =>
             if(node.isComb) {
-              node.algoIncrementale = walkingId
+              node.algoIncremental = walkingId
               node.foreachStatements(s => walk(newPath, s))
-              node.algoIncrementale = okId
+              node.algoIncremental = okId
             }
           case node: AssignmentStatement =>
             node.foreachDrivingExpression(e => walk(newPath, e))
             node.walkParentTreeStatementsUntilRootScope(s => walk(newPath, s))
           case node: TreeStatement =>
-            if (node.algoIncrementale != okId) {
+            if (node.algoIncremental != okId) {
               node.foreachDrivingExpression(e => walk(newPath, e))
-              node.algoIncrementale = okId
+              node.algoIncremental = okId
             }
           case node: Mem[_]       =>
           case node: MemReadSync  =>
@@ -1837,11 +1837,11 @@ class PhaseCheckCombinationalLoops() extends PhaseCheck{
             node.foreachDrivingExpression(e => walk(newPath, e))
         }
       }
-      node.algoIncrementale = okId
+      node.algoIncremental = okId
     }
 
     walkStatements(s => {
-      if (s.algoIncrementale != okId) {
+      if (s.algoIncremental != okId) {
         walk(s :: Nil, s)
       }
     })
@@ -1861,10 +1861,10 @@ class PhaseCheckCrossClock() extends PhaseCheck{
 
     def populateCdTag(that : BaseType): Unit = {
       val cds = mutable.LinkedHashSet[ClockDomain]()
-      val walkedId = pc.globalData.allocateAlgoIncrementale
+      val walkedId = pc.globalData.allocateAlgoIncremental
       def walk(n : BaseNode): Unit = {
-        if(n.algoIncrementale == walkedId) return
-        n.algoIncrementale = walkedId
+        if(n.algoIncremental == walkedId) return
+        n.algoIncremental = walkedId
         n match {
           case node: SpinalTagReady if node.hasTag(classOf[ClockDomainTag]) =>
             cds += node.getTag(classOf[ClockDomainTag]).get.clockDomain
@@ -1939,9 +1939,9 @@ class PhaseCheckCrossClock() extends PhaseCheck{
 
 
       def walk(node: BaseNode, path: List[(BaseNode)], clockDomain: ClockDomain): Unit = {
-        if(node.algoIncrementale == walked) return
+        if(node.algoIncremental == walked) return
 
-        node.algoIncrementale = walked
+        node.algoIncremental = walked
 
         val newPath = node :: path
 
@@ -2000,34 +2000,34 @@ class PhaseCheckCrossClock() extends PhaseCheck{
         case s: BaseType if s.hasTag(classOf[ClockDomainTag]) =>
           if (!s.isReg) {
             // if it not a reg, perform the check if the ClockDomainTag is present
-            walked = GlobalData.get.allocateAlgoIncrementale()
+            walked = GlobalData.get.allocateAlgoIncremental()
             s.foreachStatements(as => walk(as, as :: s :: Nil, s.getTag(classOf[ClockDomainTag]).get.clockDomain))
           }
           else {
             PendingError(s"Can't add ClockDomainTag to registers:\n" + s.getScalaLocationLong)
           }
         case s: BaseType if s.isReg && !s.hasTag(crossClockDomain) =>
-          walked = GlobalData.get.allocateAlgoIncrementale()
+          walked = GlobalData.get.allocateAlgoIncremental()
           s.foreachStatements(as => walk(as, as :: s :: Nil, s.clockDomain))
         case s: MemReadSync if !s.hasTag(crossClockDomain) =>
           if (s.hasTag(classOf[ClockDomainTag])) {
             PendingError(s"Can't add ClockDomainTag to memory ports:\n" + s.getScalaLocationLong)
           }
-          walked = GlobalData.get.allocateAlgoIncrementale()
+          walked = GlobalData.get.allocateAlgoIncremental()
           s.foreachDrivingExpression(as => walk(as, as :: s :: Nil, s.clockDomain))
           checkMem(s.mem, s :: Nil, s.clockDomain)
         case s: MemReadWrite if !s.hasTag(crossClockDomain) =>
           if (s.hasTag(classOf[ClockDomainTag])) {
             PendingError(s"Can't add ClockDomainTag to memory ports:\n" + s.getScalaLocationLong)
           }
-          walked = GlobalData.get.allocateAlgoIncrementale()
+          walked = GlobalData.get.allocateAlgoIncremental()
           s.foreachDrivingExpression(as => walk(as, as :: s :: Nil, s.clockDomain))
           checkMem(s.mem, s :: Nil, s.clockDomain)
         case s: MemWrite if !s.hasTag(crossClockDomain) =>
           if (s.hasTag(classOf[ClockDomainTag])) {
             PendingError(s"Can't add ClockDomainTag to memory ports:\n" + s.getScalaLocationLong)
           }
-          walked = GlobalData.get.allocateAlgoIncrementale()
+          walked = GlobalData.get.allocateAlgoIncremental()
           s.foreachDrivingExpression(as => walk(as, as :: s :: Nil, s.clockDomain))
         case _ =>
       }
@@ -2085,7 +2085,7 @@ class PhaseRemoveUselessStuff(postClockPulling: Boolean, tagVitals: Boolean) ext
   override def impl(pc: PhaseContext): Unit = {
     import pc._
 
-    val okId = globalData.allocateAlgoIncrementale()
+    val okId = globalData.allocateAlgoIncremental()
 
     def getComponentOrThrowForPulledDataCache(s: Statement, operation: String): Component = {
       val comp = s.component
@@ -2109,8 +2109,8 @@ class PhaseRemoveUselessStuff(postClockPulling: Boolean, tagVitals: Boolean) ext
         SpinalWarning("propagate called with null root statement.")
         return
       }
-      if (root.algoIncrementale == okId) return
-      root.algoIncrementale = okId
+      if (root.algoIncremental == okId) return
+      root.algoIncremental = okId
 
       val pending = mutable.ArrayStack[Statement](root)
 
@@ -2119,8 +2119,8 @@ class PhaseRemoveUselessStuff(postClockPulling: Boolean, tagVitals: Boolean) ext
             SpinalWarning("propagateInner called with null statement in pending queue.")
             return
         }
-        if (s.algoIncrementale != okId) {
-          s.algoIncrementale = okId
+        if (s.algoIncremental != okId) {
+          s.algoIncremental = okId
           pending.push(s)
         }
       }
@@ -2235,7 +2235,7 @@ class PhaseRemoveUselessStuff(postClockPulling: Boolean, tagVitals: Boolean) ext
     }
 
     walkStatements(s => {
-      if(s.algoIncrementale != okId){
+      if(s.algoIncremental != okId){
         s.removeStatement()
       }
     })
@@ -2260,7 +2260,7 @@ class PhaseRemoveIntermediateUnnameds(onlyTypeNode: Boolean) extends PhaseNetlis
   override def impl(pc: PhaseContext): Unit = {
     import pc._
 
-    val koId = globalData.allocateAlgoIncrementale()
+    val koId = globalData.allocateAlgoIncremental()
 
     walkDeclarations(e => e.algoInt = 0)
 
@@ -2271,15 +2271,15 @@ class PhaseRemoveIntermediateUnnameds(onlyTypeNode: Boolean) extends PhaseNetlis
       case _ =>
     }
 
-    walkStatements(s => if(s.algoIncrementale != koId){
+    walkStatements(s => if(s.algoIncremental != koId){
       s.walkRemapDrivingExpressions {
         case ref: BaseType =>
           if (ref.algoInt == 1 && ref.isComb && ref.isDirectionLess && (!onlyTypeNode || ref.isTypeNode) && ref.canSymplifyIt && Statement.isSomethingToFullStatement(ref) /*&& ref != excepted*/ ) {
             //TODO IR keep it
             ref.algoInt = 0
             val head = ref.head
-            ref.algoIncrementale = koId
-            head.algoIncrementale = koId
+            ref.algoIncremental = koId
+            head.algoIncremental = koId
             head.source
           } else {
             ref
@@ -2289,7 +2289,7 @@ class PhaseRemoveIntermediateUnnameds(onlyTypeNode: Boolean) extends PhaseNetlis
     })
 
     walkStatements{
-      case s if s.algoIncrementale == koId =>
+      case s if s.algoIncremental == koId =>
         s.removeStatement()
       case s =>
     }
@@ -2859,20 +2859,20 @@ class PhaseGetInfoRTL(prunedSignals: mutable.Set[BaseType], unusedSignals: mutab
       case _            =>
     }
 
-    val usedId = GlobalData.get.allocateAlgoIncrementale()
+    val usedId = GlobalData.get.allocateAlgoIncremental()
 
     walkStatements(s => {
-      s.walkDrivingExpressions(e => e.algoIncrementale = usedId)
+      s.walkDrivingExpressions(e => e.algoIncremental = usedId)
       s match {
-        case s: MemReadSync  => s.algoIncrementale = usedId
-        case s: MemReadAsync => s.algoIncrementale = usedId
-        case s: MemReadWrite => s.algoIncrementale = usedId
+        case s: MemReadSync  => s.algoIncremental = usedId
+        case s: MemReadAsync => s.algoIncremental = usedId
+        case s: MemReadWrite => s.algoIncremental = usedId
         case s =>
       }
     })
 
     prunedSignals.foreach(s => {
-      if(s.algoIncrementale != usedId) {
+      if(s.algoIncremental != usedId) {
         unusedSignals += s
       }
     })
@@ -2882,7 +2882,7 @@ class PhaseGetInfoRTL(prunedSignals: mutable.Set[BaseType], unusedSignals: mutab
 class PhasePropagateNames(pc: PhaseContext) extends PhaseMisc {
   override def impl(pc: PhaseContext) : Unit = {
     import pc._
-    val algoId = globalData.allocateAlgoIncrementale() //Allows to avoid chaining allocated names
+    val algoId = globalData.allocateAlgoIncremental() // Allows to avoid chaining allocated names
 
     // All unnamed signals are cleaned up to avoid composite / partial name side effects
     walkStatements{
@@ -2892,14 +2892,14 @@ class PhasePropagateNames(pc: PhaseContext) extends PhaseMisc {
 
     // propagate all named signals names to their unnamed drivers
     walkStatements{
-      case dst : BaseType => if (dst.isNamed && dst.algoIncrementale != algoId) {
+      case dst : BaseType => if (dst.isNamed && dst.algoIncremental != algoId) {
         def explore(bt: BaseType, depth : Int): Unit = {
           bt.foreachStatements{s =>
             s.walkDrivingExpressions{
-              case src : BaseType => if(src.isUnnamed || (src.algoIncrementale == algoId && src.algoInt > depth)){
+              case src : BaseType => if(src.isUnnamed || (src.algoIncremental == algoId && src.algoInt > depth)){
                 src.unsetName()
                 src.setWeakName(globalData.anonymSignalPrefix + "_" + dst.getName())
-                src.algoIncrementale = algoId
+                src.algoIncremental = algoId
                 src.algoInt = depth
                 explore(src, depth + 1)
               }

--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -153,7 +153,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
     }
   }
 
-  val allocateAlgoIncrementaleBase = globalData.allocateAlgoIncrementale()
+  val allocateAlgoIncrementalBase = globalData.allocateAlgoIncremental()
   val usedDefinitionNames = mutable.HashSet[String]()
 
 
@@ -163,7 +163,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
       c                           = component,
       systemVerilog               = pc.config.isSystemVerilog,
       verilogBase                 = this,
-      algoIdIncrementalBase       = allocateAlgoIncrementaleBase,
+      algoIdIncrementalBase       = allocateAlgoIncrementalBase,
       mergeAsyncProcess           = config.mergeAsyncProcess,
       asyncResetCombSensitivity   = config.asyncResetCombSensitivity,
       anonymSignalPrefix          = if(pc.config.anonymSignalUniqueness) globalData.anonymSignalPrefix + "_" + component.definitionName else globalData.anonymSignalPrefix,

--- a/core/src/main/scala/spinal/core/internals/PhaseVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVhdl.scala
@@ -145,14 +145,14 @@ class PhaseVhdl(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc wit
     }
   }
 
-  val allocateAlgoIncrementaleBase = globalData.allocateAlgoIncrementale()
+  val allocateAlgoIncrementalBase = globalData.allocateAlgoIncremental()
   val usedDefinitionNames = mutable.HashSet[String]()
 
   def compile(component: Component): String = {
     val componentBuilderVhdl = new ComponentEmitterVhdl(
       c                         = component,
       vhdlBase                  = this,
-      algoIdIncrementalBase     = allocateAlgoIncrementaleBase,
+      algoIdIncrementalBase     = allocateAlgoIncrementalBase,
       mergeAsyncProcess         = config.mergeAsyncProcess,
       asyncResetCombSensitivity = config.asyncResetCombSensitivity,
       anonymSignalPrefix        = if(pc.config.anonymSignalUniqueness) globalData.anonymSignalPrefix + "_" + component.definitionName else globalData.anonymSignalPrefix,

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -93,7 +93,7 @@ object SpinalVerilatorBackend {
       })
 
       bt.algoInt = signalId
-      bt.algoIncrementale = -1
+      bt.algoIncremental = -1
       signal.id = signalId
       vconfig.signals += signal
       signalId += 1
@@ -107,7 +107,7 @@ object SpinalVerilatorBackend {
         case mem : Mem[_] if mem.hasTag(Verilator.public) => {
           val tag = mem.getTag(classOf[MemSymbolesTag])
           mem.algoInt = signalId
-          mem.algoIncrementale = -1
+          mem.algoIncremental = -1
           tag match {
             case None => addSignal(mem)
             case Some(tag) => {
@@ -137,7 +137,7 @@ object SpinalVerilatorBackend {
       })
 
       bt.algoInt = signalId
-      bt.algoIncrementale = -1
+      bt.algoIncremental = -1
       signal.id = signalId
       vconfig.signals += signal
       signalId += 1
@@ -394,7 +394,7 @@ object SpinalVpiBackend {
       })
 
       bt.algoInt = signalId
-      bt.algoIncrementale = -1
+      bt.algoIncremental = -1
       signal.id = signalId
       signalsCollector += signal
       signalId += 1
@@ -408,7 +408,7 @@ object SpinalVpiBackend {
         case mem : Mem[_] if mem.hasTag(SimPublic) => {
           val tag = mem.getTag(classOf[MemSymbolesTag])
           mem.algoInt = signalId
-          mem.algoIncrementale = -1
+          mem.algoIncremental = -1
           tag match {
             case None => addSignal(mem)
             case Some(tag) => {
@@ -438,7 +438,7 @@ object SpinalVpiBackend {
       })
 
       bt.algoInt = signalId
-      bt.algoIncrementale = -1
+      bt.algoIncremental = -1
       signal.id = signalId
       signalsCollector += signal
       signalId += 1
@@ -497,7 +497,7 @@ object SpinalXSimBackend {
       })
 
       bt.algoInt = signalId
-      bt.algoIncrementale = -1
+      bt.algoIncremental = -1
       signal.id = signalId
       signalsCollector += signal
       signalId += 1

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -66,7 +66,7 @@ package object sim {
 
 
   private def btToSignal(manager: SimManager, bt: BaseNode) = {
-    if(bt.algoIncrementale != -1){
+    if(bt.algoIncremental != -1){
       SimError(s"UNACCESSIBLE SIGNAL : $bt isn't accessible during the simulation.\n- To fix it, call simPublic() on it during the elaboration.\nIf that doesn't resolve the issue, ensure that the signal has a name. (you can force a name via : mySignal.setName(...) durring the hardware elaboration)")
     }
 
@@ -88,7 +88,7 @@ package object sim {
       }
       case Some(tag) => {
         for(i <- 0 until tag.mapping.size; mapping = tag.mapping(i)){
-          if(mem.algoIncrementale != -1){
+          if(mem.algoIncremental != -1){
             SimError(s"UNACCESSIBLE SIGNAL : $mem isn't accessible during the simulation.\n- To fix it, call simPublic() on it during the elaboration.")
           }
           val symbol = manager.raw.userData.asInstanceOf[ArrayBuffer[Signal]](mem.algoInt + i)
@@ -114,7 +114,7 @@ package object sim {
       case Some(tag) => {
         var data = BigInt(0)
         for(i <- 0 until tag.mapping.size; mapping = tag.mapping(i)){
-          if(mem.algoIncrementale != -1){
+          if(mem.algoIncremental != -1){
             SimError(s"UNACCESSIBLE SIGNAL : $mem isn't accessible during the simulation.\n- To fix it, call simPublic() on it during the elaboration.")
           }
           val symbol = manager.raw.userData.asInstanceOf[ArrayBuffer[Signal]](mem.algoInt + i)

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -284,23 +284,51 @@ package object sim {
     }
   }
 
+  /**
+    * Register the `body` code to be called at a simulation time `delay` steps
+    * after the current timestep.
+    */
   def delayed(delay : Long)(body : => Unit) = {
     SimManagerContext.current.manager.schedule(delay)(body)
   }
 
+  /**
+    * Register the `body` code to be called at a simulation duration `delay`
+    * after the current timestep.
+    */
   def delayed(delay: TimeNumber)(body: => Unit) = {
     SimManagerContext.current.manager.schedule(timeToLong(delay))(body)
   }
 
-  def periodicaly(delay : Long)(body : => Unit) : Unit = {
+  /**
+    * Register `body` for call periodically each `delay` simulation step from
+    * current timestep.
+    */
+  def periodically(delay : Long)(body : => Unit) : Unit = {
     SimManagerContext.current.manager.schedule(delay){
       body
-      periodicaly(delay)(body)
+      periodically(delay)(body)
     }
   }
 
-  def periodicaly(delay : TimeNumber)(body : => Unit) : Unit = {
-    periodicaly(timeToLong(delay))(body)
+  // TODO enable deprecation
+  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.14.0")
+  def periodicaly(delay: Long)(body: => Unit): Unit = {
+    periodically(delay)(body)
+  }
+
+  /**
+    * Register `body` for call periodically each `delay` simulation duration from
+    * current timestep.
+    */
+  def periodically(delay : TimeNumber)(body : => Unit) : Unit = {
+    periodically(timeToLong(delay))(body)
+  }
+
+  // TODO enable deprecation
+  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.14.0")
+  def periodicaly(delay : TimeNumber)(body: => Unit): Unit = {
+    periodically(delay)(body)
   }
 
   def simThread = SimManagerContext.current.thread

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -312,7 +312,7 @@ package object sim {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.14.0")
+  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.15.0")
   def periodicaly(delay: Long)(body: => Unit): Unit = {
     periodically(delay)(body)
   }
@@ -326,7 +326,7 @@ package object sim {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.14.0")
+  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.15.0")
   def periodicaly(delay : TimeNumber)(body: => Unit): Unit = {
     periodically(delay)(body)
   }

--- a/lib/src/main/scala/spinal/lib/CrossClock.scala
+++ b/lib/src/main/scala/spinal/lib/CrossClock.scala
@@ -244,7 +244,7 @@ object ResetCtrl{
   /**
    *
    * @param input Input reset signal
-   * @param clockDomain ClockDomain which will use the synchronised reset.
+   * @param clockDomain ClockDomain which will use the synchronized reset.
    * @param inputPolarity (HIGH/LOW)
    * @param outputPolarity (HIGH/LOW)
    * @param bufferDepth Number of register stages used to avoid metastability (default=2)
@@ -277,9 +277,7 @@ object ResetCtrl{
     ret
   }
 
-  /**
-   * As asyncAssertSyncDeassert but directly drive the clockDomain reset with the synchronised signal.
-   */
+  /** As asyncAssertSyncDeassert but directly drive the clockDomain reset with the synchronized signal. */
   def asyncAssertSyncDeassertDrive(input : Bool,
                                    clockDomain : ClockDomain,
                                    inputPolarity : Polarity = HIGH,
@@ -292,7 +290,7 @@ object ResetCtrl{
     bufferDepth = bufferDepth
   )
 
-  //Return a new clockdomain which use all the properties of clockCd but use as reset source a syncronized value from resetCd
+  /** Return a new ClockDomain which use all the properties of clockCd but use as reset source a synchronized value from resetCd */
   def asyncAssertSyncDeassertCreateCd(resetCd : ClockDomain,
                                       clockCd : ClockDomain = ClockDomain.current,
                                       bufferDepth : Option[Int] = None) : ClockDomain = {

--- a/lib/src/main/scala/spinal/lib/Fragment.scala
+++ b/lib/src/main/scala/spinal/lib/Fragment.scala
@@ -152,11 +152,11 @@ class StreamFragmentPimped[T <: Data](pimped: Stream[Fragment[T]]) {
   }
 
   def toFragmentBits(bitsWidth: Int): Stream[Fragment[Bits]] = {
-    val pimpedWidhoutLast = (Stream(pimped.fragment)).translateFrom(pimped)((to, from) => {
+    val pimpedWithoutLast = (Stream(pimped.fragment)).translateFrom(pimped)((to, from) => {
       to := from.fragment
     })
 
-    val fragmented = pimpedWidhoutLast.fragmentTransaction(bitsWidth)
+    val fragmented = pimpedWithoutLast.fragmentTransaction(bitsWidth)
 
     return (Stream Fragment (Bits(bitsWidth bit))).translateFrom(fragmented)((to, from) => {
       to.last := from.last && pimped.last

--- a/lib/src/main/scala/spinal/lib/MasterSlave.scala
+++ b/lib/src/main/scala/spinal/lib/MasterSlave.scala
@@ -41,7 +41,7 @@ trait IMasterSlave {
 
   /** Override it to define port directions for a master interface.
     *
-    * @deprecated This method must be overriden but not called. Calling this
+    * @deprecated This method must be overridden but not called. Calling this
     * method is not correct. Call `setAsMaster()` or `intoMaster()` instead.
     *
     * This method is named `asXxx` but it does not return `Xxx`.
@@ -52,9 +52,9 @@ trait IMasterSlave {
 
   /** Override it to define port directions for a master interface.
     *
-    * If not overriden, defaults to the opposite port directions of `asMaster()`.
+    * If not overridden, defaults to the opposite port directions of `asMaster()`.
     *
-    * @deprecated This method can be overriden but not called. Calling this
+    * @deprecated This method can be overridden but not called. Calling this
     * method is not correct. Call `setAsSlave()` or `intoSlave()` instead.
     *
     * This method is named `asXxx` but it does not return `Xxx`.

--- a/lib/src/main/scala/spinal/lib/Mem.scala
+++ b/lib/src/main/scala/spinal/lib/Mem.scala
@@ -215,7 +215,7 @@ case class MemReadPort[T <: Data](dataType : T,addressWidth : Int) extends Bundl
     }
   }
 
-  def gotReadDuringWrite(write: Flow[MemWriteCmd[T]]): Bool = new Composite(this, "gotReadDurringWrite", true) {
+  def gotReadDuringWrite(write: Flow[MemWriteCmd[T]]): Bool = new Composite(this, "gotReadDuringWrite", true) {
     val hit = cmd.valid && write.valid && cmd.payload === write.address
     val buffer = RegNextWhen(hit, cmd.valid) init(False)
   }.buffer

--- a/lib/src/main/scala/spinal/lib/PackedBundle.scala
+++ b/lib/src/main/scala/spinal/lib/PackedBundle.scala
@@ -217,7 +217,7 @@ class PackedBundle extends Bundle {
 
 /** An enhanced form of PackedBundle with Word-centric packing.
   * Offers all the same implicit packing assignment functions, but applies packing to an assigned word.
-  * - inWord(WordIndex) - Indicates which word to pack into. Must be used after a pack assigment. If no pack range was given then the entire data length will be assumed. Ranges that exceed the word will wrap into subsequent words.
+  * - inWord(WordIndex) - Indicates which word to pack into. Must be used after a pack assignment. If no pack range was given then the entire data length will be assumed. Ranges that exceed the word will wrap into subsequent words.
   *
   * Like PackedBundle, providing no pack or word assignments will place data immediately after the last.
   *

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1642,12 +1642,12 @@ class StreamFifo[T <: Data](val dataType: HardType[T],
 
       val sync = !withAsyncRead generate new Area{
         assert(!useVec)
-        val readArbitation = addressGen.m2sPipe(flush = io.flush)
+        val readArbitration = addressGen.m2sPipe(flush = io.flush)
         val readPort = ram.readSyncPort
         readPort.cmd := addressGen.toFlowFire
-        io.pop << readArbitation.translateWith(readPort.rsp)
+        io.pop << readArbitration.translateWith(readPort.rsp)
 
-        val popReg = RegNextWhen(ptr.pop, readArbitation.fire) init(0)
+        val popReg = RegNextWhen(ptr.pop, readArbitration.fire) init(0)
         ptr.popOnIo := popReg
         when(io.flush){ popReg := 0 }
       }
@@ -1925,13 +1925,13 @@ class StreamFifoCC[T <: Data](val dataType: HardType[T],
       popPtr := popPtrPlus
     }
 
-    val readArbitation = addressGen.m2sPipe()
+    val readArbitration = addressGen.m2sPipe()
     val readPort = ram.readSyncPort(clockCrossing = true)
     readPort.cmd := addressGen.toFlowFire
-    io.pop << readArbitation.translateWith(readPort.rsp)
+    io.pop << readArbitration.translateWith(readPort.rsp)
 
-    val ptrToPush = RegNextWhen(popPtrGray, readArbitation.fire) init(0)
-    val ptrToOccupancy = RegNextWhen(popPtr, readArbitation.fire) init(0)
+    val ptrToPush = RegNextWhen(popPtrGray, readArbitration.fire) init(0)
+    val ptrToOccupancy = RegNextWhen(popPtr, readArbitration.fire) init(0)
     io.popOccupancy := (fromGray(pushPtrGray) - ptrToOccupancy).resized
   }
 

--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -1072,13 +1072,13 @@ object LatencyAnalysis {
 
   //TODO mather about clock and reset wire
   def impl(from: Expression, to: Expression): Integer = {
-    val walkedId = GlobalData.get.allocateAlgoIncrementale()
+    val walkedId = GlobalData.get.allocateAlgoIncremental()
     val pendingQueues = new Array[mutable.ArrayBuffer[BaseNode]](3)
     for(i <- 0 until pendingQueues.length) pendingQueues(i) = new ArrayBuffer[BaseNode]
     def walk(that: BaseNode): Boolean = {
-      if(that.algoIncrementale == walkedId)
+      if(that.algoIncremental == walkedId)
         return false
-      that.algoIncrementale = walkedId
+      that.algoIncremental = walkedId
       if(that == from)
         return true
 

--- a/lib/src/main/scala/spinal/lib/bus/fabric/MappedConnection.scala
+++ b/lib/src/main/scala/spinal/lib/bus/fabric/MappedConnection.scala
@@ -7,19 +7,18 @@ import spinal.lib.system.tag._
 
 import scala.collection.mutable.ArrayBuffer
 
-/**
-  * provide some software interface to connect 2 NodeBase
+/** Provide some software interface to connect 2 NodeBase
   */
 abstract class MappedConnection[N <: Node](val m : N, val s : N) extends Area {
   setLambdaName(m.isNamed && s.isNamed)(s"${m.getName()}_to_${s.getName()}")
 
-  //Specify how the connection is memory mapped to the decoder
+  // Specify how the connection is memory mapped to the decoder.
   var userMapping = Option.empty[Any]
 
   def mEmits : MemoryTransfers
 
-  //Document the memory connection in a agnostic way for further usages
-  val tag = new MemoryConnection{
+  // Document the memory connection in a agnostic way for further usages.
+  val tag = new MemoryConnection {
     override def up = MappedConnection.this.m
     override def down = MappedConnection.this.s
     override def transformers = MappedConnection.this.userMapping match {

--- a/lib/src/main/scala/spinal/lib/bus/fabric/MappedUpDown.scala
+++ b/lib/src/main/scala/spinal/lib/bus/fabric/MappedUpDown.scala
@@ -7,8 +7,8 @@ import spinal.lib._
 import scala.collection.mutable.ArrayBuffer
 
 
-trait UpDown[C] extends Nameable{
-  var withUps, withDowns = true //Used for assertion
+trait UpDown[C] extends Nameable {
+  var withUps, withDowns = true // Used for assertion
   val ups = ArrayBuffer[C]()
   val downs = ArrayBuffer[C]()
   var allowNoSlave = false

--- a/lib/src/main/scala/spinal/lib/bus/fabric/Node.scala
+++ b/lib/src/main/scala/spinal/lib/bus/fabric/Node.scala
@@ -5,12 +5,12 @@ import spinal.core.fiber.{Handle, Lock}
 
 class Node extends Area with SpinalTagReady with SpinalTag {
   val clockDomain = ClockDomain.currentHandle
-  val lock = Lock() //Allow to hold the generation of this node
+  val lock = Lock() // Allow to hold the generation of this node
   def await() = {
     lock.await()
   }
 
-  //Document the current component being host for this node
+  // Document the current component being host for this node
   Component.current.addTag(this)
 
   override def toString = (if(component != null) component.getPath() + "/"  else "") + getName()

--- a/lib/src/main/scala/spinal/lib/bus/misc/Misc.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/Misc.scala
@@ -84,10 +84,10 @@ object AddressMapping{
 
 
 /*
-- Provide offset address for decoder substraction
+- Provide offset address for decoder subtraction
 - Provide a inverted mapping (default mapping)
-- Get maximal sequencial size
-- Calculate a random address from the mapping of a given sequencial size
+- Get maximal sequential size
+- Calculate a random address from the mapping of a given sequential size
 -  //Shift things ?????
  */
 trait AddressMapping{
@@ -169,11 +169,11 @@ case class OrMapping(conds : Seq[AddressMapping]) extends AddressMapping{
   override def randomPick() : BigInt = conds.randomPick().randomPick()
   override def withOffset(addressOffset: BigInt): AddressMapping = OrMapping(conds.map(_.withOffset(addressOffset)))
   override def intersectImpl(that : AddressMapping, path : List[AddressMapping] = Nil) : AddressMapping = {
-    val filtred = conds.map(_.intersectImpl(that, this :: path)).filter(_ != NeverMapping)
-    filtred.size match {
+    val filtered = conds.map(_.intersectImpl(that, this :: path)).filter(_ != NeverMapping)
+    filtered.size match {
       case 0 => NeverMapping
-      case 1 => filtred.head
-      case _ => OrMapping(filtred)
+      case 1 => filtered.head
+      case _ => OrMapping(filtered)
     }
   }
   override def maxSequentialSize : BigInt = conds.map(_.maxSequentialSize).min
@@ -424,10 +424,10 @@ case class SizeMappingInterleaved(base: BigInt, size: BigInt, blockSize : Int, p
 }
 
 
-/**
- * Model a transformation on a address, typicaly, an address decoder may apply an offset to each of its outputs
- */
-trait AddressTransformer{
+/** Model a transformation on a address, typically, an address decoder may apply
+  * an offset to each of its outputs
+  */
+trait AddressTransformer {
   def apply(address : BigInt) : BigInt
   def apply(address : UInt) : UInt
   def invert(address : BigInt) : BigInt

--- a/lib/src/main/scala/spinal/lib/bus/regif/Block/RegInst.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Block/RegInst.scala
@@ -99,7 +99,7 @@ class RegInst(name: String, addr: BigInt, doc: String, busif: BusIf, sec: Secure
     (acc, symbol.name.startsWith("<local")) match {
       case (`ROV`, _) =>
       case (_, true)  =>{
-        SpinalWarning("an unload signal created; `val signame = field(....)` is recomended instead `field(....)`")
+        SpinalWarning("an unload signal created; `val signame = field(....)` is recommended instead `field(....)`")
         reg.setName("unload", weak = true)
       }
       case (_, false) =>reg.setName(symbol.name, weak = true)
@@ -122,11 +122,11 @@ class RegInst(name: String, addr: BigInt, doc: String, busif: BusIf, sec: Secure
   * regwire := reg32bit
   * */
   def parasiteField[T <: BaseType](reg: T, acc: AccessType, resetValue: BigInt, doc: String): Unit = {
-    assert(reg.isReg, "prasiteField should be register only, check please")
+    assert(reg.isReg, "parasiteField should be register only, check please")
     registerInWithWriteLogic(reg, acc, resetValue, doc)
   }
   def parasiteFieldAt[T <: BaseType](pos: Int, reg: T, acc: AccessType, resetValue: BigInt, doc: String): Unit = {
-    assert(reg.isReg, "prasiteField should be register only, check please")
+    assert(reg.isReg, "parasiteField should be register only, check please")
     registerAtWithWriteLogic(pos, reg, acc, resetValue, doc)
   }
 
@@ -163,7 +163,7 @@ class RegInst(name: String, addr: BigInt, doc: String, busif: BusIf, sec: Secure
   private def setname[T <: BaseType](reg: T, symbol: SymbolName) = {
     symbol.name.startsWith("<local") match {
       case true => {
-        SpinalWarning("an unload signal created; `val signame = field(....)` is recomended instead `field(....)`")
+        SpinalWarning("an unload signal created; `val signame = field(....)` is recommended instead `field(....)`")
         reg.setName("unload", weak = true)
       }
       case false => reg.setName(symbol.name, weak = true)
@@ -268,7 +268,7 @@ class RegInst(name: String, addr: BigInt, doc: String, busif: BusIf, sec: Secure
       case AccessType.RWHS  => _W( reg, section)                   // SoftWare RW then HardWare Set
       case AccessType.W1CHS => _WB(reg, section, AccessType.W1C )   //- W: 1 clears/no effect on matching bit, R: no effect
       case AccessType.W1SHS => _WB(reg, section, AccessType.W1S )   //- W: 1 sets/no effect on matching bit, R: no effect
-      case x: AccessType.CSTM  =>                                  // CSTM-AccessType don't generate logic which implement use themselfs, only register for doc
+      case x: AccessType.CSTM  =>                                  // CSTM-AccessType don't generate logic which implement use themselves, only register for doc
     }
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/simple/PipelinedMemoryBus.scala
+++ b/lib/src/main/scala/spinal/lib/bus/simple/PipelinedMemoryBus.scala
@@ -332,7 +332,7 @@ case class PipelinedMemoryBusInterconnect(){
         connection.connector(m, s)
       }else{
         val tmp = cloneOf(s)
-        m >> tmp //Adapte the bus kind.
+        m >> tmp // Adapt the bus kind.
         connection.connector(tmp,s)
       }
     }

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Axi4Bridge.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Axi4Bridge.scala
@@ -46,8 +46,8 @@ class Axi4Bridge(p : NodeParameters, withAxi3 : Boolean = false, forceAxi4Len : 
 
     val (cmdFork, dataFork) = StreamFork2(halted)
     val cmd = new Area {
-      val filtred = cmdFork.takeWhen(cmdFork.isFirst())
-      val buffered = filtred.pipelined(halfRate = true)
+      val filtered = cmdFork.takeWhen(cmdFork.isFirst())
+      val buffered = filtered.pipelined(halfRate = true)
       val isGet = buffered.opcode === Opcode.A.GET
 
       io.down.aw.valid := buffered.valid && !isGet
@@ -68,8 +68,8 @@ class Axi4Bridge(p : NodeParameters, withAxi3 : Boolean = false, forceAxi4Len : 
       io.down.aw.allStrb := buffered.opcode === Opcode.A.PUT_FULL_DATA
     }
     val data = new Area{
-      val filtred = dataFork.takeWhen(dataFork.opcode === Opcode.A.PUT_FULL_DATA || dataFork.opcode === Opcode.A.PUT_PARTIAL_DATA)
-      val buffer = filtred.pipelined(m2s = true)
+      val filtered = dataFork.takeWhen(dataFork.opcode === Opcode.A.PUT_FULL_DATA || dataFork.opcode === Opcode.A.PUT_PARTIAL_DATA)
+      val buffer = filtered.pipelined(m2s = true)
       io.down.w.arbitrationFrom(buffer)
       io.down.w.data := buffer.data
       io.down.w.strb := buffer.mask

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/AxiLite4Bridge.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/AxiLite4Bridge.scala
@@ -66,10 +66,10 @@ class AxiLite4Bridge(p : NodeParameters) extends Component{
       }
     }
     val data = new Area{
-      val filtred = dataFork.takeWhen(dataFork.opcode === Opcode.A.PUT_FULL_DATA || dataFork.opcode === Opcode.A.PUT_PARTIAL_DATA)
-      io.down.w.arbitrationFrom(filtred)
-      io.down.w.data := filtred.data
-      io.down.w.strb := filtred.mask
+      val filtered = dataFork.takeWhen(dataFork.opcode === Opcode.A.PUT_FULL_DATA || dataFork.opcode === Opcode.A.PUT_PARTIAL_DATA)
+      io.down.w.arbitrationFrom(filtered)
+      io.down.w.data := filtered.data
+      io.down.w.strb := filtered.mask
     }
   }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Decoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Decoder.scala
@@ -37,7 +37,7 @@ case class DecoderDownSpec(mappeds : Seq[MappedTransfers],
                            nodeParam : NodeParameters)
 case class Decoder(upNode : NodeParameters,
                    downsSpec : Seq[DecoderDownSpec]) extends Component{
-  //TODO it doesn't check for overlapp (elaboration time)
+  // TODO it doesn't check for overlap (elaboration time)
   val io = new Bundle{
     val up = slave(Bus(upNode))
     val downs = Vec(downsSpec.map(e => master(Bus(e.nodeParam))))

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
@@ -37,7 +37,7 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
     def acquire(param : Int, getter : M2sTransfers => SizeRange): Unit = acquireImpl(param, getter(ipEmits), getter(st))
 
     // TODO enable deprecation
-    //@deprecated("Use correctly spelled 'acquire' instead", since = "1.14.0")
+    //@deprecated("Use correctly spelled 'acquire' instead", since = "1.15.0")
     def aquire(param : Int, getter : M2sTransfers => SizeRange): Unit = acquire(param, getter)
 
     def acquireImpl(param : Int, is: SizeRange, os: SizeRange): Unit ={
@@ -49,7 +49,7 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
     }
 
     // TODO enable deprecation
-    //@deprecated("Use correctly spelled 'acquireImpl' instead", since = "1.14.0")
+    //@deprecated("Use correctly spelled 'acquireImpl' instead", since = "1.15.0")
     def aquireImpl(param : Int, is: SizeRange, os: SizeRange): Unit = acquireImpl(param, is, os)
 
     simple(0, _.putFull)

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
@@ -33,8 +33,14 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
         target += term
       }
     }
-    def aquire(param : Int, getter : M2sTransfers => SizeRange): Unit = aquireImpl(param, getter(ipEmits), getter(st))
-    def aquireImpl(param : Int, is: SizeRange, os: SizeRange): Unit ={
+
+    def acquire(param : Int, getter : M2sTransfers => SizeRange): Unit = acquireImpl(param, getter(ipEmits), getter(st))
+
+    // TODO enable deprecation
+    //@deprecated("Use correctly spelled 'acquire' instead", since = "1.14.0")
+    def aquire(param : Int, getter : M2sTransfers => SizeRange): Unit = acquire(param, getter)
+
+    def acquireImpl(param : Int, is: SizeRange, os: SizeRange): Unit ={
       ipEmits.acquireB.foreach{ size =>
         val term = Masked(6 | (log2Up(size) << 3) | (param << 3 + io.up.p.sizeWidth), (1 << io.up.p.sizeWidth+3+3)-2) //-2 to cover opcode 6 and 7
         val target = if(os.contains(size)) trueTerms else falseTerms
@@ -42,15 +48,19 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
       }
     }
 
+    // TODO enable deprecation
+    //@deprecated("Use correctly spelled 'acquireImpl' instead", since = "1.14.0")
+    def aquireImpl(param : Int, is: SizeRange, os: SizeRange): Unit = acquireImpl(param, is, os)
+
     simple(0, _.putFull)
     simple(1, _.putPartial)
     simple(2, _.arithmetic)
     simple(3, _.logical)
     simple(4, _.get)
     simple(5, _.hint)
-    aquire(Param.Grow.NtoB, _.acquireB)
-    aquire(Param.Grow.NtoT, _.acquireT)
-    aquire(Param.Grow.BtoT, _.acquireT)
+    acquire(Param.Grow.NtoB, _.acquireB)
+    acquire(Param.Grow.NtoT, _.acquireT)
+    acquire(Param.Grow.BtoT, _.acquireT)
 
     val argHit = Symplify(instruction, trueTerms, falseTerms)
     val addrHit = AddressMapping.decode(addrKey, s.mapping)
@@ -116,8 +126,8 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
         target ++= addressMasked.map(_ fuse term)
       }
     }
-    def aquire(param : Int, getter : M2sTransfers => SizeRange): Unit = aquireImpl(param, getter(ipEmits), getter(st))
-    def aquireImpl(param : Int, is: SizeRange, os: SizeRange): Unit ={
+    def acquire(param : Int, getter : M2sTransfers => SizeRange): Unit = acquireImpl(param, getter(ipEmits), getter(st))
+    def acquireImpl(param : Int, is: SizeRange, os: SizeRange): Unit ={
       ipEmits.acquireB.foreach{ size =>
         val term = Masked(6 | (log2Up(size) << 3) | (param << 3 + io.up.p.sizeWidth), (1 << io.up.p.sizeWidth+3+3)-2) //-2 to cover opcode 6 and 7
         val target = if(os.contains(size)) trueTerms else falseTerms
@@ -131,9 +141,9 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
     simple(3, _.logical)
     simple(4, _.get)
     simple(5, _.hint)
-    aquire(Param.Grow.NtoB, _.acquireB)
-    aquire(Param.Grow.NtoT, _.acquireT)
-    aquire(Param.Grow.BtoT, _.acquireT)
+    acquire(Param.Grow.NtoB, _.acquireB)
+    acquire(Param.Grow.NtoT, _.acquireT)
+    acquire(Param.Grow.BtoT, _.acquireT)
   }
 
   val instruction = io.up.a.address ## io.up.a.param ## io.up.a.size ## io.up.a.opcode

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Node.scala
@@ -228,9 +228,9 @@ class Node() extends NodeUpDown {
 
 
 /*
-    def negociate[S <: spinal.lib.bus.misc.LogicalOp[S],
+    def negotiate[S <: spinal.lib.bus.misc.LogicalOp[S],
                   P,
-                  NSP <: NegociateSP[S, P],
+                  NSP <: NegotiateSP[S, P],
                   N  <: spinal.lib.bus.fabric.Node ,
                   C <: spinal.lib.bus.fabric.MappedConnection[N]]
                   (ups : Seq[C], self : NSP, downs : Seq[C])
@@ -255,7 +255,7 @@ class Node() extends NodeUpDown {
     }
 
 
-    negociate[M2sSupport, M2sParameters, NodeM2s, NodeUpDown, ConnectionBase](
+    negotiate[M2sSupport, M2sParameters, NodeM2s, NodeUpDown, ConnectionBase](
       ups,
       m2s,
       downs

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MasterAgent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MasterAgent.scala
@@ -270,7 +270,7 @@ class MasterAgent (val bus : Bus, val cd : ClockDomain)(implicit idAllocator: Id
         if(debug) println(f"acquireBlock src=$source%02x addr=$address%x 1 -> 0 time=${simTime()}")
         onGrant(source, address, param)
       }
-      case Opcode.D.GRANT_DATA => { //TODO on naxriscv, may sent a aquire BtoT but may have been probed out meanwhile => test
+      case Opcode.D.GRANT_DATA => { // TODO on NaxRiscv, may sent a acquire BtoT but may have been probed out meanwhile => test
         assert(!block.contains(source, address))
         onGrant(source, address, param)
         b = new Block(source, address, d.param, bytes, false, d.data){

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/Wishbone.scala
@@ -22,18 +22,18 @@ object AddressGranularity extends Enumeration {
 }
 
 
-/** This class is used for configuring the Wishbone class
+/** This class is used for configuring the Wishbone class.
   * @param addressWidth size in bits of the address line
   * @param dataWidth size in bits of the data line
-  * @param selWidth size in bits of the selection line, deafult to 0 (disabled)
+  * @param selWidth size in bits of the selection line, default to 0 (disabled)
   * @param useSTALL activate the stall line, default to false (disabled)
   * @param useLOCK activate the lock line, default to false (disabled)
   * @param useERR activate the error line, default to false (disabled)
   * @param useRTY activate the retry line, default to false (disabled)
-  * @param useCTI activate the CTI line, deafult to 0 (disabled)
-  * @param tgaWidth size in bits of the tag address linie, deafult to 0 (disabled)
-  * @param tgcWidth size in bits of the tag cycle line, deafult to 0 (disabled)
-  * @param tgdWidth size in bits of the tag data line, deafult to 0 (disabled)
+  * @param useCTI activate the CTI line, default to 0 (disabled)
+  * @param tgaWidth size in bits of the tag address line, default to 0 (disabled)
+  * @param tgcWidth size in bits of the tag cycle line, default to 0 (disabled)
+  * @param tgdWidth size in bits of the tag data line, default to 0 (disabled)
   * @param useBTE activate the Burst Type Extension, default to false (disabled)
   * @param addressGranularity This specifies the address granularity for the bus.
   * @example {{{
@@ -81,8 +81,8 @@ case class WishboneConfig(
   def withBurstType              : WishboneConfig = this.copy(useCTI = true, useBTE = true)
 }
 
-/** This class rappresent a Wishbone bus
-  * @param config an istance of WishboneConfig, it will be used to configurate the Wishbone Bus
+/** This class represents a Wishbone bus.
+  * @param config an instance of WishboneConfig, it will be used to configure the Wishbone Bus
   */
 case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
   /////////////////////
@@ -96,9 +96,9 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
   val DAT_MISO  = Bits(config.dataWidth bits)
   val DAT_MOSI  = Bits(config.dataWidth bits)
 
-  ///////////////////////////
-  // OPTIONAL FLOW CONTROS //
-  ///////////////////////////
+  ////////////////////////////
+  // OPTIONAL FLOW CONTROLS //
+  ////////////////////////////
   val SEL       = if(config.useSEL)   Bits(config.selWidth bits) else null
   val STALL     = if(config.useSTALL) Bool()                     else null
   val ERR       = if(config.useERR)   Bool()                     else null
@@ -138,7 +138,7 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
     */
   override def clearAll() : this.type = {
     /////////////////////
-    // MINIMAl SIGLALS //
+    // MINIMAL SIGNALS //
     /////////////////////
     if( isMasterInterface) this.CYC.clear()
     if( isMasterInterface) this.ADR.clearAll()
@@ -148,9 +148,9 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
     if( isMasterInterface) this.WE.clear()
     if(!isMasterInterface) this.ACK.clear()
 
-    ///////////////////////////
-    // OPTIONAL FLOW CONTROS //
-    ///////////////////////////
+    ////////////////////////////
+    // OPTIONAL FLOW CONTROLS //
+    ////////////////////////////
     if(this.config.useSTALL && !isMasterInterface) this.STALL.clear()
     if(this.config.useERR   && !isMasterInterface) this.ERR.clear()
     if(this.config.useLOCK  &&  isMasterInterface) this.LOCK.clear()
@@ -170,9 +170,9 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
     this
   }
 
-  /** Connect common Wishbone signals
-    * this fuction will auto resize the slave address line
-    * only if slave.addressWidth <= master.addressWidth
+  /** Connect common Wishbone signals.
+    * This function will auto resize the slave address line
+    * only if [[slave.addressWidth <= master.addressWidth]]. 
     * @example{{{wishboneMaster >> wishboneSlave}}}
     */
   def >> (that : Wishbone) : Unit = {
@@ -189,9 +189,9 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
     that.WE       := this.WE
     this.ACK      := that.ACK
 
-    ///////////////////////////
-    // OPTIONAL FLOW CONTROS //
-    ///////////////////////////
+    ////////////////////////////
+    // OPTIONAL FLOW CONTROLS //
+    ////////////////////////////
     Wishbone.driveWeak(that.STALL,this.STALL,null,false,true)
     Wishbone.driveWeak(that.ERR,this.ERR,null,false,true)
     Wishbone.driveWeak(this.LOCK,that.LOCK,null,false,true)
@@ -210,7 +210,7 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
     Wishbone.driveWeak(this.TGD_MOSI,that.TGD_MOSI,null,false,true)
   }
 
-  /** Connect common Wishbone signals
+  /** Connect common Wishbone signals.
     * @example{{{wishboneSlave << wishboneMaster }}}
     */
   def << (that : Wishbone) : Unit = that >> this
@@ -218,9 +218,9 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
   /** Connect to a wishbone bus with optional resize.
     * This will drop all the signals that are not in common
     * @param that the wishbone bus that i want to connect, must be a wishbone slave
-    * @param allowDataResize allow the resize of the data lines, deafult to false
-    * @param allowAddressResize allow the resize of the address line, deafult to false
-    * @param allowTagResize allow the resize of the tag lines, deafult to false
+    * @param allowDataResize allow the resize of the data lines, default to false
+    * @param allowAddressResize allow the resize of the address line, default to false
+    * @param allowTagResize allow the resize of the tag lines, default to false
     */
   def connectTo(that : Wishbone, allowDataResize : Boolean = false, allowAddressResize : Boolean = false, allowTagResize : Boolean = false) : Unit = {
     /////////////////////
@@ -235,9 +235,9 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
     Wishbone.driveWeak(this.DAT_MOSI,that.DAT_MOSI,null,allowDataResize,false)
     Wishbone.driveWeak(that.DAT_MISO,this.DAT_MISO,null,allowDataResize,false)
 
-    ///////////////////////////
-    // OPTIONAL FLOW CONTROS //
-    ///////////////////////////
+    ////////////////////////////
+    // OPTIONAL FLOW CONTROLS //
+    ////////////////////////////
     Wishbone.driveWeak(that.STALL,this.STALL,null,false,true)
     Wishbone.driveWeak(that.ERR,this.ERR,null,false,true)
     Wishbone.driveWeak(this.LOCK,that.LOCK,null,false,true)
@@ -276,13 +276,13 @@ case class Wishbone(config: WishboneConfig) extends Bundle with IMasterSlave {
 object Wishbone{
   def apply(addressWidth : Int, dataWidth : Int) : Wishbone = Wishbone(WishboneConfig(addressWidth, dataWidth))
 
-  /** Connect to signal with some check
-    * This will ceck if the two signal are null, and if one of them are, connect with some condition
+  /** Connect to signal with some check.
+    * This will check if the two signal are null, and if one of them are, connect with some condition.
     * @param from must be an input
     * @param to must be an output
     * @param defaultValue if "from" is null, drive "to" with this value
     * @param allowResize allow resize allow the resize of the "from" signal
-    * @param allowDrop allow to not connect if one of the two siglar are null
+    * @param allowDrop allow to not connect if one of the two signals are null
     */
   def driveWeak[T <: Data](from: T, to: T, defaultValue: () => T, allowResize : Boolean, allowDrop: Boolean){
     (from != null, to != null) match{

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneArbiter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneArbiter.scala
@@ -49,10 +49,10 @@ class WishboneArbiter(config : WishboneConfig, inputCount : Int) extends Compone
       Wishbone.driveWeak(io.output.TGD_MISO, in.TGD_MISO, null, false, false)
     }
 
-    //Implement a round robin algorithm.
-    //The channel will remain selected is either LOCK or CYC are equals to true
-    //and pass to the next channel after the master clears CYC and LOCK
-    //this output a One Hot encoded vector/bit array
+    // Implement a round robin algorithm.
+    // The channel will remain selected is either LOCK or CYC are equals to true
+    // and pass to the next channel after the master clears CYC and LOCK
+    // this output a One Hot encoded vector/bit array.
     val requests =  if(config.useLOCK)  Vec(io.inputs.map(func => func.CYC && !func.LOCK))
                     else                Vec(io.inputs.map(func => func.CYC))
 
@@ -65,14 +65,14 @@ class WishboneArbiter(config : WishboneConfig, inputCount : Int) extends Compone
       maskLock := roundRobin
     }
 
-    //Implement the selector for the output slave signals
-    //This is ok becouse the signal is assumed as oneHotEncoded
+    // Implement the selector for the output slave signals.
+    // This is ok because the signal is assumed as oneHotEncoded.
                         (io.inputs.map(_.ACK),   selector).zipped.foreach(_ := _ && io.output.ACK)
     if(config.useSTALL) (io.inputs.map(_.STALL), selector).zipped.foreach(_ := _ && io.output.STALL)
     if(config.useERR)   (io.inputs.map(_.ERR),   selector).zipped.foreach(_ := _ && io.output.ERR)
     if(config.useRTY)   (io.inputs.map(_.RTY),   selector).zipped.foreach(_ := _ && io.output.RTY)
 
-    //Implement the selector for the input slave signals
+    // Implement the selector for the input slave signals
     io.output.CYC       := MuxOH(selector, Vec(io.inputs.map(_.CYC)))
     io.output.STB       := MuxOH(selector, Vec(io.inputs.map(_.STB)))
     io.output.WE        := MuxOH(selector, Vec(io.inputs.map(_.WE)))

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
@@ -7,16 +7,16 @@ import scala.collection.Seq
 
 /** Factory for [[spinal.lib.bus.wishbone.WishboneDecoder]] instances. */
 object WishboneDecoder {
-  /** Create a istance of a wishbone decoder/multiplexer
+  /** Create an instance of a wishbone decoder/multiplexer.
   * @param config it will use for configuring all the input/output wishbone port
   * @param decodings it will use for configuring the partial address decoder
   * @return a [[spinal.lib.bus.wishbone.WishboneDecoder]] instance
   */
   def apply(config: WishboneConfig, decodings: Seq[AddressMapping]) = new WishboneDecoder(config,decodings)
 
-  /** Create an istance of WishboneDecoder, and autocconect all input/outputs
+  /** Create an instance of WishboneDecoder, and autoconnect all input/outputs.
     * @param master connect the input to this master interface, the [[spinal.lib.bus.wishbone.Wishbone.config]] will be used for all input/output
-    * @param slaves connect the ouput to the slaves, with the correct address
+    * @param slaves connect the output to the slaves, with the correct address
     * @return a [[spinal.lib.bus.wishbone.WishboneDecoder]] instance with all the input and output connected automatically
     */
   def apply(master: Wishbone, slaves: Seq[(Wishbone, AddressMapping)]): WishboneDecoder = {
@@ -37,7 +37,7 @@ class WishboneDecoder(config : WishboneConfig, decodings : Seq[AddressMapping]) 
     val outputs = Vec(master(Wishbone(config)), decodings.size)
   }
 
-  //permanently drive some slave iunput signal to save on logic usage
+  // Permanently drive some slave input signal to save on logic usage.
   io.outputs.map{ out =>
     out.STB       := io.input.STB
     out.DAT_MOSI  := io.input.DAT_MOSI
@@ -56,10 +56,10 @@ class WishboneDecoder(config : WishboneConfig, decodings : Seq[AddressMapping]) 
   val selector = Vec(decodings.map(_.hit(io.input.ADR) && io.input.CYC))
   val selectorIndex = OHToUInt(selector)
 
-  // Generate the CYC sygnal for the selected slave
+  // Generate the CYC signal for the selected slave
   (io.outputs.map(_.CYC), selector).zipped.foreach(_ := _)
 
-  //Implementing the multiplexer logic, it thakes the one Hot bit vector/bit array as input
+  // Implementing the multiplexer logic, it takes the one Hot bit vector/bit array as input
   val selectedOutput = io.outputs(selectorIndex)
 
   io.input.ACK := selectedOutput.ACK

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneIntercon.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneIntercon.scala
@@ -30,7 +30,7 @@ case class WishboneInterconFactory(){
   }
 
   /** Modify a connection
-    * @param m the master where the conenction start
+    * @param m the master where the connection start
     * @param s the slave that is connected to the master
     * @example{{{
     * interconnect.setConnector(dBus, slowBus){(m,s) =>
@@ -133,11 +133,11 @@ case class WishboneInterconFactory(){
         connection.connector(m, s)
       }else{
         val tmp = cloneOf(s)
-        m >> tmp //Adapte the bus kind.
+        m >> tmp // Adapt the bus kind.
         connection.connector(tmp,s)
       }
     }
   }
-  //Will make SpinalHDL calling the build function at the end of the current component elaboration
+  // Will make SpinalHDL calling the build function at the end of the current component elaboration.
   Component.current.addPrePopTask(build)
 }

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
@@ -9,9 +9,9 @@ import scala.collection.Seq
 
 /** Factory for [[spinal.lib.bus.wishbone.WishboneSlaveFactory]] instances. */
 object WishboneSlaveFactory {
-  /** This is the slave facotory fot the wishbone bus
-    * @param bus the wishbone bus istance that will connect with the module
-    * @return an instanciated class of [[spinal.lib.bus.wishbone.WishboneSlaveFactory]]
+  /** This is the slave factory fot the wishbone bus.
+    * @param bus the wishbone bus instance that will connect with the module
+    * @return an instantiated class of [[spinal.lib.bus.wishbone.WishboneSlaveFactory]]
     */
   def apply(bus: Wishbone,reg_fedback: Boolean = true) = new WishboneSlaveFactory(bus,reg_fedback)
 }
@@ -30,13 +30,13 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
   val doRead = bus.doRead.allowPruning()
 
   if(!reg_fedback){
-    bus.ACK := bus.STB && bus.CYC                 //Acknowledge as fast as possible
+    bus.ACK := bus.STB && bus.CYC                 // Acknowledge as fast as possible.
   } else if(bus.config.isPipelined){
     val pip_reg = RegNext(bus.STB) init(False)
-    bus.ACK := pip_reg || (bus.STALL && bus.CYC)  //Pipelined: Acknowledge at the next clock cycle
+    bus.ACK := pip_reg || (bus.STALL && bus.CYC)  // Pipelined: Acknowledge at the next clock cycle.
   } else {
     val reg_reg = RegNext(bus.STB && bus.CYC) init(False)
-    bus.ACK := reg_reg && bus.STB                 //Classic: Acknowledge at the next clock cycle
+    bus.ACK := reg_reg && bus.STB                 // Classic: Acknowledge at the next clock cycle.
   }
 
   val byteAddress = bus.byteAddress(AddressGranularity.WORD)

--- a/lib/src/main/scala/spinal/lib/com/eth/MacTx.scala
+++ b/lib/src/main/scala/spinal/lib/com/eth/MacTx.scala
@@ -165,9 +165,9 @@ case class MacTxBuffer(pushCd : ClockDomain,
     val lengthMinusOne = length-1
     val wordCounter = Reg(UInt(wordCountWidth bits))
     val wordCountEndAt = lengthMinusOne >> log2Up(pushWidth)
-    val spliterEndAt = lengthMinusOne(log2Up(pushWidth)-1 downto log2Up(popWidth))
+    val splitterEndAt = lengthMinusOne(log2Up(pushWidth)-1 downto log2Up(popWidth))
     val ratio = pushWidth/popWidth
-    val spliter = Reg(UInt(log2Up(ratio) bits))
+    val splitter = Reg(UInt(log2Up(ratio) bits))
 
 
     fifo.io.pop.commit := io.pop.commit
@@ -176,12 +176,12 @@ case class MacTxBuffer(pushCd : ClockDomain,
 
     io.pop.stream.valid := False
     io.pop.stream.last := False
-    io.pop.stream.data := fifo.io.pop.stream.payload.subdivideIn(popWidth bits).read(spliter)
+    io.pop.stream.data := fifo.io.pop.stream.payload.subdivideIn(popWidth bits).read(splitter)
 
     switch(state){
       is(State.LENGTH){
         wordCounter := 0
-        spliter := 0
+        splitter := 0
         when(fifo.io.pop.stream.valid){
           state := State.DATA
           length := fifo.io.pop.stream.payload.asUInt.resized
@@ -191,13 +191,13 @@ case class MacTxBuffer(pushCd : ClockDomain,
       is(State.DATA) {
         io.pop.stream.valid := True
         when(io.pop.stream.ready) {
-          spliter := spliter + 1
-          when(wordCounter === wordCountEndAt && spliter === spliterEndAt) {
+          splitter := splitter + 1
+          when(wordCounter === wordCountEndAt && splitter === splitterEndAt) {
             state := State.WAIT
             fifo.io.pop.stream.ready := True
             io.pop.stream.last := True
           }
-          when(spliter === spliter.maxValue) {
+          when(splitter === splitter.maxValue) {
             wordCounter := wordCounter + 1
             fifo.io.pop.stream.ready := True
           }

--- a/lib/src/main/scala/spinal/lib/com/i2c/I2cCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/i2c/I2cCtrl.scala
@@ -359,8 +359,9 @@ object I2cCtrl {
           }
         }
 
+        // Allow to catch up a start sequence until SCL is low.
+        val inFrameLate = Reg(Bool()) setWhen(!internals.sclRead) clearWhen(!internals.inFrame)
 
-        val inFrameLate = Reg(Bool()) setWhen(!internals.sclRead) clearWhen(!internals.inFrame) //Allow to catch up a start sequance until SCL is low
         val outOfSync = !internals.inFrame && (!internals.sdaRead || !internals.sclRead)
         val IDLE: State = new State with EntryPoint {
           whenIsActive {

--- a/lib/src/main/scala/spinal/lib/com/jtag/JtagTapInstructions.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/JtagTapInstructions.scala
@@ -101,9 +101,7 @@ class JtagTapInstructionRead[T <: Data](data: T, light : Boolean) extends Area {
   }
 }
 
-/**
- * Usefull to create a jtag tap instruction that has a different data input/output, with a captureReady
- */
+/** Useful to create a jtag tap instruction that has a different data input/output, with a captureReady */
 class JtagTapInstructionReadWrite[T <: Data](captureData: T, updateData: T, captureReady: Bool) extends Area {
   val ctrl = JtagTapInstructionCtrl()
   assert(widthOf(captureData) == widthOf(updateData)) // tdo is also clocked by tck

--- a/lib/src/main/scala/spinal/lib/com/spi/SpiMasterCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/SpiMasterCtrl.scala
@@ -103,7 +103,7 @@ case class SpiMasterCtrl(generics : SpiMasterCtrlGenerics) extends Component{
      * ssSetup -> W 0x10 time between chip select enable and the next byte
      * ssHold -> W 0x14 time between the last byte transmission and the chip select disable
      * ssDisable -> W 0x18 time between chip select disable and chip select enable
-     * samplePos -> W 0x1c sample postion after edge trigger
+     * samplePos -> W 0x1c sample position after edge trigger
      */
 
     def driveFrom(bus : BusSlaveFactory, baseAddress : Int = 0)(generics : SpiMasterCtrlMemoryMappedConfig) = new Area {

--- a/lib/src/main/scala/spinal/lib/com/spi/SpiSlaveCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/SpiSlaveCtrl.scala
@@ -50,7 +50,7 @@ case class SpiSlaveCtrlIo(generics : SpiSlaveCtrlGenerics) extends Bundle{
    * - ssEnabledIntClear -> W[12] When set, clear the ssEnabledInt interrupt
    * - ssDisabledIntClear -> W[13] When set, clear the ssDisabledInt interrupt
    * - rxListen -> RW[15] Enable the reception of mosi bytes
-   * - txAvailability -> R[30:16] Space avalaible in the tx fifo
+   * - txAvailability -> R[30:16] Space available in the tx fifo
    *
    * config -> 0x08
    * - cpol -> W[0]
@@ -91,11 +91,11 @@ case class SpiSlaveCtrlIo(generics : SpiSlaveCtrlGenerics) extends Bundle{
       val ssDisabledIntEnable = busWithOffset.createReadAndWrite(Bool(), address = 4, 3) init(False)
 
 
-      val ssFiltedEdges = ssFilted.edges(True)
+      val ssFilteredEdges = ssFilted.edges(True)
       val txInt  = busWithOffset.read(txIntEnable & !txLogic.stream.valid, address = 4, 8)
       val rxInt  = busWithOffset.read(rxIntEnable & rxLogic.stream.valid , address = 4, 9)
-      val ssEnabledInt = busWithOffset.read(RegInit(False) setWhen(ssFiltedEdges.fall) clearWhen(!ssEnabledIntEnable), address = 4, bitOffset = 10)
-      val ssDisabledInt = busWithOffset.read(RegInit(False) setWhen(ssFiltedEdges.rise) clearWhen(!ssDisabledIntEnable),  address = 4, bitOffset = 11)
+      val ssEnabledInt = busWithOffset.read(RegInit(False) setWhen(ssFilteredEdges.fall) clearWhen(!ssEnabledIntEnable), address = 4, bitOffset = 10)
+      val ssDisabledInt = busWithOffset.read(RegInit(False) setWhen(ssFilteredEdges.rise) clearWhen(!ssDisabledIntEnable),  address = 4, bitOffset = 11)
       busWithOffset.clearOnSet(ssEnabledInt, address = 4, bitOffset = 12)
       busWithOffset.clearOnSet(ssDisabledInt, address = 4, bitOffset = 13)
       val interrupt = rxInt || txInt || ssEnabledInt || ssDisabledInt

--- a/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
@@ -125,13 +125,13 @@ class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
     //manage RX
     val read = new Area {
       val (stream, fifoOccupancy) = io.read.queueWithOccupancy(config.rxFifoDepth)
-      val streamBreaked = stream.throwWhen(io.readBreak)
+      val streamBroken = stream.throwWhen(io.readBreak)
       busCtrl.busDataWidth match {
         case 16 =>
-          busCtrlWrapped.readStreamNonBlocking(streamBreaked, address = 0, validBitOffset = 15, payloadBitOffset = 0)
+          busCtrlWrapped.readStreamNonBlocking(streamBroken, address = 0, validBitOffset = 15, payloadBitOffset = 0)
           busCtrlWrapped.read(sat255(fifoOccupancy),address = 6, 8)
         case 32 =>
-          busCtrlWrapped.readStreamNonBlocking(streamBreaked, address = 0, validBitOffset = 16, payloadBitOffset = 0)
+          busCtrlWrapped.readStreamNonBlocking(streamBroken, address = 0, validBitOffset = 16, payloadBitOffset = 0)
           busCtrlWrapped.read(sat255(fifoOccupancy),address = 4, 24)
       }
       def genCTS(freeThreshold : Int) = RegNext(fifoOccupancy <= config.rxFifoDepth - freeThreshold) init(False)  // freeThreshold => how many remaining space should be in the fifo before allowing transfer
@@ -141,7 +141,7 @@ class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
     val interruptCtrl = new Area {
       val writeIntEnable = busCtrlWrapped.createReadAndWrite(Bool(), address = 4, 0) init(False)
       val readIntEnable  = busCtrlWrapped.createReadAndWrite(Bool(), address = 4, 1) init(False)
-      val readInt   = readIntEnable  &  read.streamBreaked.valid
+      val readInt   = readIntEnable  &  read.streamBroken.valid
       val writeInt  = writeIntEnable & !write.stream.valid
       val interrupt = readInt || writeInt
       busCtrlWrapped.read(writeInt, address = 4, 8)

--- a/lib/src/main/scala/spinal/lib/com/uart/UartCtrlRx.scala
+++ b/lib/src/main/scala/spinal/lib/com/uart/UartCtrlRx.scala
@@ -26,8 +26,8 @@ class UartCtrlRx(g : UartCtrlGenerics) extends Component {
   // Implement the rxd sampling with a majority vote over samplingSize bits
   // Provide a new sampler.value each time sampler.tick is high
   val sampler = new Area {
-    val synchroniser = BufferCC.withTag(io.rxd,init=False)
-    val samples      = History(that=synchroniser,length=samplingSize,when=io.samplingTick,init=True)
+    val synchronizer = BufferCC.withTag(io.rxd,init=False)
+    val samples      = History(that=synchronizer,length=samplingSize,when=io.samplingTick,init=True)
     val value        = RegNext(MajorityVote(samples)) init(True)
     val tick         = RegNext(io.samplingTick) init(False)
   }

--- a/lib/src/main/scala/spinal/lib/cpu/riscv/debug/JtagTunnel.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/debug/JtagTunnel.scala
@@ -35,8 +35,8 @@ class JtagTunnel(ctrl : JtagTapInstructionCtrl, instructionWidth : Int) extends 
     }
   }
 
-  //Basicaly, with JTAG, especialy if you are in a chain, the only reference you have in a dr-scan is when it finish,
-  //as you may have some extra dr-scan cycle at the beggining to propagate through the chaine
+  // Basically, with JTAG, especially if you are in a chain, the only reference you have in a dr-scan is when it finish,
+  // as you may have some extra dr-scan cycle at the beginning to propagate through the chain.
   val tdiBuffer = Delay(ctrl.tdi, 1+7+1)
   val tdoBuffer = False
   val tdoShifter = Delay(tdoBuffer, 4)

--- a/lib/src/main/scala/spinal/lib/dsptool/FixData.scala
+++ b/lib/src/main/scala/spinal/lib/dsptool/FixData.scala
@@ -95,7 +95,7 @@ case class FixData(raw: Double,
   def asLongPositive: Long = if(value < 0) q.capcity.toLong + this.asLong else this.asLong
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.14.0")
+  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.15.0")
   def asLongPostive: Long = asLongPositive
 
   def hex: String = s"%${q.alignHex}s".format(this.asLongPostive.toHexString).replace(' ','0')

--- a/lib/src/main/scala/spinal/lib/dsptool/FixData.scala
+++ b/lib/src/main/scala/spinal/lib/dsptool/FixData.scala
@@ -89,10 +89,14 @@ case class FixData(raw: Double,
   }
 
 //  def asInt: Int          = this.value / q.resolution toInt
-//  def asIntPostive: Int   = if(rawIsNegative) q.capcity.toInt + this.asInt else this.asInt
+//  def asIntPositive: Int   = if(rawIsNegative) q.capcity.toInt + this.asInt else this.asInt
 
   def asLong: Long        = this.value / q.resolution toLong
-  def asLongPostive: Long = if(value < 0) q.capcity.toLong + this.asLong else this.asLong
+  def asLongPositive: Long = if(value < 0) q.capcity.toLong + this.asLong else this.asLong
+
+  // TODO enable deprecation
+  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.14.0")
+  def asLongPostive: Long = asLongPositive
 
   def hex: String = s"%${q.alignHex}s".format(this.asLongPostive.toHexString).replace(' ','0')
   def bin: String = s"%${q.width}s".format(this.asLongPostive.toBinaryString).replace(' ','0')

--- a/lib/src/main/scala/spinal/lib/dsptool/package.scala
+++ b/lib/src/main/scala/spinal/lib/dsptool/package.scala
@@ -3,7 +3,7 @@ package spinal.lib
 //todo jijing 2020.1.17
 
 package object dsptool {
-//  fixSwitch implitation
+//  fixSwitch implementation
 //  implicit def DoubleToComplex(x: Double): Complex = {}
 //  implicit def IntToComplex(x: Int): Complex = {}
 //  implicit class DoubleWithFixFeature(x: Double) {}

--- a/lib/src/main/scala/spinal/lib/eda/TimingExtractor.scala
+++ b/lib/src/main/scala/spinal/lib/eda/TimingExtractor.scala
@@ -37,7 +37,7 @@ class TimingExtractorSdc(path : File, marginFactor : Double) extends TimingExtra
 
   def freqToTimeSingle(cd : ClockDomain) = (cd.frequency match {
     case f : FixedFrequency => f.getValue.toTime.toBigDecimal * 1e9
-    case _ => SpinalError("Unknown frequancy for " + cd.clock)
+    case _ => SpinalError("Unknown frequency for " + cd.clock)
   })*marginFactor
 
   def writeFalsePath(target: Any, tag: crossClockFalsePath) : Unit = {
@@ -111,8 +111,8 @@ object TimingExtractor {
       val frequencies = mutable.LinkedHashSet[ClockDomain.ClockFrequency]()
       frequencies ++= cds.map(_.frequency)
       if(frequencies.size > 1) {
-        val filtred = frequencies.filter(!_.isInstanceOf[ClockDomain.UnknownFrequency])
-        frequencies.clear(); frequencies ++= filtred
+        val filtered = frequencies.filter(!_.isInstanceOf[ClockDomain.UnknownFrequency])
+        frequencies.clear(); frequencies ++= filtered
       }
       assert(frequencies.size == 1)
       listener.writeClock(clock, frequencies.head)

--- a/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
+++ b/lib/src/main/scala/spinal/lib/eda/altera/QSys.scala
@@ -26,7 +26,7 @@ object QSysify{
 }
 
 trait QSysifyInterfaceEmiter{
-  //Check the 'i' interface, if it reconize something, should return true and complette the TCL `builder` with corresponding things.
+  //Check the 'i' interface, if it recognize something, should return true and complete the TCL `builder` with corresponding things.
   def emit(i : Data,builder : StringBuilder) : Boolean
 }
 
@@ -159,7 +159,7 @@ class AvalonEmitter extends QSysifyInterfaceEmiter{
       val (masterPinDir,slavePinDir,startEnd) = if(isMaster) ("Output", "Input","start") else ("Input","Output","end")
       val name = e.getName()
       val clockDomainTag = e.getTag(classOf[ClockDomainTag])
-      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You shoud apply the ClockDomainTag to the inferface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
+      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You should apply the ClockDomainTag to the interface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
       val clockName = clockDomainTag.get.clockDomain.clock.getName()
       val resetName = clockDomainTag.get.clockDomain.reset.getName()
       builder ++= s"""
@@ -331,7 +331,7 @@ class ApbEmitter extends QSysifyInterfaceEmiter{
       val (masterPinDir,slavePinDir,startEnd) = if(isMaster) ("Output", "Input","start") else ("Input","Output","end")
       val name = e.getName()
       val clockDomainTag = e.getTag(classOf[ClockDomainTag])
-      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You shoud apply the ClockDomainTag to the inferface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
+      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You should apply the ClockDomainTag to the interface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
       val clockName = clockDomainTag.get.clockDomain.clock.getName()
       val resetName = clockDomainTag.get.clockDomain.reset.getName()
       builder ++=
@@ -373,7 +373,7 @@ add_interface_port $name ${e.PREADY.getName()} pready ${slavePinDir} 1
 //      val (masterPinDir,slavePinDir,startEnd) = if(isMaster) ("Output", "Input","start") else ("Input","Output","end")
 //      val name = e.getName()
 //      val clockDomainTag = e.getTag(classOf[ClockDomainTag])
-//      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You shoud apply the ClockDomainTag to the inferface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
+//      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You should apply the ClockDomainTag to the interface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
 //      val clockName = clockDomainTag.get.clockDomain.clock.getName()
 //      val resetName = clockDomainTag.get.clockDomain.reset.getName()
 //      builder ++= s"""
@@ -458,7 +458,7 @@ class Axi4Emitter extends QSysifyInterfaceEmiter{
       val (masterPinDir,slavePinDir,startEnd) = if(isMaster) ("Output", "Input","start") else ("Input","Output","end")
       val name = e.getName()
       val clockDomainTag = e.getTag(classOf[ClockDomainTag])
-      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You shoud apply the ClockDomainTag to the inferface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
+      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You should apply the ClockDomainTag to the interface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
       val clockName = clockDomainTag.get.clockDomain.clock.getName()
       val resetName = clockDomainTag.get.clockDomain.reset.getName()
       builder ++= s"""
@@ -575,7 +575,7 @@ class AxiLite4Emitter extends QSysifyInterfaceEmiter{
       val (masterPinDir,slavePinDir,startEnd) = if(isMaster) ("Output", "Input","start") else ("Input","Output","end")
       val name = e.getName()
       val clockDomainTag = e.getTag(classOf[ClockDomainTag])
-      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You shoud apply the ClockDomainTag to the inferface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
+      if(clockDomainTag.isEmpty) SpinalError(s"Clock domain of ${i} is not defined, You should apply the ClockDomainTag to the interface\nyourBus.addTag(ClockDomainTag(ClockDomain.current))")
       val clockName = clockDomainTag.get.clockDomain.clock.getName()
       val resetName = clockDomainTag.get.clockDomain.reset.getName()
       builder ++= s"""

--- a/lib/src/main/scala/spinal/lib/generator_backup/Generator.scala
+++ b/lib/src/main/scala/spinal/lib/generator_backup/Generator.scala
@@ -356,17 +356,17 @@ class GeneratorCompiler {
         generator.generateIt()
         progressed = true
       }
-      if(!progressed){
+      if(!progressed) {
         val unelaborateds = generatorsAll.filter(!_.elaborated)
-        val missingDepedancies = unelaborateds.flatMap(_.dependencies).toSet.filter(!_.isDone)
-        val missingHandle = missingDepedancies.filter(_.isInstanceOf[Handle[_]]).map(_.asInstanceOf[Handle[Any]])
+        val missingDependencies = unelaborateds.flatMap(_.dependencies).toSet.filter(!_.isDone)
+        val missingHandle = missingDependencies.filter(_.isInstanceOf[Handle[_]]).map(_.asInstanceOf[Handle[Any]])
         val producatable = unelaborateds.flatMap(_.products).map(_.core).toSet
         val withoutSources = missingHandle.filter(e => !producatable.contains(e.core))
         SpinalError(
-          s"Composable hang, remaings generators are :\n" +
+          s"Composable hang, reaming generators are :\n" +
           s"${unelaborateds.map(p => s"- ${p} depend on ${p.dependencies.filter(d => !d.isDone).mkString(", ")}\n").mkString}" +
           s"\nDependable not completed :\n" +
-          s"${missingDepedancies.map(d => "- " + d + "\n").mkString}" +
+          s"${missingDependencies.map(d => "- " + d + "\n").mkString}" +
           s"\nHandles without potential sources :\n" +
           s"${withoutSources.toSeq.sortBy(_.getName()).map(d => "- " + d + "\n").mkString}"
         )

--- a/lib/src/main/scala/spinal/lib/io/Gpio.scala
+++ b/lib/src/main/scala/spinal/lib/io/Gpio.scala
@@ -15,7 +15,7 @@ object Gpio {
                        var input : Seq[Int] = null,   //List of pin id which can be inputs (null mean all)
                        var output : Seq[Int]  = null, //List of pin id which can be outputs (null mean all)
                        interrupt : Seq[Int]  = Nil,   //List of pin id which can be used as interrupt source
-                       readBufferLength : Int = 2)    //Number of syncronisation stages
+                       readBufferLength : Int = 2)    //Number of synchronization stages
 
   abstract class Ctrl[T <: spinal.core.Data with IMasterSlave](p: Gpio.Parameter,
                                                                 busType: HardType[T],
@@ -32,12 +32,12 @@ object Gpio {
     }
 
     val mapper = factory(io.bus)
-    val syncronized = Delay(io.gpio.read, p.readBufferLength)
-    val last = RegNext(syncronized)
+    val isSynchronized = Delay(io.gpio.read, p.readBufferLength)
+    val last = RegNext(isSynchronized)
 
 
     for(i <- 0 until p.width){
-      if(p.input.contains(i)) mapper.read(syncronized(i), 0x00, i)
+      if(p.input.contains(i)) mapper.read(isSynchronized(i), 0x00, i)
       if(p.output.contains(i)) mapper.driveAndRead(io.gpio.write(i), 0x04, i) else io.gpio.write(i) := False
       if(p.output.contains(i) && p.input.contains(i)) mapper.driveAndRead(io.gpio.writeEnable(i), 0x08, i) init(False) else io.gpio.writeEnable(i) := Bool(p.output.contains(i))
     }
@@ -47,10 +47,10 @@ object Gpio {
         val high, low, rise, fall = Bits(p.width bits)
       }
 
-      val valid = ((enable.high & syncronized)
-                | (enable.low & ~syncronized)
-                | (enable.rise & (syncronized & ~last))
-                | (enable.fall & (~syncronized & last)))
+      val valid = ((enable.high & isSynchronized)
+                | (enable.low & ~isSynchronized)
+                | (enable.rise & (isSynchronized & ~last))
+                | (enable.fall & (~isSynchronized & last)))
 
       for(i <- 0 until p.width){
         if(p.interrupt.contains(i)){

--- a/lib/src/main/scala/spinal/lib/io/TriState.scala
+++ b/lib/src/main/scala/spinal/lib/io/TriState.scala
@@ -44,12 +44,12 @@ case class TriStateArray(width : Int) extends Bundle with IMasterSlave{
   def apply(i : Int) : TriState[Bool] = {
     val ret = TriState(Bool())
 
-    //Make ret readable
+    // Make ret readable.
     ret.read := this.read(i)
     ret.write := this.write(i)
     ret.writeEnable := this.writeEnable(i)
 
-    //Define a fonction which redirect write access of a userSignal to another signal
+    /// Define a function which redirect write access of a userSignal to another signal.
     def writePatch(userSignal : BaseType, realSignal : BaseType) : Unit = {
       userSignal.compositeAssign = new Assignable {
         override def assignFromImpl(that: AnyRef, target: AnyRef, kind: AnyRef)(implicit loc: Location): Unit = that match {
@@ -59,7 +59,7 @@ case class TriStateArray(width : Int) extends Bundle with IMasterSlave{
       }
     }
 
-    //Make ret writable
+    // Make ret writable.
     writePatch(ret.read, this.read(i))
     writePatch(ret.write, this.write(i))
     writePatch(ret.writeEnable, this.writeEnable(i))

--- a/lib/src/main/scala/spinal/lib/memory/sdram/xdr/Tasker.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/xdr/Tasker.scala
@@ -235,7 +235,7 @@ case class Tasker(cpa : CoreParameterAggregate) extends Component{
     val doRead = inputRead && allowRead
     val doSomething = valid && (doActive || doPrecharge || doWrite || doRead) && !inibated
 
-    val blockedByWriteTocken = inputWrite && allowWrite && !writeTockens.map(_.ready).read(portId) //For debug visualisation
+    val blockedByWriteTocken = inputWrite && allowWrite && !writeTockens.map(_.ready).read(portId) // For debug visualization
 
     val sel = Bool() //Arbitration allow you to do your stuff
     val fire = False //It is the last cycle for this station

--- a/lib/src/main/scala/spinal/lib/memory/sdram/xdr/Xdr.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/xdr/Xdr.scala
@@ -228,10 +228,10 @@ case class SdramTiming(generation : Int,
 
 //object SoftConfig{
 //  def apply(timing : SdramTiming,
-//            frequancy : HertzNumber,
+//            frequency : HertzNumber,
 //            cpa : CoreParameterAggregate,
 //            phyClockRatio : Int): SoftConfig = {
-//    implicit def toCycle(spec : (TimeNumber, Int)) = Math.max(0, Math.max((spec._1 * frequancy).toDouble.ceil.toInt, (spec._2+phyClockRatio-1)/phyClockRatio))
+//    implicit def toCycle(spec : (TimeNumber, Int)) = Math.max(0, Math.max((spec._1 * frequency).toDouble.ceil.toInt, (spec._2+phyClockRatio-1)/phyClockRatio))
 //    SoftConfig(
 //      RFC = timing.RFC,
 //      RAS = timing.RAS,

--- a/lib/src/main/scala/spinal/lib/misc/PathTracer.scala
+++ b/lib/src/main/scala/spinal/lib/misc/PathTracer.scala
@@ -65,7 +65,7 @@ object PathTracer {
     }
   }
   def impl(from: Expression, to: Expression): Node = {
-    val walkedId = GlobalData.get.allocateAlgoIncrementale()
+    val walkedId = GlobalData.get.allocateAlgoIncremental()
     val keyToNode = mutable.LinkedHashMap[BaseNode, Node]()
 
     val toNode = new Node(to)
@@ -103,9 +103,9 @@ object PathTracer {
     }
 
     def foreach(that: BaseNode)(onUp : (BaseNode, Int) => Unit): Unit = {
-//      if(that.algoIncrementale == walkedId)
+//      if(that.algoIncremental == walkedId)
 //        return
-//      that.algoIncrementale = walkedId
+//      that.algoIncremental = walkedId
 //      if(that == from)
 //        return
 

--- a/lib/src/main/scala/spinal/lib/misc/Plru.scala
+++ b/lib/src/main/scala/spinal/lib/misc/Plru.scala
@@ -3,9 +3,8 @@ package spinal.lib.misc
 import spinal.core._
 import spinal.lib._
 
-/**
-  * Pseudo least recently used combinatorial logic
-  * io.context.state need to be handled externaly.
+/** Pseudo least recently used combinatorial logic
+  * io.context.state need to be handled externally.
   * When you want to specify a access to a entry, you can use the io.update interface
   * to get the new state value.
   */
@@ -17,7 +16,7 @@ case class Plru(entries : Int, withEntriesValid : Boolean) extends Area{
   val io = new Bundle{
     val context = new Bundle{
       val state = Plru.State(entries)
-      val valids = withEntriesValid generate Bits(entries bits) //Allow to specify prefered entries to remove
+      val valids = withEntriesValid generate Bits(entries bits) // Allow to specify preferred entries to remove
     }
     val evict = new Bundle{
       val id =  UInt(log2Up(entries) bits)

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicTrigger.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicTrigger.scala
@@ -53,7 +53,7 @@ case class ImsicTriggerMapper(sourceIds: Seq[Int], hartId: Int, guestId: Int) ex
 /**
  * ImsicMapping: IMSIC interrupt file mapping info
  *
- * Each interrupt file address should be calcuated as below:
+ * Each interrupt file address should be calculated as below:
  * g * 2^E + B + h * 2^D
  *
  * g is the IMSIC group id and the h is the hart id in the group
@@ -70,8 +70,8 @@ case class ImsicTriggerMapper(sourceIds: Seq[Int], hartId: Int, guestId: Int) ex
  *   2^E in the address formula.
  *
  * For convenient, all the arguments could be set to zero for auto
- * calcuation. But when `interruptFileHartOffset` is not zero,
- * `interruptFileGroupSize` must be set non-zero, or the calcuation
+ * calculation. But when `interruptFileHartOffset` is not zero,
+ * `interruptFileGroupSize` must be set non-zero, or the calculation
  * will fail.
  *
  */
@@ -89,7 +89,7 @@ object ImsicTrigger {
 
     require(interruptFileHartSize == 0 || isPow2(interruptFileHartSize), "interruptFileHartSize should be power of 2")
     require(interruptFileGroupSize == 0 || isPow2(interruptFileGroupSize), "interruptFileGroupSize should be power of 2")
-    require(!(interruptFileHartOffset != 0 && interruptFileGroupSize == 0), "Can not auto calcuate interruptFileGroupSize when interruptFileHartOffset != 0")
+    require(!(interruptFileHartOffset != 0 && interruptFileGroupSize == 0), "Can not auto calculate interruptFileGroupSize when interruptFileHartOffset != 0")
 
     require(maxGuestId < 16, "Per hart can only have max 15 guest interrupt files.")
 

--- a/lib/src/main/scala/spinal/lib/misc/pipeline/JoinLink.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/JoinLink.scala
@@ -27,9 +27,9 @@ class JoinLink(override val ups : Seq[Node], val down : Node) extends Link {
     down.valid := ups.map(_.isValid).andR
     ups.foreach(_.ready := down.isValid && down.isReady)
     for(key <- down.fromUp.payload){
-      val filtred = ups.filter(up => up.keyToData.contains(key) || up.fromUp.payload.contains(key))
-      filtred.size match {
-        case 1 => down(key) := filtred(0)(key)
+      val filtered = ups.filter(up => up.keyToData.contains(key) || up.fromUp.payload.contains(key))
+      filtered.size match {
+        case 1 => down(key) := filtered(0)(key)
       }
     }
   }

--- a/lib/src/main/scala/spinal/lib/misc/plic/PlicMapper.scala
+++ b/lib/src/main/scala/spinal/lib/misc/plic/PlicMapper.scala
@@ -84,7 +84,7 @@ object PlicMapper{
     
     // for each gateway, generate priority register & pending bit as needed
     val gatewayMapping = for(gateway <- gateways) yield new Area{
-      if(gatewayPriorityWriteGen && !gateway.priority.hasAssignement) bus.drive(gateway.priority, address = gatewayPriorityOffset + (gateway.id << gatewayPriorityShift), documentation = s"Driving priority for gateway ${gateway.getName()}. Inits to 0 (interrupt is disabled)" ) init(0)
+      if(gatewayPriorityWriteGen && !gateway.priority.hasAssignment) bus.drive(gateway.priority, address = gatewayPriorityOffset + (gateway.id << gatewayPriorityShift), documentation = s"Driving priority for gateway ${gateway.getName()}. Inits to 0 (interrupt is disabled)" ) init(0)
       if(gatewayPriorityReadGen) bus.read(gateway.priority, address = gatewayPriorityOffset + (gateway.id << gatewayPriorityShift), documentation = s"Read priority for gateway ${gateway.getName()}")
       if(gatewayPendingReadGen) bus.read(gateway.ip, address = gatewayPendingOffset + (gateway.id/bus.busDataWidth)*bus.busDataWidth/8, bitOffset = gateway.id % bus.busDataWidth, documentation = s"Read Pending bit for gateway " + gateway.getName())
     }
@@ -134,7 +134,7 @@ object PlicMapper{
     val targetMapping = for(target <- targets) yield new Area {
       val thresholdOffset = targetThresholdOffset + (target.id << targetThresholdShift)
       val claimOffset = targetClaimOffset + (target.id << targetClaimShift)
-      if(targetThresholdWriteGen && !target.threshold.hasAssignement) bus.drive(target.threshold, address = thresholdOffset, documentation = s"Drive target threshold for target ${target.id}. inits to 0") init (0)
+      if(targetThresholdWriteGen && !target.threshold.hasAssignment) bus.drive(target.threshold, address = thresholdOffset, documentation = s"Drive target threshold for target ${target.id}. inits to 0") init (0)
       if(targetThresholdReadGen) bus.read(target.threshold, address = thresholdOffset, documentation = s"Read target threshold for target ${target.id}")
       bus.read(target.claim, address = claimOffset, documentation = s"Read target claim for target ${target.id} ")
       bus.onRead(claimOffset) {
@@ -154,7 +154,7 @@ object PlicMapper{
       for ((gateway, gatewayIndex) <- gateways.zipWithIndex) {
         val address = targetEnableOffset + (target.id << targetEnableShift) + bus.busDataWidth/8 * (gateway.id / bus.busDataWidth)
         val bitOffset = gateway.id % bus.busDataWidth
-        if(targetEnableWriteGen && !target.ie(gatewayIndex).hasAssignement) bus.drive(target.ie(gatewayIndex), address, bitOffset, documentation = s"Drive target enable for gateway ${gatewayIndex} for target ${target.id}. inits to 0b0") init(False)
+        if(targetEnableWriteGen && !target.ie(gatewayIndex).hasAssignment) bus.drive(target.ie(gatewayIndex), address, bitOffset, documentation = s"Drive target enable for gateway ${gatewayIndex} for target ${target.id}. inits to 0b0") init(False)
         if(targetEnableReadGen)  bus.read(target.ie(gatewayIndex),  address, bitOffset, documentation = s"Read target enable for gateway ${gatewayIndex} for target ${target.id}.")
       }
     }

--- a/lib/src/main/scala/spinal/lib/misc/plic/PlicTarget.scala
+++ b/lib/src/main/scala/spinal/lib/misc/plic/PlicTarget.scala
@@ -7,7 +7,7 @@ import scala.collection.Seq
 
 
 case class PlicTarget(id : Int, gateways : Seq[PlicGateway], priorityWidth : Int) extends Area{
-  assert(gateways.map(_.id).distinct.length == gateways.length, "PLIC gatways have duplicated ID")
+  assert(gateways.map(_.id).distinct.length == gateways.length, "PLIC gateways have duplicated ID")
   val ie = Vec.fill(gateways.length)(Bool())
   val threshold = UInt(priorityWidth bits)
   val idWidth = log2Up((gateways.map(_.id) ++ Seq(0)).max + 1)

--- a/lib/src/main/scala/spinal/lib/misc/plugin/Host.scala
+++ b/lib/src/main/scala/spinal/lib/misc/plugin/Host.scala
@@ -68,10 +68,10 @@ class PluginHost {
 
   def find[T: ClassTag](filter: T => Boolean) = findOption(filter).get
   def findOption[T: ClassTag](filter: T => Boolean) = {
-    val flitred = list[T].filter(filter)
-    flitred.size match {
+    val filtered = list[T].filter(filter)
+    filtered.size match {
       case 0 => None
-      case 1 => Some(flitred.head)
+      case 1 => Some(filtered.head)
     }
 
   }

--- a/lib/src/main/scala/spinal/lib/misc/test/DualSimTracer.scala
+++ b/lib/src/main/scala/spinal/lib/misc/test/DualSimTracer.scala
@@ -33,7 +33,7 @@ object DualSimTracer {
       try {
         compiled.doSimUntilVoid(name = s"explorer", seed = seed) { dut =>
           disableSimWave()
-          periodicaly(window) {
+          periodically(window) {
             mTime = simTime()
           }
           onSimEnd {

--- a/lib/src/main/scala/spinal/lib/pipeline/Stage.scala
+++ b/lib/src/main/scala/spinal/lib/pipeline/Stage.scala
@@ -163,7 +163,7 @@ class Stage(implicit _pip: Pipeline = null)  extends Area {
   def forkIt(cond : Bool)(implicit loc: Location) : Unit = internals.request.forks += nameFromLocation(CombInit(cond), "forkRequest")
   def spawnIt(cond : Bool)(implicit loc: Location) : Unit = internals.request.spawns += nameFromLocation(CombInit(cond), "spawnRequest")
 
-  //Not being root will not clear the output valid of the stage, which can be quite usefull
+  // Not being root will not clear the output valid of the stage, which can be quite useful.
   def flushIt(cond : Bool, root : Boolean = true) : Unit = {
     internals.request.flush += cond
     if(root) internals.request.flushRoot += cond
@@ -195,7 +195,7 @@ class Stage(implicit _pip: Pipeline = null)  extends Area {
     if(internals.arbitration.isFlushed == null) internals.arbitration.isFlushed = ContextSwapper.outsideCondScopeData(Bool())
     internals.arbitration.isFlushed
   }
-  //So, not realy well named, as it just check if a transaction is moving to the next stage (output.valid && output.ready)
+  // So, not really well named, as it just check if a transaction is moving to the next stage (output.valid && output.ready).
   def isForked : Bool = {
     if(internals.arbitration.isForked == null) internals.arbitration.isForked = ContextSwapper.outsideCondScopeData(Bool())
     internals.arbitration.isForked

--- a/lib/src/main/scala/spinal/lib/sim/Flow.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Flow.scala
@@ -66,7 +66,7 @@ class FlowDriver[T <: Data](flow: Flow[T], clockDomain: ClockDomain, var driver:
 
   var factor = Option.empty[Float]
   def setFactor(value: Float) = factor = Some(value)
-  def setFactorPeriodically(period: Long) = periodicaly(period)(setFactor(simRandom.nextFloat()))
+  def setFactorPeriodically(period: Long) = periodically(period)(setFactor(simRandom.nextFloat()))
 
 
   var state = 0

--- a/lib/src/main/scala/spinal/lib/sim/Misc.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Misc.scala
@@ -131,7 +131,7 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
   val content = mutable.HashMap[Long, Array[Byte]]()
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'getElseAllocate' instead", since = "1.14.0")
+  //@deprecated("Use correctly spelled 'getElseAllocate' instead", since = "1.15.0")
   def getElseAlocate(idx : Long) = getElseAllocate(idx)
 
   def getElseAllocate(idx : Long) = {

--- a/lib/src/main/scala/spinal/lib/sim/Misc.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Misc.scala
@@ -146,18 +146,18 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
   def write(address : Long, data : Int) : Unit = {
     for(i <- 0 to 3) {
       val a = address + i
-      getElseAlocate((a >> 20))(a.toInt & 0xFFFFF) = (data >> (i*8)).toByte
+      getElseAllocate((a >> 20))(a.toInt & 0xFFFFF) = (data >> (i*8)).toByte
     }
   }
   def write(address : Long, data : Long) : Unit = {
     for(i <- 0 to 7) {
       val a = address + i
-      getElseAlocate((a >> 20))(a.toInt & 0xFFFFF) = (data >> (i*8)).toByte
+      getElseAllocate((a >> 20))(a.toInt & 0xFFFFF) = (data >> (i*8)).toByte
     }
   }
 
   def write(address : Long, data : Byte) : Unit = {
-    getElseAlocate((address >> 20))(address.toInt & 0xFFFFF) = data
+    getElseAllocate((address >> 20))(address.toInt & 0xFFFFF) = data
   }
 
   def write(address : Long, data : Array[Byte]) : Unit = {
@@ -165,7 +165,7 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
     var ptr = address
     var offset = 0
     while(offset != size){
-      val mem = getElseAlocate((ptr >> 20))
+      val mem = getElseAllocate((ptr >> 20))
       do{
         mem(ptr.toInt & 0xFFFFF) = data(offset)
         ptr += 1
@@ -178,7 +178,7 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
     var ptr = address
     var offset = 0
     while(offset != size){
-      val mem = getElseAlocate((ptr >> 20))
+      val mem = getElseAllocate((ptr >> 20))
       do{
         if((mask(offset >> 3) & (1 << (offset & 7))) != 0) mem(ptr.toInt & 0xFFFFF) = data(offset)
         ptr += 1
@@ -191,7 +191,7 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
     var ptr = address
     var offset = 0
     while(offset != size){
-      val mem = getElseAlocate((ptr >> 20))
+      val mem = getElseAllocate((ptr >> 20))
       do{
         if(mask(offset)) mem(ptr.toInt & 0xFFFFF) = data(offset)
         ptr += 1
@@ -204,7 +204,7 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
     var ptr = address
     var offset = 0
     while(offset != size){
-      val mem = getElseAlocate((ptr >> 20))
+      val mem = getElseAllocate((ptr >> 20))
       do{
         if(mask(offset+dataSkip)) mem(ptr.toInt & 0xFFFFF) = data(offset+dataSkip)
         ptr += 1
@@ -222,7 +222,7 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
     var ptr = address
     var offset = 0
     while(offset != size){
-      val mem = getElseAlocate((ptr >> 20))
+      val mem = getElseAllocate((ptr >> 20))
       do{
         data(offset) = mem(ptr.toInt & 0xFFFFF)
         ptr += 1
@@ -236,7 +236,7 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
     var ptr = address
     var offset = 0
     while(offset != size) {
-      val mem = getElseAlocate((ptr >> 20))
+      val mem = getElseAllocate((ptr >> 20))
       do{
         dst(offset + dstOffset) = mem(ptr.toInt & 0xFFFFF)
         ptr += 1

--- a/lib/src/main/scala/spinal/lib/sim/Misc.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Misc.scala
@@ -130,7 +130,11 @@ class RandomGen(var state : Long = simRandom.nextLong()){
 case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset : Long = 0l){
   val content = mutable.HashMap[Long, Array[Byte]]()
 
-  def getElseAlocate(idx : Long) = {
+  // TODO enable deprecation
+  //@deprecated("Use correctly spelled 'getElseAllocate' instead", since = "1.14.0")
+  def getElseAlocate(idx : Long) = getElseAllocate(idx)
+
+  def getElseAllocate(idx : Long) = {
     content.get(idx) match {
       case Some(value) => value
       case None => val rand = new RandomGen(seed ^ ((idx << 20) + randOffset))
@@ -210,7 +214,7 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
   }
 
   def read(address : Long) : Byte = {
-    getElseAlocate((address >> 20))(address.toInt & 0xFFFFF)
+    getElseAllocate((address >> 20))(address.toInt & 0xFFFFF)
   }
 
   def readBytes(address : Long, size : Int) : Array[Byte] = {

--- a/lib/src/main/scala/spinal/lib/sim/Scoreboard.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Scoreboard.scala
@@ -60,7 +60,7 @@ class ScoreboardInOrder[T]() {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'checkEmptiness' instead", since = "1.14.0")
+  //@deprecated("Use correctly spelled 'checkEmptiness' instead", since = "1.15.0")
   def checkEmptyness(): Unit = checkEmptiness
 
   def checkEmptiness(): Unit ={

--- a/lib/src/main/scala/spinal/lib/sim/Scoreboard.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Scoreboard.scala
@@ -27,7 +27,7 @@ class ScoreboardInOrder[T]() {
 
   if(Phase.isUsed){
     Phase.check{
-      checkEmptyness()
+      checkEmptiness()
     }
   }
 
@@ -59,7 +59,11 @@ class ScoreboardInOrder[T]() {
     }
   }
 
-  def checkEmptyness(): Unit ={
+  // TODO enable deprecation
+  //@deprecated("Use correctly spelled 'checkEmptiness' instead", since = "1.14.0")
+  def checkEmptyness(): Unit = checkEmptiness
+
+  def checkEmptiness(): Unit ={
     if(dut.nonEmpty || ref.nonEmpty){
       if(dut.nonEmpty){
         println("Unmatched DUT transaction : \n")

--- a/lib/src/main/scala/spinal/lib/sim/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Stream.scala
@@ -95,7 +95,7 @@ class StreamDriver[T <: Data](stream : Stream[T], clockDomain: ClockDomain, var 
 
   var factor = Option.empty[Float]
   def setFactor(value : Float) = factor = Some(value)
-  def setFactorPeriodically(period : Long) = periodicaly(period)(setFactor(simRandom.nextFloat()))
+  def setFactorPeriodically(period : Long) = periodically(period)(setFactor(simRandom.nextFloat()))
 
   //The  following commented threaded code is the equivalent to the following uncommented thread-less code (nearly)
 //  fork{
@@ -171,7 +171,7 @@ object StreamReadyRandomizer {
 case class StreamReadyRandomizer[T <: Data](stream : Stream[T], clockDomain: ClockDomain,var condition: () => Boolean){
   var factor = 0.5f
   def setFactor(value : Float) = factor = value
-  def setFactorPeriodically(period : Long) = periodicaly(period)(setFactor(simRandom.nextFloat()))
+  def setFactorPeriodically(period : Long) = periodically(period)(setFactor(simRandom.nextFloat()))
   val readyProxy = stream.ready.simProxy()
   clockDomain.onSamplings{
     if (condition()) {

--- a/lib/src/main/scala/spinal/lib/sim/bus/wishbone/WishboneDriver.scala
+++ b/lib/src/main/scala/spinal/lib/sim/bus/wishbone/WishboneDriver.scala
@@ -28,7 +28,7 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
   }
 
   /** Drive the wishbone bus as master.
-    * @param transactions a sequence of transactions that compouse the wishbone cycle
+    * @param transactions a sequence of transactions that compose the wishbone cycle
     */
   def sendBlockAsMaster(transactions: Seq[WishboneTransaction], we: Boolean): Unit = {
     bus.CYC #= true
@@ -47,7 +47,7 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
   }
 
   /** Drive the wishbone bus as master in a pipelined way.
-    * @param transactions a sequence of transactions that compouse the wishbone cycle
+    * @param transactions a sequence of transactions that compose the wishbone cycle
     */
   def sendPipelinedBlockAsMaster(transactions: Seq[WishboneTransaction], we: Boolean): Unit = {
     bus.CYC #= true
@@ -65,7 +65,7 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
     bus.CYC #= false
   }
 
-  /** Drive the wishbone bus as slave with a transaction, and acknoledge the master.
+  /** Drive the wishbone bus as slave with a transaction, and acknowledge the master.
     * @param transaction The transaction to send.
     */
   def sendAsSlave(transaction : WishboneTransaction): Unit = {
@@ -78,7 +78,7 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
 
   /** Drive the wishbone bus as a slave.
     * this function can hang if the master require more transactions than specified
-    * @param transactions a sequence of transactions that compouse the wishbone cycle
+    * @param transactions a sequence of transactions that compose the wishbone cycle
     */
   def sendBlockAsSlave(transactions: Seq[WishboneTransaction]): Unit = {
     transactions.foreach{ transaction =>
@@ -88,7 +88,7 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
 
   /** Drive the wishbone bus as a slave in a pipelined way.
     * this function can hang if the master require more transactions than specified
-    * @param transactions a sequence of transactions that compouse the wishbone cycle
+    * @param transactions a sequence of transactions that compose the wishbone cycle
     */
   def sendPipelinedBlockAsSlave(transactions: Seq[WishboneTransaction]): Unit = {
     bus.ACK #= true
@@ -101,8 +101,8 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
   }
 
   /** Drive the wishbone bus.
-    * This will utomatically selects the wright function to use
-    * @param transactions a sequence of transactions that compouse the wishbone cycle
+    * This will automatically selects the right function to use.
+    * @param transactions a sequence of transactions that compose the wishbone cycle
     */
   def drive(transactions: Seq[WishboneTransaction], we: Boolean= true): Unit = {
     (bus.isMasterInterface,bus.config.isPipelined) match {
@@ -113,7 +113,7 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
     }
   }
 
-  /** Dumb slave acknoledge.
+  /** Dumb slave acknowledgment.
     */
   def slaveAckResponse(): Unit = {
     clockdomain.waitSamplingWhere(busStatus.isTransfer)
@@ -122,7 +122,7 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
     bus.ACK #= false
   }
 
-  /** Dumb acknoledge, as a pipelined slave.
+  /** Dumb acknowledgment, as a pipelined slave.
     */
   def slaveAckPipelinedResponse(): Unit = {
     clockdomain.waitSamplingWhere(busStatus.isCycle)
@@ -142,8 +142,8 @@ class WishboneDriver(bus: Wishbone, clockdomain: ClockDomain){
     cycle.join()
   }
 
-  /** Dumb slave acknoledge.
-    * This will utomatically selects the wright function to use
+  /** Dumb slave acknowledgment.
+    * This will automatically selects the right function to use.
     */
   def slaveSink(): Unit = {
     val dummy = fork{

--- a/lib/src/main/scala/spinal/lib/sim/bus/wishbone/WishboneMonitor.scala
+++ b/lib/src/main/scala/spinal/lib/sim/bus/wishbone/WishboneMonitor.scala
@@ -10,7 +10,7 @@ object WishboneMonitor{
   def apply(bus : Wishbone, clockdomain: ClockDomain)(callback: (Wishbone) => Unit) = new WishboneMonitor(bus,clockdomain).addCallback(callback)
 }
 
-/** This is a helping class for executing code when an acknoledge happend on the bus
+/** This is a helping class for executing code when an acknowledgment happens on the bus
   * @param bus the wishbone bus to drive
   * @param clockdomain the clockdomain where the bus reside
   */
@@ -18,7 +18,7 @@ class WishboneMonitor(bus: Wishbone, clockdomain: ClockDomain){
   val busStatus = WishboneStatus(bus)
   val callbacks = ArrayBuffer[(Wishbone) => Unit]()
 
-  /** Add a callback, this will be executed on every bus acknoledge
+  /** Add a callback, this will be executed on every bus acknowledgment
     * @param callback a function or code block that takes a wishbone bus as parameter
     */
   def addCallback(callback: (Wishbone) => Unit): Unit = callbacks += callback

--- a/lib/src/main/scala/spinal/lib/soc/pinsec/Pinsec.scala
+++ b/lib/src/main/scala/spinal/lib/soc/pinsec/Pinsec.scala
@@ -110,8 +110,8 @@ class Pinsec(config: PinsecConfig) extends Component{
     val axiResetUnbuffered  = False
     val coreResetUnbuffered = False
 
-    //Implement an counter to keep the reset axiResetOrder high 64 cycles
-    // Also this counter will automaticly do a reset when the system boot.
+    // Implement a counter to keep the reset axiResetOrder high 64 cycles
+    // Also this counter will automatically do a reset when the system boot.
     val axiResetCounter = Reg(UInt(6 bits)) init(0)
     when(axiResetCounter =/= U(axiResetCounter.range -> true)){
       axiResetCounter := axiResetCounter + 1

--- a/lib/src/main/scala/spinal/lib/system/debugger/SystemDebuggerBundles.scala
+++ b/lib/src/main/scala/spinal/lib/system/debugger/SystemDebuggerBundles.scala
@@ -49,7 +49,7 @@ case class SystemDebuggerMemBus(c: SystemDebuggerConfig) extends Bundle with IMa
     mm.read := cmd.valid && !cmd.wr
     mm.write := cmd.valid && cmd.wr
     mm.address := cmd.address(cmd.address.high downto 2) @@ U"00"
-    mm.writeData := cmd.data //No allignment needed, done by remote
+    mm.writeData := cmd.data // No alignment needed, done by remote
     mm.byteEnable := (cmd.size.mux (
       U(0) -> B"0001",
       U(1) -> B"0011",
@@ -77,7 +77,7 @@ case class SystemDebuggerMemBus(c: SystemDebuggerConfig) extends Bundle with IMa
     mm.cmd.arbitrationFrom(cmd)
     mm.cmd.write := cmd.wr
     mm.cmd.address := cmd.address(cmd.address.high downto 2) @@ U"00"
-    mm.cmd.data := cmd.data //No allignment needed, done by remote
+    mm.cmd.data := cmd.data // No alignment needed, done by remote
     mm.cmd.mask := (cmd.size.mux (
       U(0) -> B"0001",
       U(1) -> B"0011",
@@ -102,7 +102,7 @@ case class SystemDebuggerMemBus(c: SystemDebuggerConfig) extends Bundle with IMa
     mm.sharedCmd.addr  := cmdFork.address
     mm.sharedCmd.size  := cmdFork.size.resized
     mm.writeData.valid := dataFork.valid
-    mm.writeData.data  := dataFork.data //No allignment needed, done by remote
+    mm.writeData.data  := dataFork.data // No alignment needed, done by remote
     mm.writeData.strb  := (dataFork.size.mux (
       U(0) -> B"0001",
       U(1) -> B"0011",

--- a/lib/src/main/scala/spinal/lib/system/dma/sg/DmaSg.scala
+++ b/lib/src/main/scala/spinal/lib/system/dma/sg/DmaSg.scala
@@ -170,8 +170,8 @@ object DmaSg{
     def canOutput = outputsPorts.nonEmpty
 
     assert(linkedListCapable || directCtrlCapable, "A DMA channel should be at least controllable via a linked list or direct access")
-    assert(!(!directCtrlCapable && selfRestartCapable), "Channel self restart is only available if direct controle is enabled")
-    assert(memoryToMemory || inputsPorts.nonEmpty || outputsPorts.nonEmpty, "A DMA channel require at least one opperation (m->m, m->s, s->m)")
+    assert(!(!directCtrlCapable && selfRestartCapable), "Channel self restart is only available if direct control is enabled")
+    assert(memoryToMemory || inputsPorts.nonEmpty || outputsPorts.nonEmpty, "A DMA channel require at least one operation (m->m, m->s, s->m)")
     val withProgressCounter = progressProbes || halfCompletionInterrupt || linkedListCapable && canInput
     val withProgressCounterM2s = progressProbes || halfCompletionInterrupt
 
@@ -273,7 +273,7 @@ object DmaSg{
       val priority = Reg(UInt(p.memory.priorityWidth bits)) init(0)
       val weight = Reg(UInt(p.weightWidth bits)) init(0)
       val selfRestart = cp.selfRestartCapable generate Reg(Bool())
-      val readyToStop = True //todo Check s2b b2s transiants
+      val readyToStop = True //todo Check s2b b2s transients
 
 
 
@@ -1134,8 +1134,8 @@ object DmaSg{
         val oh = OHMasking.first(requests)
         val sel = OHMasking.first(requests)
         def channel[T <: Data](f: ChannelLogic => T, keep : ChannelLogic => Boolean = _ => true) = {
-          val (ohFiltred, channelsFiltred) = (oh.toSeq, channels).zipped.filter((a,b) => keep(b))
-          MuxOH(B(ohFiltred), channelsFiltred.map(f))
+          val (ohFiltered, channelsFiltered) = (oh.toSeq, channels).zipped.filter((a,b) => keep(b))
+          MuxOH(B(ohFiltered), channelsFiltered.map(f))
         }
         val head = channel(_.ll.head)
         val isJustASink = channel(_.descriptorValid)

--- a/lib/src/main/scala/spinal/lib/system/dma/sg/DmaSg.scala
+++ b/lib/src/main/scala/spinal/lib/system/dma/sg/DmaSg.scala
@@ -1694,7 +1694,7 @@ abstract class DmaSgTester(p : DmaSg.Parameter,
     val reservedSink = mutable.HashSet[Int]()
   }
 
-  periodicaly(10*1000){
+  periodically(10*1000){
     outputs.foreach(_.readyDriver.factor = simRandom.nextFloat)
   }
 

--- a/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
+++ b/lib/src/main/scala/spinal/lib/system/tag/Bus.scala
@@ -153,10 +153,10 @@ object MemoryConnection{
       val invertTransform = c.transformers.reverse
       val remapped = dmt.map { e =>
         val transformed = invertTransform.foldRight(e.mapping)((t, a) => a.withOffsetInvert(t))
-        val filtred = c.sToM(transformed)
+        val filtered = c.sToM(transformed)
         val where = new MappedNode(
           e.node,
-          filtred,
+          filtered,
           c.transformers ++ e.where.transformers
         )
         val transfers = c.sToM(e.transfers, e.where)
@@ -164,17 +164,17 @@ object MemoryConnection{
       }
 
       //Let's merge entries which target the same endpoint
-      val aggreged = mutable.LinkedHashMap[MappedNode, MemoryTransfers]()
+      val aggregated = mutable.LinkedHashMap[MappedNode, MemoryTransfers]()
       for (e <- remapped) {
-        aggreged.get(e.where) match {
-          case None => aggreged(e.where) = e.transfers
-          case Some(value) => aggreged(e.where) = {
+        aggregated.get(e.where) match {
+          case None => aggregated(e.where) = e.transfers
+          case Some(value) => aggregated(e.where) = {
             assert(e.transfers.intersect(value).isEmpty, "Same transfers can go to two different busses")
             e.transfers.mincover(value)
           }
         }
       }
-      ret ++= aggreged.map(e => new MappedTransfers(e._1, e._2))
+      ret ++= aggregated.map(e => new MappedTransfers(e._1, e._2))
     }
     ret
   }

--- a/tester/src/test/python/spinal/RiscvTester/RiscvTester.py
+++ b/tester/src/test/python/spinal/RiscvTester/RiscvTester.py
@@ -172,7 +172,7 @@ class Tester:
 
             if int(dut.io_iCheck_valid) == 1 :
               if (int(dut.io_iCheck_payload_address) & 3) != 0:
-                raise TestFailure("iCmd bad allignement")
+                raise TestFailure("iCmd bad alignment")
               if int(dut.io_iCheck_payload_data) != 0x00000013 and int(dut.io_iCheck_payload_data) != 0x01c02023 and int(dut.io_iCheck_payload_data) != 0xffc02e23 :
                 for i in range(0,4):
                   if self.rom[int(dut.io_iCheck_payload_address)+i] != ((int(dut.io_iCheck_payload_data) >> (i*8)) & 0xFF):

--- a/tester/src/test/scala/spinal/lib/SpinalSimDmaSg2ReadOnlyTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimDmaSg2ReadOnlyTester.scala
@@ -50,7 +50,7 @@ class SpinalSimDmaSg2ReadOnlyTester extends SpinalAnyFunSuite{
 
       val tasks = Queue[Task]()
       val bspReady = StreamReadyRandomizer(dut.io.bsb, dut.popCd)
-      periodicaly(10000){
+      periodically(10000) {
         bspReady.setFactor(simRandom.nextFloat())
       }
       val bsb = StreamMonitor(dut.io.bsb, dut.popCd){d =>

--- a/tester/src/test/scala/spinal/lib/SpinalSimDmaSg2WriteOnlyTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimDmaSg2WriteOnlyTester.scala
@@ -73,7 +73,7 @@ class SpinalSimDmaSg2WriteOnlyTester extends SpinalAnyFunSuite{
 
       val tasks = Queue[Task]()
       val bsbDriver = new BsbDriver(dut.io.bsb, cd)
-      periodicaly(10000){
+      periodically(10000) {
         bsbDriver.sd.setFactor(simRandom.nextFloat())
         mem.driver.driver.randomizeStallRate()
       }

--- a/tester/src/test/scala/spinal/lib/bus/tilelink/CacheTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/tilelink/CacheTester.scala
@@ -120,7 +120,7 @@ class CacheTester extends AnyFunSuite{
     tester.doSim("manual") { tb =>
 //      disableSimWave()
 
-      periodicaly(10000) {
+      periodically(10000) {
         tb.mastersStuff.foreach(_.agent.driver.driver.randomizeStallRate())
         tb.slavesStuff.foreach(_.model.driver.driver.randomizeStallRate())
       }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneBusInterfaceTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneBusInterfaceTester.scala
@@ -65,7 +65,7 @@ class SpinalSimWishboneBusInterfaceTester extends SpinalAnyFunSuite{
       dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0, 100), WishboneTransaction(1 * wordInc, 2)), we = true)
       dri.drive(scala.collection.immutable.Seq(WishboneTransaction(0), WishboneTransaction(1 * wordInc)), we = false)
 
-      sco.checkEmptyness()
+      sco.checkEmptiness()
     }
   }
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
@@ -57,7 +57,7 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
       dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10*wordInc, 200), WishboneTransaction(0, 2)), we = true)
       dri.drive(scala.collection.immutable.Seq(WishboneTransaction(10*wordInc), WishboneTransaction(0)), we = false)
 
-      scoreboard.checkEmptyness()
+      scoreboard.checkEmptiness()
 //
 //      for(repeat <- 0 until 100){
 //        driver.drive(for(x <- 1 to 10) yield WishboneTransaction(address=10).randomizeData(dut.io.bus.config.dataWidth), we = true)


### PR DESCRIPTION
This PR adds several method alternatives with corrected names. It also fix spelling errors in comments, local variables and error messages.

There is no change in the interface, and currently it doesn't emit any deprecation warning. The deprecation annotations are commented and ready for the next minor release:

```
  // TODO enable deprecation
  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.15.0")
  def hasAssignement : Boolean = hasAssignment

  def hasAssignment : Boolean = !this.dlcIsEmpty
```

I can set it to `1.14.2` and turn it on if it's a better. On a side note, I have seen that there is a 1.14.1 tag in git but no release on github, I don't know if it's normal.

# Impact on code generation

No change in code generation.
