### PR TITLE
Add Companion trait for Bundles and MultiData types

### DIFF
--- a/lib/src/main/java/spinal/lib/companion.java
+++ b/lib/src/main/java/spinal/lib/companion.java
@@ -1,0 +1,8 @@
+package spinal.lib;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface companion {
+}

--- a/lib/src/main/scala/spinal/lib/Companion.scala
+++ b/lib/src/main/scala/spinal/lib/Companion.scala
@@ -1,0 +1,56 @@
+package spinal.lib
+
+import spinal.core.{Data, MultiData, dontName}
+
+/** A trait that a `MultiData` can implement, to make it less lonely :) */
+trait Companion[T <: Data] {
+
+  /** Make sure we are implemented on a MultiData object only */
+  assert(this.isInstanceOf[MultiData], s"Error: Companion ${this} must be of Type spinal.core.MultiData")
+
+  /** The value to act as a companion
+    * Initialized as lazy so as to not fail during object creation
+    */
+  lazy private val companion = getCompanion()
+
+  /** Parse object to find the field with the companion attribute
+    * Ensure that there is one (and only one) field with said attribute
+    * @return The field in this with the companion attribute as an instance of [T <: Data]
+    */
+  private def getCompanion(): T = {
+    var companion: T = null.asInstanceOf[T]
+    for (field <- this.getClass.getDeclaredFields) {
+      if (field.isAnnotationPresent(classOf[companion])) {
+        field.setAccessible(true)
+        if (companion == null) companion = field.get(this).asInstanceOf[T]
+        else assert(false, s"Error: There may only be one companion annotation in ${this}")
+      }
+    }
+    if (companion == null) assert(false, s"Error: ${this} has no Companions and is sad :(")
+    companion
+  }
+
+  /** Access the companion attribute */
+  def apply(): T = companion
+
+  /** I found another way to initialize this, though I'm not sure which method is better
+    * It works in the same way, but makes companion a var instead of a lazy val
+    * (and hence is null only until apply() is called)
+    * Feedback would be appreciated :)
+
+        private var companion: T = _
+
+        private def getCompanion(): Unit = {
+          for (field <- this.getClass.getDeclaredFields) {
+            if (field.isAnnotationPresent(classOf[companion])) {
+              field.setAccessible(true)
+              if (companion == null) companion = field.get(this).asInstanceOf[T]
+              else assert(false, s"Error: There may only be one companion annotation in ${this}")
+            }
+          }
+          if (companion == null) assert(false, s"Error: ${this} has no Companions and is sad :(")
+        }
+
+        def apply(): T = { if (companion == null) getCompanion(); companion }
+    */
+}

--- a/tester/src/test/scala/spinal/lib/SpinalSimCompanionTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimCompanionTester.scala
@@ -1,0 +1,176 @@
+package spinal.lib
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.tester.SpinalAnyFunSuite
+
+class SpinalSimCompanionTester extends SpinalAnyFunSuite {
+  test("instantiation") {
+    SpinalVerilog(new Component{
+      val test = new Bundle with Companion[Bool] {
+        val b1 = Bool()
+        @companion val b2 = Bool()
+        val b3 = Bool()
+      }
+      assert(test().isInstanceOf[Bool])
+      assert(test.b2 == test())
+    })
+  }
+
+  test("assignment") {
+    SpinalVerilog(new Component {
+      val i = 64
+      val testBits = Bits(i bits)
+      val testCompanion = new Bundle with Companion[Bits] {
+        val other = Bool()
+        @companion val comp = Bits(i bits)
+      }
+      assert(testBits.getBitsWidth == testCompanion().getBitsWidth)
+      testCompanion() := i
+      testBits := testCompanion()
+    })
+  }
+
+  test("random") {
+    SimConfig.compile(new CompanionTester()).doSim(seed = 0) { dut =>
+      //randomize() doesn't work in simulation, small workaround
+      val rand = new scala.util.Random
+      for(i <- 0 until 1000) {
+        dut.io.inCompanion() #= rand.nextInt(BigInt(2).pow(18).toInt)
+        sleep(1)
+        assert(checkAssign(dut))
+      }
+    }
+  }
+
+  test("sweep") {
+    SimConfig.compile(new CompanionTester()).doSim(seed = 0) { dut =>
+      for(i <- 0 until BigInt(2).pow(18).toInt) {
+        dut.io.inCompanion() #= i
+        sleep(1)
+        assert(checkAssign(dut))
+      }
+    }
+  }
+
+  test("nested_companion") {
+    SpinalVerilog(new Component{
+      //with companion needed for nesting!
+      type B = Bundle with Companion[Bool]
+      val outer = new Bundle with Companion[B] {
+        @companion val inner = new Bundle with Companion[Bool] {
+          @companion val test = Bool()
+        }
+      }
+      assert(outer() == outer.inner)
+      assert(outer.inner() == outer.inner.test)
+      //double apply is yucky but necessary
+      assert(outer()() == outer.inner.test)
+    })
+  }
+
+  test("use_companion_name") {
+    SpinalVerilog(new Component{
+      val test = new Bundle with Companion[Bool] {
+        @companion val companion = Bool()
+      }
+      //this works since companion is now a reference to the Bundle val, not the one in Companion
+      assert(test.companion == test())
+    })
+  }
+
+  test("incorrect_casting") {
+    SpinalVerilog(new Component{
+      var test: Bundle with Companion[Bits] = null
+      try {
+        test = new Bundle with Companion[Bits] {
+          val b1 = Bits(5 bits)
+          @companion val b2 = Bool()
+        }
+      } catch {
+        //type not checked upon instantiation, should not fail
+        case _: Throwable => assert(false)
+      }
+      try {
+        //apply method should fail, casting Bits to Bool
+        test()
+      } catch {
+        case c: java.lang.ClassCastException => println(s"Exception Caught!: ${c}")
+        case _: Throwable => assert(false)
+      }
+    })
+  }
+
+  test("single_companion") {
+    SpinalVerilog(new Component{
+      try {
+        val test = new Bundle with Companion[Bool] {
+          val b1 = Bool()
+          val b2 = Bool()
+        }
+        //no Companion present, should throw assertion error
+        test()
+      } catch {
+        case a: java.lang.AssertionError => println(s"Exception Caught!: ${a}")
+        case _: Throwable => assert(false)
+      }
+      try {
+        val test = new Bundle with Companion[Bool] {
+          @companion val b1 = Bool()
+          @companion val b2 = Bool()
+        }
+        //more than one Companion present, should throw assertion error
+        test()
+      } catch {
+        case a: java.lang.AssertionError => println(s"Exception Caught!: ${a}")
+        case _: Throwable => assert(false)
+      }
+    })
+  }
+
+  test("non_multi_data") {
+    SpinalVerilog(new Component{
+      try {
+        //extending Companion on a UInt (non-MultiData)
+        val test = new UInt with Companion[Bits] {
+          setWidth(5)
+          @companion val toBits = Bits(this.getBitsWidth bits)
+        }
+      } catch {
+        case a: java.lang.AssertionError => println(s"Exception Caught!: ${a}")
+        case _: Throwable => assert(false)
+      }
+      try {
+        /* TODO(?) : Make a simple MultiData type and try extending Companion with it here */
+      } catch {
+        // Should not fail that custom MultiData
+        case _: Throwable => assert(false)
+      }
+    })
+  }
+
+  def checkAssign(dut: CompanionTester): Boolean = {
+    val checkUInt = dut.io.inCompanion().toInt == dut.io.outInt.toInt
+    // BitVector lsb method doesn't work in simulation, this is just a workaround
+    val compLsb = (dut.io.inCompanion().toInt % 2).toBoolean
+    val checkBool = compLsb == dut.io.outBool.toBoolean
+    checkUInt && checkBool
+  }
+}
+
+class CompanionTester extends Component {
+  val b = 18 //only to 18 since any more will take eternity
+  val io = new Bundle {
+    val inCompanion = new Bundle with Companion[UInt] {
+      @companion val comp = in UInt(b bits)
+    }
+    val outInt = out UInt(b bits)
+    val outBool = out Bool()
+  }
+  io.inCompanion().simPublic()
+  io.outInt.simPublic()
+  io.outBool.simPublic()
+
+  io.outInt := io.inCompanion()
+  io.outBool := io.inCompanion()(0)
+}


### PR DESCRIPTION
Just so they can be less lonely :)

# Context, Motivation & Description

Rationale: Imagine a circuit for a clock with 3 primary signals: an output clock, a feedback clock, and an enable line. In my mind, something like the following would be a nice way of organizing these signals:

```scala
val io = new Bundle {
  val clock = out Bool()
  val clock = new Bundle {
    val enable = out Bool()
    val feedback = in Bool()
  }
}
```

Obviously this doesn't work, but I found it appealing being able to treat `io.clock` as a separate "entity" from `io.clock._`. I *sort of* accomplished this via adding a new trait, `Companion`, that a `MultiData` type can extend. The only caveat of this feature being it overwrites the no-parameter `apply()` method. To use this in a bundle, simply do:

```scala
val io = new Bundle {
  val clock = new Bundle with Companion[Bool] {
    @companion val output = out Bool()
    val enable = out Bool()
    val feedback = in Bool()
  }
}
```

Then, calling the empty apply `io.clock()` will net you the value of `io.clock.output`, thereby (almost) replicating the original problem I presented!

# Another Example

With the Companion trait, something like the following is possible:

```scala
class CompanionStream[T <: Data](plType: HardType[T]) extends Stream(plType) with Companion[T] {
  @companion val plWhenFire = RegNextWhen(this.payload, this.fire)
}
```

Then, you may simply use `val streamData = compStream()`, instead of `... = RegNextWhen(compStream.payload...`. While this isn't the ideal usage of a `Stream`, this is just an example of how a `Companion` can be used (especially in larger projects, where the verbosity of complex Bundles and functions can get overwhelming).

# Impact on code generation

None to my knowledge, though I have considered adding the functionality of making the generated companion signal have no partial name (i.e., as in the first example, `io_clock_output` will be renamed to `io_clock`). This isn't exactly ideal, though, as considering my second example, it would make more sense to name it `compStream_plWhenFire`, as opposed to just `compStream`. Any suggestions on this would be appreciated (though, using `setPartialName("")` directly may just be the best solution).

# Other Miscellany

I mostly implemented this for my own use cases, but thought it would be worth at least opening a pull request for. I don't expect it to be upstreamed, but at least the exposure here could be beneficial if others deem this functionality suitable to their needs and use it in their own projects. There are some quirks with it, notably that the execution code doesn't happen at runtime, but rather whenever the `apply()` method is called. Also, nesting `Companion` bundles is weird and doesn't *exactly* work as I'd like (as it only provides `this.companion` and doesn't resolve to the lowest-level). Any feedback/suggestions/comments are welcome! :)

# Checklist

- [X] Unit tests were added
- [X] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?

*Scala docs are added to commited files, I can add RTD documentation should this feature be desired!