### PR TITLE
Remove easy warnings

### DIFF
--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -661,11 +661,16 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
     this
   }
 
+
+  // TODO enable deprecation
+  //@deprecated("use randBoot() instead", since = "1.15.0")
+  def randBoot(u : Unit): this.type = randBoot()
+  
   /**
     * Useful for register that doesn't need a reset value in RTL,
     * but need a random value for simulation (avoid x-propagation)
-    */
-  def randBoot(u : Unit): this.type = {
+    */  
+  def randBoot(): this.type = {
     if(!globalData.phaseContext.config.noRandBoot) flatten.foreach(_.addTag(spinal.core.randomBoot))
     this
   }

--- a/lib/src/main/scala/spinal/lib/bus/regif/Block/RegBase.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Block/RegBase.scala
@@ -1,7 +1,6 @@
 package spinal.lib.bus.regif
 
 import spinal.core._
-import spinal.lib.bus.regif.{AccessType, BusIf, RegSlice}
 
 import scala.collection.mutable.ListBuffer
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Axi4Bridge.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/fabric/Axi4Bridge.scala
@@ -5,7 +5,6 @@ import spinal.core.fiber._
 import spinal.lib.bus.amba4.axi.Axi4
 import spinal.lib.bus.misc.SizeMapping
 import spinal.lib.bus.tilelink
-import spinal.lib.bus.tilelink.{Axi4Bridge, S2mSupport}
 import spinal.lib.system.tag.{MappedNode, MemoryConnection, MemoryTransferTag, MemoryTransfers}
 
 

--- a/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/sim/JtagVpi.scala
@@ -61,7 +61,6 @@ object JtagVpi {
     }
 
     val server = new SocketThread
-    onSimEnd()
     server.start()
 
     // reconnect loop

--- a/tester/src/test/scala/spinal/lib/bus/amba4/axi/Axi4SharedOnChipRamTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/amba4/axi/Axi4SharedOnChipRamTester.scala
@@ -19,7 +19,6 @@ import spinal.sim._
 import spinal.core.sim._
 
 import spinal.lib.bus.misc.SizeMapping
-import spinal.lib.bus.amba4.axi.{Axi4, Axi4Config, Axi4SharedOnChipRam}
 import spinal.lib.bus.amba4.axi.sim.{
     Axi4ReadOnlyMasterAgent,
     Axi4ReadOnlyMonitor,

--- a/tester/src/test/scala/spinal/tester/code/FormalBlackbox.scala
+++ b/tester/src/test/scala/spinal/tester/code/FormalBlackbox.scala
@@ -2,7 +2,7 @@ package spinal.tester.code
 
 import spinal.core._
 import spinal.core.formal._
-import spinal.tester.SpinalAnyFunSuite
+
 /*
  * This test is for Issue #1256, to verify that SpinalHDL copies any
  * external rtl specified in blackboxes or added by

--- a/tester/src/test/scala/spinal/tester/code/Presentation.scala
+++ b/tester/src/test/scala/spinal/tester/code/Presentation.scala
@@ -2152,7 +2152,7 @@ object Summit extends App{
 
 object Ccc37A {
 
-  class Timer extends Component {
+  class MyTimer extends Component {
     val increment = in Bool()
     val counter = Reg(UInt(8 bits)) init(0)
     val full = counter === 255

--- a/tester/src/test/scala/spinal/tester/code/PresentationDsl.scala
+++ b/tester/src/test/scala/spinal/tester/code/PresentationDsl.scala
@@ -1576,7 +1576,7 @@ object Date2024{
 
 import spinal.core._
 
-class Timer extends Component {
+class CustomTimer extends Component {
   val increment = in Bool()
   val counter = Reg(UInt(8 bits)) init(0)
   val full = out(counter === 255)
@@ -1586,7 +1586,7 @@ class Timer extends Component {
   }
 }
 object MyMain extends App{
-  SpinalVerilog(new Timer)
+  SpinalVerilog(new CustomTimer)
 }
 
 //class Toplevel(cdA : ClockDomain, cdB : ClockDomain) extends Component {

--- a/tester/src/test/scala/spinal/tester/code/PresentationDsl.scala
+++ b/tester/src/test/scala/spinal/tester/code/PresentationDsl.scala
@@ -780,8 +780,8 @@ object Main100 extends App{
     val apbDecoder = Apb3Decoder(
       master = commonBus,
       slaves = List(
-        gpioBus -> (0x2000, 4 kB),
-        uartBus -> (0x5000, 4 kB)
+        gpioBus -> (0x2000, 4 KiB),
+        uartBus -> (0x5000, 4 KiB)
       )
     )
   })
@@ -801,11 +801,11 @@ object Main101 extends App{
 
     val axiCrossbar = Axi4CrossbarFactory()
     axiCrossbar.addSlaves(
-      mainBus       -> (0x00000000,  4 GB),
-      ramBus        -> (0x40000000, 64 kB),
-      peripheralBus -> (0x10000000,  1 MB),
-      gpioBus       -> (    0x2000,  4 kB),
-      uartBus       -> (    0x5000,  4 kB)
+      mainBus       -> (0x00000000,  4 GiB),
+      ramBus        -> (0x40000000, 64 KiB),
+      peripheralBus -> (0x10000000,  1 MiB),
+      gpioBus       -> (    0x2000,  4 KiB),
+      uartBus       -> (    0x5000,  4 KiB)
     )
 
     axiCrossbar.addConnections(

--- a/tester/src/test/scala/spinal/tester/scalatest/AttributeEmitTests.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/AttributeEmitTests.scala
@@ -1,6 +1,5 @@
 package spinal.tester.scalatest
 
-import spinal.tester.SpinalAnyFunSuite
 import spinal.core._
 
 class AttributeEmitTests extends SpinalAnyFunSuite {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimMiscTester.scala
@@ -6,8 +6,6 @@ import spinal.core._
 import spinal.sim._
 import spinal.core.sim.{SpinalSimConfig, _}
 import spinal.lib.{BufferCC, OHMasking, SetFromFirstOne}
-import spinal.tester.SpinalAnyFunSuite
-import spinal.tester.scalatest
 
 import scala.concurrent.{Await, Future}
 import scala.util.Random

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimRandomIsolationTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimRandomIsolationTester.scala
@@ -2,7 +2,6 @@ package spinal.tester.scalatest
 
 import spinal.core._
 import spinal.core.sim._
-import spinal.tester.SpinalAnyFunSuite
 
 import scala.collection.mutable
 import scala.concurrent.{Future, Await}

--- a/tester/src/test/scala/spinal/tester/scalatest/VerilatorRandomIsolationTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/VerilatorRandomIsolationTester.scala
@@ -2,7 +2,6 @@ package spinal.tester.scalatest
 
 import spinal.core._
 import spinal.core.sim._
-import spinal.tester.SpinalAnyFunSuite
 
 import scala.collection.mutable
 import scala.concurrent.{Future, Await}


### PR DESCRIPTION
This PR follows #1891 and fix the remaining warnings what should change nothing to the engine of spinalHDL or the generated HDL. 

As discussed in #1891 I added the deprecation of `def randBoot(u : Unit)` replaced by `def randBoot()`. The deprecation is commented and should be turned on before the next minor.

with this build config:
```diff
-  scalacOptions ++= Seq("-unchecked","-target:jvm-1.8"/*, "-feature" ,"-deprecation"*/),
+  scalacOptions ++= Seq("-unchecked","-target:jvm-1.8", "-deprecation", "-feature"),
```

After this PR I get 56 warnings after a `sbt "clean; compile"`. `v1.14.1` had 123 warnings, so it's already a good start.

I will pause my warning hunting campaign for now, I need to gain a better understanding of scala, hdl and the internals of spinal before fixing safely the others.

Perhaps turning warning on again in the `build.sbt` could help by having the developers of the lib fixing the warning of the code they know when they add new feature/fix bugs. But perhaps it create noise for users of the lib, I don't know, I don't really master the build system.

# Impact on code generation

None
