### PR TITLE
keep enum name for localparam to avoid naming alias.

### DIFF
--- a/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/PhaseVerilog.scala
@@ -80,8 +80,7 @@ class PhaseVerilog(pc: PhaseContext, report: SpinalReport[_]) extends PhaseMisc 
 
       outFile.flush()
       outFile.close()
-    }
-    else {
+    } else {
       val fileList: mutable.LinkedHashSet[String] = new mutable.LinkedHashSet()
       // dump Enum define to define.v instead attach that on every .v file
       if(enums.nonEmpty){

--- a/core/src/main/scala/spinal/core/internals/VerilogBase.scala
+++ b/core/src/main/scala/spinal/core/internals/VerilogBase.scala
@@ -121,14 +121,14 @@ trait VerilogBase extends VhdlVerilogBase{
 
   def emitEnumLiteral[T <: SpinalEnum](senum: SpinalEnumElement[T], encoding: SpinalEnumEncoding, prefix: String = "`"): String = {
 //    prefix + senum.spinalEnum.getName() + "_" + encoding.getName() + "_" + senum.getName()
-    var prefix_fix = prefix;
+    var prefix_fix = prefix
     if(prefix=="`" && !senum.spinalEnum.isGlobalEnable) prefix_fix = ""
 
-    if(senum.spinalEnum.isPrefixEnable) {
-      val withEncoding = senum.spinalEnum.defaultEncoding != encoding && (senum.spinalEnum.defaultEncoding == native && encoding != binarySequential)
+    val withEncoding = senum.spinalEnum.defaultEncoding != encoding && (senum.spinalEnum.defaultEncoding == native && encoding != binarySequential)
+    if(senum.spinalEnum.isGlobalEnable) {
       prefix_fix + globalPrefix + senum.spinalEnum.getName() + (if(withEncoding) "_" + encoding.getName() else "") + "_" + senum.getName()
     } else {
-      prefix_fix + globalPrefix + senum.getName()
+      prefix_fix + senum.spinalEnum.getName() + (if(withEncoding) "_" + encoding.getName() else "") + "_" + senum.getName()
     }
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1887 

# Context, Motivation & Description
As described #1887 , there is a problem when set **enumPrefixEnable = false**.
This fix always add enum name as localparam prefix to avoid naming alias.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
`localparam` name changed for verilog code.
# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
