### PR TITLE
Remove trivial warnings

### DIFF
--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -124,7 +124,7 @@ abstract class BitVector extends BaseType with Widthable {
 
     var result = cloneOf(this).asInstanceOf[T]
     result := this.asInstanceOf[T]
-    for(i <- that.range){
+    for(i <- that.bitsRange) {
       result \= (that(i) ? result.rotateLeft(1 << i).asInstanceOf[T] | result)
     }
     result
@@ -139,7 +139,7 @@ abstract class BitVector extends BaseType with Widthable {
 
     var result = cloneOf(this).asInstanceOf[T]
     result := this.asInstanceOf[T]
-    for(i <- that.range){
+    for(i <- that.bitsRange) {
       result \= (that(i) ? result.rotateRight(1 << i).asInstanceOf[T] | result)
     }
     result

--- a/core/src/main/scala/spinal/core/fiber/Misc.scala
+++ b/core/src/main/scala/spinal/core/fiber/Misc.scala
@@ -24,7 +24,7 @@ case class Lock() extends Handle[Int]{
 }
 
 
-trait Lockable extends Area{
+trait Lockable extends Area {
   val lock = spinal.core.fiber.Lock()
   def retain() = lock.retain()
   def release() = lock.release()
@@ -34,13 +34,13 @@ trait Lockable extends Area{
 class RetainerHold extends Handle[Unit] {
   def release() = {
     assert(!isLoaded, "Double retainer release :(")
-    load()
+    load(())
   }
-  def done() = load()
+  def done() = load(())
 }
 
 
-case class Retainer() extends Area{
+case class Retainer() extends Area {
   val retainers = mutable.Queue[RetainerHold]()
   def apply() : RetainerHold = {
     val rh = new RetainerHold()

--- a/idslplugin/src/main/scala/spinal/idslplugin/components/MainTransformer.scala
+++ b/idslplugin/src/main/scala/spinal/idslplugin/components/MainTransformer.scala
@@ -68,9 +68,9 @@ class MainTransformer(val global: Global) extends PluginComponent with Transform
                 val sel = Select(thiz, func)
                 val appl = Apply(sel, List(vd.rhs, lit))
 
-                thiz.tpe = clazz.tpe
-                sel.tpe = func.tpe
-                appl.tpe = definitions.UnitTpe
+                thiz.setType(clazz.tpe)
+                sel.setType(func.tpe)
+                appl.setType(definitions.UnitTpe)
                 lit.setType(definitions.StringTpe)
                 treeCopy.ValDef(vd, vd.mods, vd.name, vd.tpt, appl)
               case e => e
@@ -99,8 +99,8 @@ class MainTransformer(val global: Global) extends PluginComponent with Transform
                 val func = tpe.members.find(_.name.toString == "postInitCallback").get
                 val sel = Select(a, func.name)
                 val appl = Apply(sel, Nil)
-                sel.tpe = MethodType(Nil, a.tpe)
-                appl.tpe = a.tpe
+                sel.setType(MethodType(Nil, a.tpe))
+                appl.setType(a.tpe)
                 ret = appl
               }
             }
@@ -124,9 +124,9 @@ class MainTransformer(val global: Global) extends PluginComponent with Transform
                 val sel = Select(thiz, func)
                 val appl = Apply(sel, List(vd.rhs, lit))
 
-                thiz.tpe = clazz.tpe
-                sel.tpe = func.tpe
-                appl.tpe = definitions.UnitTpe
+                thiz.setType(clazz.tpe)
+                sel.setType(func.tpe)
+                appl.setType(definitions.UnitTpe)
                 lit.setType(definitions.StringTpe)
                 treeCopy.ValDef(vd, vd.mods, vd.name, vd.tpt, appl)
               case e => e

--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -91,7 +91,7 @@ object OHToUInt {
     if (mapping.size == 1) {
       ret := mapping.head
     } else {
-      for (bitId <- ret.range) {
+      for (bitId <- ret.bitsRange) {
         val triggersId = mapping.zipWithIndex.filter(e => ((e._1 >> bitId) & 1) != 0).map(_._2)
         val triggers = triggersId.map(oh(_))
         ret(bitId) := triggers.orR
@@ -491,7 +491,7 @@ object EndiannessSwap{
 object Reverse{
   def apply[T <: BitVector](that : T) : T = {
     val ret = cloneOf(that)
-    for(i <- that.range){
+    for(i <- that.bitsRange) {
       ret(i) := that(that.getWidth-1-i)
     }
     ret
@@ -1732,7 +1732,7 @@ object Shift {
   def rightWithScrap(that : Bits, by : UInt) : Bits = {
     var logic = that
     val scrap = False
-    for(i <- by.range){
+    for(i <- by.bitsRange) {
       scrap setWhen(by(i) && logic(0, 1 << i bits) =/= 0)
       logic \= by(i) ? (logic |>> (BigInt(1) << i)) | logic
     }

--- a/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3.scala
@@ -159,7 +159,7 @@ case class AhbLite3(config: AhbLite3Config) extends Bundle with IMasterSlave {
     val low  =  HADDR(config.symboleRange)
     val high = HADDR(config.symboleRange) + Vec((0 to config.bytePerWord).map(idx => idx === HSIZE)).asBits.asUInt
 
-    for(idx <- lowMask.range){
+    for(idx <- lowMask.bitsRange) {
       lowMask(idx)  := (if(idx != low.maxValue) low <= idx else True)
       highMask(idx) := high > idx
     }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Channel.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axi/Axi4Channel.scala
@@ -389,15 +389,15 @@ object Axi4Priv{
     assert(stream.config.addressWidth >= sink.config.addressWidth, s"Expect $stream addressWidth=${stream.config.addressWidth} >= $sink addressWidth=${sink.config.addressWidth}")
 
     sink.addr := stream.addr.resized
-    driveWeak(stream,sink,stream.id,sink.id,() => U(sink.id.range -> false),true,false)
-    driveWeak(stream,sink,stream.region,sink.region,() => B(sink.region.range -> false),false,true)
-    driveWeak(stream,sink,stream.len,sink.len,() => U(sink.len.range -> false),false,false)
+    driveWeak(stream,sink,stream.id,sink.id,() => U(sink.id.bitsRange -> false),true,false)
+    driveWeak(stream,sink,stream.region,sink.region,() => B(sink.region.bitsRange -> false),false,true)
+    driveWeak(stream,sink,stream.len,sink.len,() => U(sink.len.bitsRange -> false),false,false)
     driveWeak(stream,sink,stream.size,sink.size,() => U(log2Up(sink.config.dataWidth/8)),false,false)
     driveWeak(stream,sink,stream.burst,sink.burst,() => Axi4.burst.INCR,false,false)
     driveWeak(stream,sink,stream.lock,sink.lock,() => Axi4.lock.NORMAL,false,true)
     driveWeak(stream,sink,stream.cache,sink.cache,() => B"0000",false,true)
     driveWeak(stream,sink,stream.qos,sink.qos,() => B"0000",false,true)
-    driveWeak(stream,sink,stream.user,sink.user,() => B(sink.user.range -> false),true,true)
+    driveWeak(stream,sink,stream.user,sink.user,() => B(sink.user.bitsRange -> false),true,true)
     driveWeak(stream,sink,stream.prot,sink.prot,() => B"010",false,true)
     driveWeak(stream,sink,stream.allStrb,sink.allStrb,() => False,false,true)
   }
@@ -452,8 +452,8 @@ object Axi4W{
     def drive(sink: Stream[Axi4W]): Unit = {
       sink.arbitrationFrom(stream)
       sink.data := stream.data
-      Axi4Priv.driveWeak(stream,sink,stream.strb,sink.strb,() => B(sink.strb.range -> true),false,false)
-      Axi4Priv.driveWeak(stream,sink,stream.user,sink.user,() => B(sink.user.range -> false),false,true)
+      Axi4Priv.driveWeak(stream,sink,stream.strb,sink.strb,() => B(sink.strb.bitsRange -> true),false,false)
+      Axi4Priv.driveWeak(stream,sink,stream.user,sink.user,() => B(sink.user.bitsRange -> false),false,true)
       Axi4Priv.driveWeak(stream,sink,stream.last,sink.last,null,false,true)
       Axi4Priv.driveWeak(stream,sink,stream.id,sink.id,null,true,true)
     }
@@ -469,7 +469,7 @@ object Axi4B{
 
       Axi4Priv.driveWeak(stream,sink,stream.id,sink.id,null,true,true)
       Axi4Priv.driveWeak(stream,sink,stream.resp,sink.resp,() => Axi4.resp.OKAY,false,true)
-      Axi4Priv.driveWeak(stream,sink,stream.user,sink.user,() => B(sink.user.range -> false),false,true)
+      Axi4Priv.driveWeak(stream,sink,stream.user,sink.user,() => B(sink.user.bitsRange -> false),false,true)
     }
   }
 }
@@ -484,7 +484,7 @@ object Axi4R{
       Axi4Priv.driveWeak(stream,sink,stream.last,sink.last,null,false,true)
       Axi4Priv.driveWeak(stream,sink,stream.id,sink.id,null,true,true)
       Axi4Priv.driveWeak(stream,sink,stream.resp,sink.resp,() => Axi4.resp.OKAY,false,true)
-      Axi4Priv.driveWeak(stream,sink,stream.user,sink.user,() => B(sink.user.range -> false),false,true)
+      Axi4Priv.driveWeak(stream,sink,stream.user,sink.user,() => B(sink.user.bitsRange -> false),false,true)
     }
   }
 }

--- a/lib/src/main/scala/spinal/lib/bus/bmb/BmbSpecificBridges.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bmb/BmbSpecificBridges.scala
@@ -117,7 +117,7 @@ case class BmbAligner(ip : BmbParameter, alignmentWidth : Int) extends Component
           transferCounter := 0
         }
 
-        drop setWhen(!context.write && (io.input.rsp.first && beatCounter(context.paddings.range) < context.paddings || transferCounter > context.transfers))
+        drop setWhen(!context.write && (io.input.rsp.first && beatCounter(context.paddings.bitsRange) < context.paddings || transferCounter > context.transfers))
 
         io.input.rsp.last setWhen(transferCounter === context.transfers)
         io.input.rsp.data := io.output.rsp.data

--- a/lib/src/main/scala/spinal/lib/bus/bmb/sim/BmbMemoryTester.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bmb/sim/BmbMemoryTester.scala
@@ -38,7 +38,7 @@ class BmbMemoryTester(bmb : Bmb,
       override def onRspRead(address: BigInt, data: Byte): Unit = assert(data == memory.getByte(address.toLong), f"$address%x -> dut=$data%x expect ${memory.getByte(address.toLong)}%x")
       override def getCmd(): () => Unit = if(Phase.stimulus.isActive || cmdQueue.nonEmpty) super.getCmd() else null
       override def regionAllocate(sizeMax : Int): SizeMapping = regions.allocate(addressGen, sizeMax, busP, checkAvailability = checkAvailability)
-      override def regionFree(region: SizeMapping): Unit = if(checkAvailability) regions.free(region) else true
+      override def regionFree(region: SizeMapping): Unit = if(checkAvailability) regions.free(region)
       override def regionIsMapped(region: SizeMapping, opcode : Int): Boolean = true
     }
     onMasterAgentCreate(masterAgent)

--- a/lib/src/main/scala/spinal/lib/bus/bsb/BsbUpSizerSparse.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bsb/BsbUpSizerSparse.scala
@@ -13,7 +13,7 @@ class BsbUpSizerSparse(p : BsbParameter, outputBytes : Int) extends Component{
   val ratio = outputBytes/p.byteCount
   io.output.arbitrationFrom(io.input)
   io.output.data.assignDontCare()
-  io.output.data(io.input.data.range)   := io.input.data
+  io.output.data(io.input.data.bitsRange)   := io.input.data
   io.output.mask   := io.input.mask.resized
   io.output.source := io.input.source
   io.output.sink   := io.input.sink

--- a/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
@@ -816,7 +816,7 @@ object SpiXdrMasterCtrl {
 
       //Generate SCLK
       val sclkWrite = B(0, p.spi.ioRate bits)
-      io.spi.sclk.write := sclkWrite ^ B(sclkWrite.range -> io.config.kind.cpol)
+      io.spi.sclk.write := sclkWrite ^ B(sclkWrite.bitsRange -> io.config.kind.cpol)
       when(io.cmd.valid && io.cmd.isData){
         switch(io.config.mod) {
           for (m <- p.mods) {

--- a/lib/src/main/scala/spinal/lib/com/usb/ohci/UsbOhci.scala
+++ b/lib/src/main/scala/spinal/lib/com/usb/ohci/UsbOhci.scala
@@ -765,7 +765,7 @@ case class UsbOhci(p : UsbOhciParameter, ctrlParameter : BmbParameter) extends C
 
       val isoRelativeFrameNumber = reg.hcFmNumber.FN - SF
       val tooEarly = isoRelativeFrameNumber.msb
-      val isoFrameNumber = isoRelativeFrameNumber(FC.range)
+      val isoFrameNumber = isoRelativeFrameNumber(FC.bitsRange)
       val isoOverrun = !tooEarly && isoRelativeFrameNumber > FC
       val isoOverrunReg = RegNext(isoOverrun)
       val isoLast = !isoOverrun && !tooEarly && isoFrameNumber === FC

--- a/lib/src/main/scala/spinal/lib/cpu/riscv/debug/DebugModule.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/debug/DebugModule.scala
@@ -56,14 +56,14 @@ object DebugModuleCmdErr extends SpinalEnum(binarySequential){
 }
 
 case class DebugSysBusCmd() extends Bundle{
-  val wr = Bool
+  val wr = Bool()
   val address = UInt(32 bits)
   val data = Bits(32 bit)
   val size = UInt(2 bit)
 }
 
 case class DebugSysBusRsp() extends Bundle{
-  val error = Bool
+  val error = Bool()
   val data = Bits(32 bit)
 }
 

--- a/lib/src/main/scala/spinal/lib/cpu/riscv/impl/ICache.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/impl/ICache.scala
@@ -204,7 +204,7 @@ class InstructionCache(implicit p : InstructionCacheConfig) extends Component{
     }
 
     val readyDelay = Reg(UInt(1 bit))
-    when(loadedWordsNext === B(loadedWordsNext.range -> true)){
+    when(loadedWordsNext === B(loadedWordsNext.bitsRange -> true)) {
       readyDelay := readyDelay + 1
     }
     request.ready := readyDelay === 1

--- a/lib/src/main/scala/spinal/lib/cpu/riscv/impl/extension/DebugExtension.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/impl/extension/DebugExtension.scala
@@ -141,10 +141,10 @@ class DebugExtension(val clockDomain: ClockDomain) extends CoreExtension{
       } otherwise{
         when(io.bus.cmd.wr){
           core.writeBack.regFileWrite.valid := True
-          core.writeBack.regFileWrite.address := io.bus.cmd.address(core.writeBack.regFileWrite.address.range)
+          core.writeBack.regFileWrite.address := io.bus.cmd.address(core.writeBack.regFileWrite.address.bitsRange)
           core.writeBack.regFileWrite.data := io.bus.cmd.data
         } otherwise {
-          core.decode.regFileReadAddress0 := io.bus.cmd.address(core.writeBack.regFileWrite.address.range)
+          core.decode.regFileReadAddress0 := io.bus.cmd.address(core.writeBack.regFileWrite.address.bitsRange)
           core.c.regFileReadyKind match{
             case `async` => busReadDataReg := core.decode.src0
             case `sync` => readRegFileReg := True

--- a/lib/src/main/scala/spinal/lib/cpu/riscv/impl/extension/SimpleInterruptExtension.scala
+++ b/lib/src/main/scala/spinal/lib/cpu/riscv/impl/extension/SimpleInterruptExtension.scala
@@ -14,7 +14,7 @@ class SimpleInterruptExtension(exceptionVector : Int) extends CoreExtension{
     this
   }
   def addIrq(id : Int,pins : Bits,irqUsage: IrqUsage,name : String): this.type = {
-    for(i <- pins.range){
+    for(i <- pins.bitsRange) {
       interruptUsage(i + id) = Tuple3(pins(i),name + "_" + i, irqUsage)
     }
     this

--- a/lib/src/main/scala/spinal/lib/memory/sdram/dfi/function/BmbSpliter.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/dfi/function/BmbSpliter.scala
@@ -151,7 +151,7 @@ case class BmbAligner(ip: BmbParameter, alignmentWidth: Int) extends Component {
         }
 
         drop setWhen (!context.write && (io.input.rsp.first && beatCounter(
-          context.paddings.range
+          context.paddings.bitsRange
         ) < context.paddings || transferCounter > context.transfers))
 
         io.input.rsp.last setWhen (transferCounter === context.transfers & (transferCounter =/= 0))

--- a/lib/src/main/scala/spinal/lib/memory/sdram/sdr/SdramCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/memory/sdram/sdr/SdramCtrl.scala
@@ -145,7 +145,7 @@ case class SdramCtrl[T <: Data](l : SdramLayout, t : SdramTimings, CAS : Int, co
     val done = RegInit(False)
     when(!done) {
       counter := counter + 1
-      when(counter === U(counter.range -> true)) {
+      when(counter === U(counter.bitsRange -> true)) {
         done := True
       }
     }
@@ -363,7 +363,7 @@ case class SdramCtrl[T <: Data](l : SdramLayout, t : SdramTimings, CAS : Int, co
       sdram.WEn  := True
       sdram.DQ.write := cmd.data
       sdram.DQ.writeEnable := 0
-      sdram.DQM := (sdram.DQM.range -> !readHistory(if(CAS == 3) 1 else 0))
+      sdram.DQM := (sdram.DQM.bitsRange -> !readHistory(if(CAS == 3) 1 else 0))
 
       when(cmd.valid) {
         switch(cmd.task) {

--- a/lib/src/main/scala/spinal/lib/soc/pinsec/Pinsec.scala
+++ b/lib/src/main/scala/spinal/lib/soc/pinsec/Pinsec.scala
@@ -113,7 +113,7 @@ class Pinsec(config: PinsecConfig) extends Component{
     // Implement a counter to keep the reset axiResetOrder high 64 cycles
     // Also this counter will automatically do a reset when the system boot.
     val axiResetCounter = Reg(UInt(6 bits)) init(0)
-    when(axiResetCounter =/= U(axiResetCounter.range -> true)){
+    when(axiResetCounter =/= U(axiResetCounter.bitsRange -> true)){
       axiResetCounter := axiResetCounter + 1
       axiResetUnbuffered := True
     }

--- a/lib/src/main/scala/spinal/lib/system/dma/sg/DmaSg.scala
+++ b/lib/src/main/scala/spinal/lib/system/dma/sg/DmaSg.scala
@@ -852,7 +852,7 @@ object DmaSg{
 
         val first = io.read.rsp.first
         val last = io.read.rsp.last
-        for (byteId <- memory.ports.m2b.cmd.mask.range) {
+        for (byteId <- memory.ports.m2b.cmd.mask.bitsRange) {
           val toLow = first && byteId < context.start
           val toHigh = last && byteId > context.stop
           memory.ports.m2b.cmd.mask(byteId) := !toLow && !toHigh

--- a/scalaplugin/src/main/scala/spinal/idscp/components/MainTransformer.scala
+++ b/scalaplugin/src/main/scala/spinal/idscp/components/MainTransformer.scala
@@ -40,10 +40,10 @@ class MainTransformer(val global: Global) extends PluginComponent with Transform
               val lit = Literal(const)
               val ident = Select(thiz, name)
               val appl = Apply(sel, List(ident, lit))
-              ident.tpe = definitions.AnyTpe
-              thiz.tpe = clazz.tpe
-              sel.tpe = MethodType(List(definitions.AnyTpe.termSymbol, definitions.StringTpe.termSymbol), definitions.UnitTpe)
-              appl.tpe = definitions.UnitTpe
+              ident.setType(definitions.AnyTpe)
+              thiz.setType(clazz.tpe)
+              sel.setType(MethodType(List(definitions.AnyTpe.termSymbol, definitions.StringTpe.termSymbol), definitions.UnitTpe))
+              appl.setType(definitions.UnitTpe)
               lit.setType(definitions.StringTpe)
               appl
             }
@@ -76,8 +76,8 @@ class MainTransformer(val global: Global) extends PluginComponent with Transform
                 val func = tpe.members.find(_.name.toString == "postInitCallback").get
                 val sel = Select(a, func.name)
                 val appl = Apply(sel, Nil)
-                sel.tpe = MethodType(Nil, a.tpe)
-                appl.tpe = a.tpe
+                sel.setType(MethodType(Nil, a.tpe))
+                appl.setType(a.tpe)
                 ret = appl
               }
             }

--- a/tester/src/main/scala/spinal/tester/SpinalSimTester.scala
+++ b/tester/src/main/scala/spinal/tester/SpinalSimTester.scala
@@ -2,7 +2,6 @@ package spinal.tester
 
 import spinal.core._
 import spinal.core.sim.{SpinalSimConfig, _}
-import spinal.tester.SpinalAnyFunSuite
 
 abstract class SpinalSimTester{
   def SimConfig : SpinalSimConfig

--- a/tester/src/test/scala/spinal/core/ChecksTester.scala
+++ b/tester/src/test/scala/spinal/core/ChecksTester.scala
@@ -185,7 +185,7 @@ class ChecksTester extends SpinalAnyFunSuite  {
 
       val areaA = new ClockingArea(ClockDomain(clockA)){
         val reg = Reg(Bool())
-        reg := in(Bool)
+        reg := in(Bool())
       }
 
       val areaB = new ClockingArea(ClockDomain(clockB)){
@@ -200,8 +200,8 @@ class ChecksTester extends SpinalAnyFunSuite  {
   test("checkClockCrossingCheckingCheckSourcesPaths") {
     generationShouldPass(new Component{
       val clock = in Bool()
-      val clockA =  Bool
-      val clockB =  Bool
+      val clockA =  Bool()
+      val clockB =  Bool()
 
       clockA := clock
       val sub = new Component{
@@ -217,7 +217,7 @@ class ChecksTester extends SpinalAnyFunSuite  {
       clockB := sub.cOut
       val areaA = new ClockingArea(ClockDomain(clockA)){
         val reg = Reg(Bool())
-        reg := in(Bool)
+        reg := in(Bool())
       }
 
       val areaB = new ClockingArea(ClockDomain(clockB)){
@@ -233,8 +233,8 @@ class ChecksTester extends SpinalAnyFunSuite  {
     generationShouldFail(new Component{
       val clock1 = in Bool()
       val clock2 = in Bool()
-      val clockA =  Bool
-      val clockB =  Bool
+      val clockA =  Bool()
+      val clockB =  Bool()
 
       clockA := clock1
       val sub = new Component{
@@ -250,7 +250,7 @@ class ChecksTester extends SpinalAnyFunSuite  {
       clockB := sub.cOut
       val areaA = new ClockingArea(ClockDomain(clockA)){
         val reg = Reg(Bool())
-        reg := in(Bool)
+        reg := in(Bool())
       }
 
       val areaB = new ClockingArea(ClockDomain(clockB)){
@@ -742,8 +742,8 @@ class NameingTester extends SpinalAnyFunSuite {
             val aaaa = Bool()
             val bbbb = Vec(Bool(),8)
             val cccc = Vec( Vec( Vec(Bool(),8),8),8)
-            val dddd = List.fill(4)(Bool)
-            val eeee = List.fill(4)(List.fill(4)(Bool))
+            val dddd = List.fill(4)(Bool())
+            val eeee = List.fill(4)(List.fill(4)(Bool()))
           },4)
         }
       }

--- a/tester/src/test/scala/spinal/core/CrossClockCheckerTester.scala
+++ b/tester/src/test/scala/spinal/core/CrossClockCheckerTester.scala
@@ -4,11 +4,11 @@ import spinal.tester.SpinalAnyFunSuite
 
 
 class BBA(val cd : ClockDomain) extends BlackBox{
-  val i = in(Bool)
+  val i = in(Bool())
 }
 
 class BBB(val cd : ClockDomain) extends BlackBox{
-  val o = out(Bool)
+  val o = out(Bool())
 }
 
 class CrossClockCheckerTesterA extends Component{
@@ -172,8 +172,8 @@ class SyncronousCheckerTesterC(v : Int) extends Component{
   val input = in UInt(8 bits)
   val output = out UInt(8 bits)
 
-  val clk1Buf = List.fill(3)(Bool).foldLeft(clk1){(i,o) => o := i; o}
-  val clk2Buf = List.fill(3)(Bool).foldLeft(clk2){(i,o) => o := i; o}
+  val clk1Buf = List.fill(3)(Bool()).foldLeft(clk1){(i,o) => o := i; o}
+  val clk2Buf = List.fill(3)(Bool()).foldLeft(clk2){(i,o) => o := i; o}
 
   val cd1 = ClockDomain(clk1Buf, reset)
   val cd2 = ClockDomain(clk2Buf, reset)

--- a/tester/src/test/scala/spinal/core/InOutTester.scala
+++ b/tester/src/test/scala/spinal/core/InOutTester.scala
@@ -183,7 +183,7 @@ object InOutTester3 {
   class Sub extends Component{
     val bus2 = slave(Bus())
     val tmp2 = Analog(analogType)
-    for(i <- bus2.gpio.range) {
+    for(i <- bus2.gpio.bitsRange) {
       when(bus2.cmd.writeEnable(i)) {
         tmp2(i) := bus2.cmd.write(i)
       }

--- a/tester/src/test/scala/spinal/core/LatchTester.scala
+++ b/tester/src/test/scala/spinal/core/LatchTester.scala
@@ -9,7 +9,7 @@ class LatchTester extends SpinalAnyFunSuite {
 
     try {
       SimConfig.compile(new Component {
-        val myCond = Bool
+        val myCond = Bool()
         val inVal = Bits(8 bits)
         val latchVal = Bits(8 bits)
 

--- a/tester/src/test/scala/spinal/tester/PlayDev.scala
+++ b/tester/src/test/scala/spinal/tester/PlayDev.scala
@@ -87,7 +87,7 @@ object PlayDevPullCkock{
     val subsub = new SubSub
   }
   class TopLevel extends Component {
-    val cd = ClockDomain(Bool, Bool)
+    val cd = ClockDomain(Bool(), Bool())
     val sub = cd(new Sub)
   }
 
@@ -245,7 +245,7 @@ object PlayDevCrossClock{
 
     val areaA = new ClockingArea(ClockDomain(clockA)){
       val reg = Reg(Bool())
-      reg := in(Bool)
+      reg := in(Bool())
       val wire = Bool()
       wire := reg
       val wire2 = Bool()
@@ -587,10 +587,10 @@ object PlayDevBugx{
 
 object PlayDevAnalog{
   class TopLevel extends Component {
-    val cmd = slave(TriState(Bool))
-    val gpio = inout(Analog(Bool))
+    val cmd = slave(TriState(Bool()))
+    val gpio = inout(Analog(Bool()))
 
-    val tmp = Analog(Bool)
+    val tmp = Analog(Bool())
     when(cmd.writeEnable){
       tmp := cmd.write
     }
@@ -612,12 +612,12 @@ object PlayWithBug {
 
   class I2C extends Component {
     val io = new Bundle {
-      val SDA = inout(Analog(Bool))
+      val SDA = inout(Analog(Bool()))
     }
   }
   class Test extends Component {
     val io = new Bundle{
-      val SDAs = Vec(inout(Analog(Bool)), 4)
+      val SDAs = Vec(inout(Analog(Bool())), 4)
     }
     for(j <- io.SDAs.range){
       val i2c = new I2C();
@@ -633,10 +633,10 @@ object PlayWithBug {
 
 object PlayDevAnalog2{
   class Sub extends Component{
-    val cmd2 = slave(TriState(Bool))
-    val gpio2 = inout(Analog(Bool))
+    val cmd2 = slave(TriState(Bool()))
+    val gpio2 = inout(Analog(Bool()))
 
-    val tmp2 = Analog(Bool)
+    val tmp2 = Analog(Bool())
     when(cmd2.writeEnable){
       tmp2 := cmd2.write
     }
@@ -646,11 +646,11 @@ object PlayDevAnalog2{
   }
 
   class TopLevel extends Component {
-    val cmd = slave(TriState(Bool))
-    val cmd2 = slave(TriState(Bool))
-    val gpio = inout(Analog(Bool))
+    val cmd = slave(TriState(Bool()))
+    val cmd2 = slave(TriState(Bool()))
+    val gpio = inout(Analog(Bool()))
 
-    val tmp = Analog(Bool)
+    val tmp = Analog(Bool())
     when(cmd.writeEnable){
       tmp := cmd.write
     }
@@ -691,7 +691,7 @@ object PlayDevNoMerge{
   class TopLevel extends Component {
     val x,y, z = False
     z.noBackendCombMerge
-    when(in(Bool)){
+    when(in(Bool())){
       x := True
       y := True
     } otherwise {
@@ -994,7 +994,7 @@ object PlayWithIndex extends App {
 object PlayTriStateArrayToTriState extends App {
   class TopLevel extends Component{
     val gpio = slave(TriStateArray(8 bits))
-    val led = master(TriState(Bool))
+    val led = master(TriState(Bool()))
 
     gpio.read.assignDontCare()
     led <> gpio(2)
@@ -1369,7 +1369,7 @@ object DebBugFormal extends App{
   case class rle[T <: Data](val dataType: HardType[T], val depth: Int) extends Component{
     val io = new Bundle{
       val input = in(dataType())
-      val enable = in(Bool)
+      val enable = in(Bool())
       val output = master(Flow(rleBus(dataType,depth)))
     }
 

--- a/tester/src/test/scala/spinal/tester/code/Debug.scala
+++ b/tester/src/test/scala/spinal/tester/code/Debug.scala
@@ -2285,14 +2285,13 @@ object PlayComposablePlugin extends App{
 }
 
 
+object PlayLockV2 extends App {
 
-object PlayLockV2 extends App{
-
-  class Retainer extends Area{
+  class Retainer extends Area {
     val handle = Handle[Unit]
     def await() = handle.await()
     def release(): Unit = {
-      handle.load()
+      handle.load(())
     }
   }
   case class LockV2() {
@@ -2326,10 +2325,7 @@ object PlayLockV2 extends App{
 }
 
 
-
-
-object PlayLockV3 extends App{
-
+object PlayLockV3 extends App {
 
   case class LockV2() {
     val retainers = mutable.Queue[Retainer]()
@@ -2337,7 +2333,7 @@ object PlayLockV3 extends App{
     class Retainer extends Handle[Unit] {
       retainers += this
       def release(): Unit = {
-        load()
+        load(())
       }
     }
 

--- a/tester/src/test/scala/spinal/tester/code/Debug.scala
+++ b/tester/src/test/scala/spinal/tester/code/Debug.scala
@@ -999,8 +999,8 @@ object Foo32 extends App{
 
 
   class TestIO(a: Boolean = false) extends Bundle {
-    val z = Bool
-    val more = if (a) Some(Bool) else None
+    val z = Bool()
+    val more = if (a) Some(Bool()) else None
   }
 
   class Test extends Component {

--- a/tester/src/test/scala/spinal/tester/code/Play1.scala
+++ b/tester/src/test/scala/spinal/tester/code/Play1.scala
@@ -53,7 +53,7 @@ class Stage1 extends Bundle with BundleA with BundleB with BundleD
 
 object Play1 {
   case class Sub() extends Component {
-    val io = inout(Analog(Bool))
+    val io = inout(Analog(Bool()))
 
     io := True
   }
@@ -364,7 +364,7 @@ object Play5 {
 
 object PlayFifo {
   class TopLevel extends Component{
-    val fifo = new StreamFifo(Bool,8)
+    val fifo = new StreamFifo(Bool(),8)
     fifo.io.clone.clone
   }
   def main(args: Array[String]): Unit = {
@@ -1489,7 +1489,7 @@ object PlayLoop {
     //    tmp(0) := tmp(1)
     //    tmp(1) := tmp(0)
     //    io.output := tmp
-    val myFlow = Flow(Bool)
+    val myFlow = Flow(Bool())
     val myStream = myFlow.toStream.stage
   }
 
@@ -1893,16 +1893,16 @@ object PlayBlink {
 object PlayDefault {
 
   class SubLevel extends Component {
-    val input = in(Bool) default (False)
-    val output = out(Bool)
-    val internal = Bool default (True)
+    val input = in(Bool()) default (False)
+    val output = out(Bool())
+    val internal = Bool() default (True)
     output := input && internal
   }
 
   class TopLevel extends Component {
     val sub = new SubLevel
 
-    val output = out(Bool)
+    val output = out(Bool())
     output := sub.output
   }
 
@@ -2763,7 +2763,7 @@ object PlayCase {
 object PlayMux2 {
 
   class TopLevel extends Component {
-    val output = out(Mux(in(Bool.setName("sel")),in(SInt(2 bit)),S(0)))
+    val output = out(Mux(in(Bool().setName("sel")),in(SInt(2 bit)),S(0)))
   }
 
   def main(args: Array[String]) {

--- a/tester/src/test/scala/spinal/tester/code/Play2.scala
+++ b/tester/src/test/scala/spinal/tester/code/Play2.scala
@@ -78,7 +78,7 @@ object PlayB6 {
   val myBits = Bits()
   val myBool = Bool()
   val yolo =  myBits.asBools.map(_ ^ myBool).asBits()
-  val yolo2 = myBits ^ B(myBits.range -> myBool)
+  val yolo2 = myBits ^ B(myBits.bitsRange -> myBool)
   class TopLevel extends Component {
     val notUsed = False
 
@@ -711,7 +711,7 @@ object PlayVerilog1 {
     y := a + b
     y(0) := False
 
-    z(z.range) := U"0110"
+    z(z.bitsRange) := U"0110"
 
     val l,m = UInt(4 bits).dontSimplifyIt()
     l := a & b

--- a/tester/src/test/scala/spinal/tester/code/Play2.scala
+++ b/tester/src/test/scala/spinal/tester/code/Play2.scala
@@ -54,7 +54,7 @@ object Play74 {
 
   class TopLevel extends Component {
 
-    when(in(Bool)) {
+    when(in(Bool())) {
       assert(
         assertion = True,
         message = "Address read doesn't match the address of the device ",
@@ -104,7 +104,7 @@ object PlayB5 {
     val myClockDomain = ClockDomain(myClock, True)
 
     val area = new ClockingArea(myClockDomain) {
-      val result = out(RegNext(in(Bool)) init (True))
+      val result = out(RegNext(in(Bool())) init (True))
     }
 
   }

--- a/tester/src/test/scala/spinal/tester/code/Play3.scala
+++ b/tester/src/test/scala/spinal/tester/code/Play3.scala
@@ -973,8 +973,8 @@ object PlayPatch{
 
   case class PipelinedMemoryBus(addressWidth : Int, dataWidth : Int) extends Bundle with IMasterSlave {
     // Check the generic parameters
-    val enable     = Bool // Bus can be used when 'enable' is high
-    val writeMode  = Bool // High to write data, low to read data
+    val enable     = Bool() // Bus can be used when 'enable' is high
+    val writeMode  = Bool() // High to write data, low to read data
     val address    = UInt(addressWidth bits) // Address (byte-aligned)
     val writeData  = Bits(dataWidth bits)
     val readData   = Bits(dataWidth bits)

--- a/tester/src/test/scala/spinal/tester/code/Presentation.scala
+++ b/tester/src/test/scala/spinal/tester/code/Presentation.scala
@@ -329,7 +329,7 @@ object C10_2 {
     val io = new Bundle {
       val cfgPort = slave Flow Fragment(Bits(8 bit))
     }
-    val waitTrigger = io.cfgPort filterHeader (0x01) toRegOf (Bool) init (False)
+    val waitTrigger = io.cfgPort filterHeader (0x01) toRegOf (Bool()) init (False)
     val userTrigger = io.cfgPort pulseOn (0x02)
     val configs = io.cfgPort filterHeader (0x0F) toRegOf (LogicAnalyserConfig())
   }
@@ -380,7 +380,7 @@ object C10_removed {
 
 
   //Memory of 1024 Bool
-  val mem = Mem(Bool, 1024)
+  val mem = Mem(Bool(), 1024)
 
   //Write it
   mem(5) := True
@@ -850,8 +850,8 @@ object t10 {
   val arrayOfUInt = Vec(UInt(5 bit), 16)
   val sumOfUInt = arrayOfUInt.fold(U(0, 9 bit))(_ + _)
 
-  val arrayOfStreamA = Vec(Stream(Bool), 10)
-  val arrayOfStreamB = Vec(Stream(Bool), 10)
+  val arrayOfStreamA = Vec(Stream(Bool()), 10)
+  val arrayOfStreamB = Vec(Stream(Bool()), 10)
   (arrayOfStreamA, arrayOfStreamB).zipped.foreach(_ >> _)
 
   for (i <- 0 to 10) {

--- a/tester/src/test/scala/spinal/tester/code/Presentation.scala
+++ b/tester/src/test/scala/spinal/tester/code/Presentation.scala
@@ -1955,7 +1955,7 @@ object PlayAdder2{
     uint8 := uint12.resize(8)
     uint8 := uint12.resized
     uint8 := uint12(7 downto 0)
-    uint8 := uint12(uint8.range)
+    uint8 := uint12(uint8.bitsRange)
 
     val bits4 = Bits(4 bits)
     uint8 := bits4.asUInt.resized

--- a/tester/src/test/scala/spinal/tester/code/Trash.scala
+++ b/tester/src/test/scala/spinal/tester/code/Trash.scala
@@ -151,7 +151,7 @@ class Ram_1w_1r(_wordWidth: Int, _wordCount: Int) extends BlackBox {
 import spinal.lib._
 object TestStreamWithReg {
   val a = in UInt(3 bit)
-  val str = Stream(Bool)
+  val str = Stream(Bool())
   str <-/< str
 a.pull()
 }


### PR DESCRIPTION
I'm a big fan of warning free production code. My opinion is when there is too much warnings you stop looking at them and they become distractions. But they are very useful to catch potential bugs at a very low dev cost.

So this PR is a first step to have a warning free `sbt compile`. I started with the trivial ones, where there is no effect on the rtl generation, the simulation behavior or user code compilation.

This can be merged as is.

For the next PR with more complicated warning fix, I have the following question: one warning that comes frequently is this one:

```
[warn] SpinalHDL/lib/src/main/scala/spinal/lib/memory/sdram/xdr/Xdr.scala:310:38: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
[warn]         signature: Data.randBoot(u: Unit): Data.this.type
[warn]   given arguments: <none>
[warn]  after adaptation: Data.randBoot((): Unit)
[warn]       mapper.drive(ODTend, 0x34,  8) randBoot()
```

`randBoot` has `u : Unit` as argument. This is different compared to others chainable modifiers without arguments like `allowPruning()`, `setAsReg()`, etc. Is there a reason for this ?

If not, I propose to define a `def randBoot()` and make `def randBoot(u : Unit)` point to it with a deprecation. This way people what fixed the scala warning with randBoot(()) will still have a compiling code.

# Impact on code generation

No impact.
