### PR TITLE
Add scaladoc for the FSM lib based on RTD doc

### DIFF
--- a/lib/src/main/scala/spinal/lib/fsm/State.scala
+++ b/lib/src/main/scala/spinal/lib/fsm/State.scala
@@ -30,13 +30,16 @@ import spinal.core._
 import scala.collection.mutable.ArrayBuffer
 
 /**
-  * This trait indicate the entry point of the state machine
+  * This trait indicate the entry point of the state machine.
+  * 
+  * @see [[setEntry]]
+  * @see [[StateEntryPoint]] 
   */
 trait EntryPoint
 
 
-/**
-  * Define the Entry point state
+/** Syntactic sugar for `new State with EntryPoint`
+  * @see [[EntryPoint]]
   */
 object StateEntryPoint {
   def apply()(implicit stateMachineAccessor: StateMachineAccessor): State = new State with EntryPoint
@@ -60,11 +63,37 @@ object State{
 }
 
 
-/**
-  * State
-  */
-
 case class StateMachineTask(priority : Int, body : () => Unit)
+
+/**
+  * Represents a state within a state machine.
+  * 
+  * States can define behaviors for entry, exit, and active phases using methods like `onEntry`, `onExit`, and `whenIsActive`.
+  * 
+  * @example {{{
+  *   val fsm = new StateMachine {
+  *     val stateA: State = new State with EntryPoint {
+  *       onEntry {
+  *         counter := 0
+  *       }
+  *       whenIsActive {
+  *         counter := counter + 1
+  *         when(counter === 4) {
+  *           goto(stateB)
+  *         }
+  *       }
+  *       onExit {
+  *         io.result := True
+  *       }
+  *     }
+  *     val stateB: State = new State {
+  *       whenIsActive {
+  *         goto(stateA)
+  *       }
+  *     }
+  *   }
+  * }}}
+  */
 class State(implicit stateMachineAccessor: StateMachineAccessor) extends Area with ScalaLocated {
 
   val onEntryTasks       = ArrayBuffer[() => Unit]()
@@ -74,42 +103,129 @@ class State(implicit stateMachineAccessor: StateMachineAccessor) extends Area wi
   val whenIsNextTasks    = ArrayBuffer[() => Unit]()
   @dontName var innerFsm = ArrayBuffer[StateMachine]()
 
+  /**
+    * Defines statements to apply when the state machine is not in this state 
+    * but will be in it during the next cycle.
+    *
+    * @param doThat hardware statement(s)
+    * 
+    * @example {{{
+    *   val stateA: State = new State with EntryPoint {
+    *     onEntry {
+    *       counter := 0
+    *       io.led := True
+    *     }
+    *     whenIsActive {
+    *       goto(stateB)
+    *     }
+    *   }
+    * }}}
+    */
   def onEntry(doThat: => Unit): this.type = {
     onEntryTasks += (() => doThat)
     this
   }
 
+  /**
+    * Defines statements applied when the state machine is in this state and
+    * will be in another state the next cycle.
+    *
+    * @param doThat Hardware statement(s)
+    * 
+    * @example {{{
+    *   val stateA: State = new State with EntryPoint {
+    *     whenIsActive {
+    *       goto(stateB)
+    *     }
+    *     onExit {
+    *       io.result := True
+    *       io.led := False
+    *     }
+    *   }
+    * }}}
+    */
   def onExit(doThat: => Unit): this.type = {
     onExitTasks += (() => doThat)
     this
   }
 
+  /**
+    * Defines statements applied when the state machine is in this state.
+    *
+    * @param doThat hardware statement(s)
+    * 
+    * @example {{{
+    *   val stateA: State = new State with EntryPoint {
+    *     whenIsActive {
+    *       counter := counter + 1
+    *       when(counter === 10) {
+    *         goto(stateB)
+    *       }
+    *     }
+    *   }
+    * }}}
+    */
   def whenIsActive(doThat: => Unit): this.type = {
     whenIsActiveWithPriority(0)(doThat)
     this
   }
 
+  /** Used internally by the state machine library 
+   * @see [[#whenIsActive()]]
+   */
   def whenIsActiveWithPriority(priority : Int)(doThat: => Unit): this.type = {
     whenActiveTasks += StateMachineTask(priority, () => doThat)
     this
   }
 
+  /**
+    * Defines statements applied when the state machine is not in this state.
+    *
+    * @param doThat hardware statement(s)
+    */
   def whenIsInactive(doThat: => Unit): this.type = {
     whenInactiveTasks += (() => doThat)
     this
   }
 
+  /**
+    * Defines statements applied when the state machine will be in state the 
+    * next cycle (even if it is already in it).
+    */
   def whenIsNext(doThat: => Unit): this.type = {
     whenIsNextTasks += (() => doThat)
     this
   }
 
+  /**
+    * Schedules the state machine to be in the provided [[State]] the next cycle.
+    *
+    * @param state [[State]] to transition to.
+    * 
+    * @example {{{
+    *   val pingState: State = new State with EntryPoint {
+    *     whenIsActive {
+    *       goto(pongState)
+    *     }
+    *   }
+    *   val pongState: State = new State {
+    *     whenIsActive {
+    *       goto(pingState)
+    *     }
+    *   }
+    * }}}
+    */
   def goto(state: State) = stateMachineAccessor.goto(state)
 
+  /** Internal to the state machine library */
   def innerFsm(that: => StateMachine): Unit = innerFsm += that
 
+  /** Schedules the state machine to be in the boot state the next cycle 
+    * (or, in [[StateFsm]], to exit the current nested state machine).
+    */
   def exit(): Unit = stateMachineAccessor.exitFsm()
 
+  /** Used internally by the state machine library */
   def getStateMachineAccessor() = stateMachineAccessor
 
   val stateId = stateMachineAccessor.add(this)
@@ -119,7 +235,40 @@ class State(implicit stateMachineAccessor: StateMachineAccessor) extends Area wi
 
 
 /**
-  * Use to execute a State machine into a stateMachine
+  * Allows you to describe a state containing a nested state machine.
+  * 
+  * When the nested state machine is done (exited), statements in whenCompleted { ... } are executed.
+  * 
+  * This allows embedding a state machine as a state within another state machine. The embedded state machine starts on entry and completes on exit.
+  * 
+  * @example {{{
+  *   // internalFsm is a function defined below
+  *   val stateC = new StateFsm(fsm=internalFsm()) {
+  *     whenCompleted {
+  *       goto(stateD)
+  *     }
+  *   }
+  *   
+  *   def internalFsm() = new StateMachine {
+  *     val counter = Reg(UInt(8 bits)) init(0)
+  *   
+  *     val stateA : State = new State with EntryPoint {
+  *       whenIsActive {
+  *         goto(stateB)
+  *       }
+  *     }
+  *   
+  *     val stateB : State = new State {
+  *       onEntry (counter := 0)
+  *       whenIsActive {
+  *         when(counter === 4) {
+  *           exit()
+  *         }
+  *         counter := counter + 1
+  *       }
+  *     }
+  *   }
+  * }}}
   */
 class StateFsm[T <: StateMachineAccessor](val fsm:  T)(implicit stateMachineAccessor: StateMachineAccessor) extends State with StateCompletionTrait {
   valCallback(fsm, "fsm") //Provide naming to the fsm instance
@@ -140,9 +289,7 @@ class StateFsm[T <: StateMachineAccessor](val fsm:  T)(implicit stateMachineAcce
 }
 
 
-/**
-  * Run several state machine in Serie
-  */
+/** Runs several state machine in serially */
 object StatesSerialFsm {
 
   def apply(_fsms:  StateMachineAccessor*)(doWhenCompleted: (State) =>  Unit)(implicit stateMachineAccessor: StateMachineAccessor): Seq[State] = {
@@ -163,9 +310,18 @@ object StatesSerialFsm {
   }
 }
 
-
 /**
-  * Run several state machine in parallel
+  * Allows you to handle multiple nested state machines. 
+  * 
+  * When all nested state machine are done, statements in whenCompleted { ... } are executed.
+  * 
+  * @example {{{
+  *   val stateD = new StateParallelFsm (internalFsmA(), internalFsmB()) {
+  *     whenCompleted {
+  *       goto(stateE)
+  *     }
+  *   }
+  * }}}
   */
 class StateParallelFsm(val _fsms: StateMachineAccessor*)(implicit stateMachineAccessor: StateMachineAccessor) extends State with StateCompletionTrait {
   val fsms = _fsms
@@ -204,20 +360,24 @@ class StateMachineSharableRegUInt {
 
 
 /**
-  * State Delay
-  *
+  * Allows you to create a state which waits for a fixed number of cycles
+  * before executing statements in whenCompleted {...}.
+  * 
+  * The preferred way to use it is:
+  *  
   * @example {{{
-  *   val fsm = new StateMachine {
-  *      ...
-  *     val sDelay: State = new StateDelay(10 us){
-  *       whenCompleted {
-  *         goto(sIdle)
-  *       }
+  *   val stateG : State = new StateDelay(cyclesCount=40) {
+  *     whenCompleted {
+  *       goto(stateH)
   *     }
-  *     ...
   *   }
   * }}}
-  *
+  * 
+  * It can also be written in one line:
+  *  
+  * @example {{{
+  *   val stateG : State = new StateDelay(40) { whenCompleted(goto(stateH)) }
+  * }}}
   */
 class StateDelay(cyclesCount: AnyRef, minWidth: Int)(implicit stateMachineAccessor: StateMachineAccessor)
     extends State

--- a/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
+++ b/lib/src/main/scala/spinal/lib/fsm/StateMachine.scala
@@ -34,11 +34,21 @@ import scala.collection.mutable.ArrayBuffer
 
 trait StateMachineAccessor {
 
+  /**
+    * Defines a State as the entry point.
+    *
+    * @see [[EntryPoint]]
+    */
   def setEntry(state: State): Unit
   def getEntry(): State
 
+  /** Returns [[True]] when the state machine is in the given state */
   def isActive(state: State): Bool
+
+  /** Returns [[True]] when the state machine is entering the given state */
   def isEntering(state: State): Bool
+
+  /** Returns [[True]] when the state machine is exiting the given state */
   def isExiting(state: State): Bool
 
   def goto(state: State): Unit
@@ -90,26 +100,27 @@ class StateMachineEnum extends SpinalEnum
 
 
 /**
-  * State machine
-  *
+  * Defines a state machine with states and transitions.
+  * 
   * @example {{{
   *   val fsm = new StateMachine {
-  *     val sIdle: State = StateEntryPoint{
+  *     val idleState: State = StateEntryPoint{
   *       ...
   *     }
-  *     val sState1: State = new State {
-  *       whenIsActive{
-  *         goto(sIdle)
+  *     val firstState: State = new State {
+  *       whenIsActive {
+  *         goto(idleState)
   *       }
   *     }
-  *     ...
   *   }
   * }}}
+  * 
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/fsm.html State machine library documentation]]
   */
 class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
 
   /**
-    * Set the condition for state transitions
+    * Set the condition for state transitions.
     *
     * goto() will only have an effect, if condition is True
     */
@@ -132,7 +143,31 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
     corruptedState
   }
 
+  /**
+    * Sets the encoding for the state machine states.
+    *
+    * By default the FSM state vector will be encoded using the native encoding
+    * of the language/tools the RTL is generated for (Verilog or VHDL). This 
+    * default can be overridden by using the setEncoding(...) method which 
+    * either takes a [[SpinalEnumEncoding]] or varargs of type ([[State]], [[BigInt]]) 
+    * for a custom encoding. 
+    */
   def setEncoding(encoding: SpinalEnumEncoding): Unit = enumDef.defaultEncoding = encoding
+  
+  /**
+    * Sets a custom encoding for the state machine states.
+    *
+    * @param spec A mapping of states to their encoded values
+    * 
+    * @example {{{
+    *   val fsm = new StateMachine {
+    *     val stateA = new State with EntryPoint
+    *     val stateB = new State
+    *     ...
+    *     setEncoding((stateA -> 0x23), (stateB -> 0x22))
+    *   }
+    * }}}
+    */
   def setEncoding(spec: (State, BigInt)*): Unit = {
     val mapping = spec.map(e => states.indexOf(e._1) -> e._2).toMapLinked()
     enumDef.defaultEncoding = SpinalEnumEncoding(mapping.apply)
@@ -170,7 +205,17 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
 
   var stateBoot : State = new State()(this).setCompositeName(this, "BOOT", Nameable.DATAMODEL_WEAK)
 
-  def makeInstantEntry(): State ={
+  /**
+    * Returns the boot state, active directly after reset.
+    * 
+    * This allows to have the state machine directly booting into a user state.
+    *
+    * Note that the onEntry of that state will only be called when it transitions 
+    * from another state to this state and not during boot.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/fsm.html#notes-about-the-entry-state FSM library boot documentation]]
+    */
+  def makeInstantEntry(): State = {
     setEntry(stateBoot.unsetName())
     stateBoot
   }
@@ -326,6 +371,19 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
     stateNext := enumOf(state)
   }
 
+  /**
+    * Allows to do define statement(s) after the elaboration fo the state machine.
+    * 
+    * This could be useful if access to `stateReg` is needed:     
+    * @example {{{
+    *   //  After or inside the fsm's definition.
+    *   fsm.postBuild {
+    *     io.status := fsm.stateReg.asBits // io.status is the signal user want to assigned to.
+    *   }
+    * }}}
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/fsm.html#notes-about-using-state-value FSM library doc about accessing state value]]
+    */
   def postBuild(body : => Unit){
     builded match {
       case false => postBuildTasks += (() => body)
@@ -405,7 +463,7 @@ class StateMachine extends Area with StateMachineAccessor with ScalaLocated {
   def isRunning = isStarted
 }
 
-
+// TODO document this
 class StateMachineSlave extends StateMachine{
   disableAutoStart()
 }


### PR DESCRIPTION
I used the SpinalDoc-RTD to add scaladoc the the state machine library.

This way a developer can quickly access the doc when coding.

Still open but not blocking for PR:

* `StateMachineSlave` is not documented
* the method `innerFsm` is not used anywhere (at least in this repos code). It's a bit confusing, because some example use classes or variables using this name. Perhaps we should remote it or deprecate it.
* I added a scaladoc description as "used internally" for `getStateMachineAccessor` `whenIsActiveWithPriority`. Perhaps we should make them protected or private, but it could break things, I don't know

# Impact on code generation

Do not change the scala code an thus the generation as well.


