### PR TITLE
lib: bus: WishboneSlaveFactory: Improve Error Handling

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/bmb/BmbToWishbone.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bmb/BmbToWishbone.scala
@@ -51,7 +51,10 @@ case class BmbToWishbone(p : BmbParameter) extends Component{
   rsp.source  := inputCmd.source
   rsp.context := inputCmd.context
   rsp.last    := beatLast
-  rsp.setSuccess() //TODO
+  rsp.setSuccess()
+  when(io.output.ERR) {
+    rsp.setError()
+  }
 
   halt := !rsp.ready
 

--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneSlaveFactory.scala
@@ -6,6 +6,7 @@ package spinal.lib.bus.wishbone
 import spinal.core._
 import spinal.lib.bus.misc._
 import scala.collection.Seq
+import scala.collection.mutable.ArrayBuffer
 
 /** Factory for [[spinal.lib.bus.wishbone.WishboneSlaveFactory]] instances. */
 object WishboneSlaveFactory {
@@ -13,23 +14,25 @@ object WishboneSlaveFactory {
     * @param bus the wishbone bus instance that will connect with the module
     * @return an instantiated class of [[spinal.lib.bus.wishbone.WishboneSlaveFactory]]
     */
-  def apply(bus: Wishbone,reg_fedback: Boolean = true) = new WishboneSlaveFactory(bus,reg_fedback)
+  def apply(bus: Wishbone, reg_feedback: Boolean = true, errorOnUnmapped: Boolean = true) = new WishboneSlaveFactory(bus, reg_feedback, errorOnUnmapped)
 }
 
 /** This is the slave facotory fot the wishbone bus
   * @param bus the wishbone bus istance that will connect with the module
-  * @param reg_fedback if set to false, the slave will acknowledge as soon as possible otherwise will wait the next clock cycle(default)
+  * @param reg_feedback if set to false, the slave will acknowledge as soon as possible otherwise will wait the next clock cycle(default)
+  * @param errorOnUnmapped if set to true (default), accesses to unmapped addresses assert ERR. Requires useERR in the config.
   */
-class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends BusSlaveFactoryDelayed{
+class WishboneSlaveFactory(bus: Wishbone, reg_feedback: Boolean = true, errorOnUnmapped: Boolean = true) extends BusSlaveFactoryDelayed{
   bus.DAT_MISO := 0
   if(bus.config.isPipelined) bus.STALL := False
+  if(bus.config.useERR) bus.ERR := False
 
   val askWrite = bus.isWrite.allowPruning()
   val askRead = bus.isRead.allowPruning()
   val doWrite = bus.doWrite.allowPruning()
   val doRead = bus.doRead.allowPruning()
 
-  if(!reg_fedback){
+  if(!reg_feedback){
     bus.ACK := bus.STB && bus.CYC                 // Acknowledge as fast as possible.
   } else if(bus.config.isPipelined){
     val pip_reg = RegNext(bus.STB) init(False)
@@ -51,6 +54,19 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
 
   override def writeByteEnable() = bus.SEL
 
+  private val customErrors = ArrayBuffer[Bool]()
+
+  /** Register a custom error condition on this slave.
+    * When [[condition]] is True during an active transfer, the bus will respond
+    * with ERR and suppress ACK, with timing matched to the configured feedback
+    * mode. Requires [[bus.config.useERR]] to be set.
+    * @param condition combinatorial Bool that is True when an error is present
+    */
+  def setError(condition: Bool): Unit = {
+    require(bus.config.useERR, "setError requires useERR to be enabled in the WishboneConfig")
+    customErrors += condition
+  }
+
   override def build(): Unit = {
     super.doNonStopWrite(bus.DAT_MOSI)
 
@@ -64,9 +80,13 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
       readData = bus.DAT_MISO
     )
 
+    val hit = Bool()
+    hit := False
+
     switch(byteAddress) {
       for ((address, jobs) <- elementsPerAddress if address.isInstanceOf[SingleMapping]) {
         is(address.asInstanceOf[SingleMapping].address) {
+          hit := True
           doMappedElements(jobs)
         }
       }
@@ -74,8 +94,34 @@ class WishboneSlaveFactory(bus: Wishbone,reg_fedback: Boolean = true) extends Bu
 
     for ((address, jobs) <- elementsPerAddress if !address.isInstanceOf[SingleMapping]) {
       when(address.hit(byteAddress)){
+        hit := True
         doMappedElements(jobs)
       }
+    }
+
+    if(bus.config.useERR) {
+      val unmappedErr = if(errorOnUnmapped) !hit else { hit.allowPruning(); False }
+      val errCondition = customErrors.foldLeft(unmappedErr)(_ || _)
+      if(!reg_feedback) {
+        when(errCondition && bus.STB && bus.CYC) {
+          bus.ERR := True
+          bus.ACK := False
+        }
+      } else if(bus.config.isPipelined) {
+        val pip_err = RegNext(bus.STB && errCondition) init(False)
+        when(pip_err) {
+          bus.ERR := True
+          bus.ACK := False
+        }
+      } else {
+        val reg_err = RegNext(bus.STB && bus.CYC && errCondition) init(False)
+        when(reg_err && bus.STB) {
+          bus.ERR := True
+          bus.ACK := False
+        }
+      }
+    } else {
+      hit.allowPruning()
     }
   }
 }

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneSlaveFactoryTester.scala
@@ -9,11 +9,22 @@ import spinal.lib.sim._
 
 import scala.language.postfixOps
 
-class WishboneSimpleSlave(config : WishboneConfig) extends Component{
+class WishboneSlaveWithCustomError(config: WishboneConfig) extends Component {
+  val io = new Bundle {
+    val bus  = slave(Wishbone(config))
+    val busy = in Bool()
+  }
+  val busCtrl = WishboneSlaveFactory(io.bus)
+  val reg0 = busCtrl.createReadAndWrite(Bits(config.dataWidth bits), 0)
+  reg0.init(0)
+  busCtrl.setError(io.busy)
+}
+
+class WishboneSimpleSlave(config : WishboneConfig, reg_feedback: Boolean = true, errorOnUnmapped: Boolean = true) extends Component{
   val io = new Bundle{
     val bus = slave(Wishbone(config))
   }
-  val busCtrl = WishboneSlaveFactory(io.bus)
+  val busCtrl = WishboneSlaveFactory(io.bus, reg_feedback=reg_feedback, errorOnUnmapped=errorOnUnmapped)
   val regA = busCtrl.createReadOnly(Bits(busCtrl.busDataWidth bits), 10 * config.dataWidth / 8)
   regA := 100
   val regB = busCtrl.createReadAndWrite(Bits(busCtrl.busDataWidth bits), 0)
@@ -94,4 +105,121 @@ class SpinalSimWishboneSlaveFactoryTester extends SpinalAnyFunSuite{
 //    val conf = WishboneConfig(8,8).pipelined
 //    testBus(conf,description="pipelined")
 //  }
+
+  def initBus(dut: WishboneSimpleSlave): Unit = {
+    dut.io.bus.CYC      #= false
+    dut.io.bus.STB      #= false
+    dut.io.bus.WE       #= false
+    dut.io.bus.ADR      #= 0
+    dut.io.bus.DAT_MOSI #= 0
+    if(dut.io.bus.config.useLOCK)     dut.io.bus.LOCK  #= false
+    if(dut.io.bus.config.isPipelined) dut.io.bus.STALL #= false
+  }
+
+  test("err_on_unmapped_address") {
+    val conf = WishboneConfig(32, 32, useERR = true)
+    val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneSimpleSlave(conf))
+    fixture.doSim("err_on_unmapped_address") { dut =>
+      dut.clockDomain.forkStimulus(period = 10)
+      SimTimeout(1000 * 20 * 100)
+
+      initBus(dut)
+      dut.clockDomain.waitSampling()
+
+      // Access a mapped address: ACK expected, ERR must not fire
+      dut.io.bus.CYC #= true
+      dut.io.bus.STB #= true
+      dut.io.bus.WE  #= false
+      dut.io.bus.ADR #= 0  // regB lives at byte address 0, word address 0
+      dut.clockDomain.waitSamplingWhere(dut.io.bus.ACK.toBoolean || dut.io.bus.ERR.toBoolean)
+      assert(!dut.io.bus.ERR.toBoolean, "ERR should not be asserted for a mapped address")
+      assert( dut.io.bus.ACK.toBoolean, "ACK should be asserted for a mapped address")
+      dut.io.bus.STB #= false
+      dut.io.bus.CYC #= false
+      dut.clockDomain.waitSampling()
+
+      // Access an unmapped address: ERR expected, ACK must not fire
+      dut.io.bus.CYC #= true
+      dut.io.bus.STB #= true
+      dut.io.bus.WE  #= false
+      dut.io.bus.ADR #= 5  // no register mapped at this address
+      dut.clockDomain.waitSamplingWhere(dut.io.bus.ACK.toBoolean || dut.io.bus.ERR.toBoolean)
+      assert( dut.io.bus.ERR.toBoolean, "ERR should be asserted for an unmapped address")
+      assert(!dut.io.bus.ACK.toBoolean, "ACK must not be asserted when ERR fires")
+      dut.io.bus.STB #= false
+      dut.io.bus.CYC #= false
+      dut.clockDomain.waitSampling()
+    }
+  }
+
+  test("setError") {
+    val conf = WishboneConfig(32, 32, useERR = true)
+    val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneSlaveWithCustomError(conf))
+    fixture.doSim("setError") { dut =>
+      dut.clockDomain.forkStimulus(period = 10)
+      SimTimeout(1000 * 20 * 100)
+
+      dut.io.bus.CYC      #= false
+      dut.io.bus.STB      #= false
+      dut.io.bus.WE       #= false
+      dut.io.bus.ADR      #= 0
+      dut.io.bus.DAT_MOSI #= 0
+      dut.io.busy         #= false
+      if(dut.io.bus.config.useLOCK)     dut.io.bus.LOCK  #= false
+      if(dut.io.bus.config.isPipelined) dut.io.bus.STALL #= false
+      dut.clockDomain.waitSampling()
+
+      // Write while not busy: ACK expected, no ERR
+      dut.io.bus.CYC      #= true
+      dut.io.bus.STB      #= true
+      dut.io.bus.WE       #= true
+      dut.io.bus.ADR      #= 0
+      dut.io.bus.DAT_MOSI #= 0xFFFFFFFFL
+      dut.io.busy         #= false
+      dut.clockDomain.waitSamplingWhere(dut.io.bus.ACK.toBoolean || dut.io.bus.ERR.toBoolean)
+      assert(!dut.io.bus.ERR.toBoolean, "ERR should not fire when not busy")
+      assert( dut.io.bus.ACK.toBoolean, "ACK should be asserted when not busy")
+      dut.io.bus.STB #= false
+      dut.io.bus.CYC #= false
+      dut.clockDomain.waitSampling()
+
+      // Write while busy: ERR expected, no ACK
+      dut.io.bus.CYC      #= true
+      dut.io.bus.STB      #= true
+      dut.io.bus.WE       #= true
+      dut.io.bus.ADR      #= 0
+      dut.io.bus.DAT_MOSI #= 0xFFFFFFFFL
+      dut.io.busy         #= true
+      dut.clockDomain.waitSamplingWhere(dut.io.bus.ACK.toBoolean || dut.io.bus.ERR.toBoolean)
+      assert( dut.io.bus.ERR.toBoolean, "ERR should fire when busy")
+      assert(!dut.io.bus.ACK.toBoolean, "ACK should not be asserted when busy")
+      dut.io.bus.STB #= false
+      dut.io.bus.CYC #= false
+      dut.clockDomain.waitSampling()
+    }
+  }
+
+  test("no_err_on_unmapped_when_disabled") {
+    val conf = WishboneConfig(32, 32, useERR = true)
+    val fixture = SimConfig.allOptimisation.compile(rtl = new WishboneSimpleSlave(conf, errorOnUnmapped=false))
+    fixture.doSim("no_err_on_unmapped_when_disabled") { dut =>
+      dut.clockDomain.forkStimulus(period = 10)
+      SimTimeout(1000 * 20 * 100)
+
+      initBus(dut)
+      dut.clockDomain.waitSampling()
+
+      // Access an unmapped address with errorOnUnmapped disabled: ACK expected, no ERR
+      dut.io.bus.CYC #= true
+      dut.io.bus.STB #= true
+      dut.io.bus.WE  #= false
+      dut.io.bus.ADR #= 5  // no register mapped here
+      dut.clockDomain.waitSamplingWhere(dut.io.bus.ACK.toBoolean || dut.io.bus.ERR.toBoolean)
+      assert(!dut.io.bus.ERR.toBoolean, "ERR should not fire for unmapped address when errorOnUnmapped is disabled")
+      assert( dut.io.bus.ACK.toBoolean, "ACK should be asserted for unmapped address when errorOnUnmapped is disabled")
+      dut.io.bus.STB #= false
+      dut.io.bus.CYC #= false
+      dut.clockDomain.waitSampling()
+    }
+  }
 }


### PR DESCRIPTION
The Wisbone error signal (ERR) is currently not driven when the Wishbone parameter "useERR" is set. Extend the WishboneSlaveFactory to generate error signals under two scenarios:

Generate an error on access to unmapped registers. This is an optional feature and can be disabled via the "errorOnUnmapped" flag.

Additionally, the slave factory has a new function
  setError(condition: Bool)
to register error conditions. If one of those conditions is true, the slave factory will generate an error event. For example, a bus subordinate (slave) can generate an error when the FIFO is full.