### PR TITLE
lib: bus: WishboneDecoder: use byte address for slave selection

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/wishbone/WishboneDecoder.scala
@@ -12,15 +12,26 @@ object WishboneDecoder {
   * @param decodings it will use for configuring the partial address decoder
   * @return a [[spinal.lib.bus.wishbone.WishboneDecoder]] instance
   */
-  def apply(config: WishboneConfig, decodings: Seq[AddressMapping]) = new WishboneDecoder(config,decodings)
+  def apply(config: WishboneConfig, decodings: Seq[AddressMapping]) = new WishboneDecoder(config, decodings)
+  def apply(config: WishboneConfig, decodings: Seq[AddressMapping], byteAddressedDecodings: Boolean) = new WishboneDecoder(config, decodings, byteAddressedDecodings)
 
   /** Create an instance of WishboneDecoder, and autoconnect all input/outputs.
     * @param master connect the input to this master interface, the [[spinal.lib.bus.wishbone.Wishbone.config]] will be used for all input/output
     * @param slaves connect the output to the slaves, with the correct address
     * @return a [[spinal.lib.bus.wishbone.WishboneDecoder]] instance with all the input and output connected automatically
     */
-  def apply(master: Wishbone, slaves: Seq[(Wishbone, AddressMapping)]): WishboneDecoder = {
-    val decoder = new WishboneDecoder(master.config, slaves.map(_._2))
+  def apply(master: Wishbone, slaves: Seq[(Wishbone, AddressMapping)]): WishboneDecoder =
+    apply(master, slaves, byteAddressedDecodings = false)
+
+  /** Create an instance of WishboneDecoder, and autoconnect all input/outputs.
+    * @param master connect the input to this master interface, the [[spinal.lib.bus.wishbone.Wishbone.config]] will be used for all input/output
+    * @param slaves connect the output to the slaves, with the correct address
+    * @param byteAddressedDecodings when true, the word address on the bus is converted to a byte address
+    *                               before matching; decodings must then be specified in bytes
+    * @return a [[spinal.lib.bus.wishbone.WishboneDecoder]] instance with all the input and output connected automatically
+    */
+  def apply(master: Wishbone, slaves: Seq[(Wishbone, AddressMapping)], byteAddressedDecodings: Boolean): WishboneDecoder = {
+    val decoder = new WishboneDecoder(master.config, slaves.map(_._2), byteAddressedDecodings)
     decoder.io.input <> master
     (slaves.map(_._1), decoder.io.outputs).zipped.map(_ << _)
     decoder.setPartialName(master, "decoder")
@@ -30,15 +41,18 @@ object WishboneDecoder {
 /** Create a wishbone decoder/demultiplexer
   * @param config it will use for configuring all the input/output wishbone port
   * @param decodings it will use for configuring the partial address decoder
+  * @param byteAddressedDecodings when true, the word address on the bus is converted to a byte address
+  *                               before matching; decodings must then be specified in bytes.
+  *                               Defaults to false to preserve existing behaviour.
   */
-class WishboneDecoder(config : WishboneConfig, decodings : Seq[AddressMapping]) extends Component {
+class WishboneDecoder(config: WishboneConfig, decodings: Seq[AddressMapping], byteAddressedDecodings: Boolean = false) extends Component {
   val io = new Bundle {
     val input = slave(Wishbone(config))
     val outputs = Vec(master(Wishbone(config)), decodings.size)
   }
 
   // Permanently drive some slave input signal to save on logic usage.
-  io.outputs.map{ out =>
+  io.outputs.map { out =>
     out.STB       := io.input.STB
     out.DAT_MOSI  := io.input.DAT_MOSI
     out.WE        := io.input.WE
@@ -52,8 +66,12 @@ class WishboneDecoder(config : WishboneConfig, decodings : Seq[AddressMapping]) 
     Wishbone.driveWeak(io.input.BTE, out.BTE, null, false, false)
   }
 
+  // Optionally convert the bus word address to a byte address so that AddressMapping
+  // objects can be specified in bytes, consistent with WishboneSlaveFactory.
+  val selectAddress = if (byteAddressedDecodings) io.input.byteAddress(AddressGranularity.WORD) else io.input.ADR
+
   // the selector will use the decodings list to select the right slave based on the address line
-  val selector = Vec(decodings.map(_.hit(io.input.ADR) && io.input.CYC))
+  val selector = Vec(decodings.map(_.hit(selectAddress) && io.input.CYC))
   val selectorIndex = OHToUInt(selector)
 
   // Generate the CYC signal for the selected slave

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimWishboneDecoderTester.scala
@@ -18,7 +18,7 @@ class WishboneDecoderComponent(config : WishboneConfig,decodings : Seq[SizeMappi
   }
   val ff = Reg(Bool())
   val outs = io.busOUT zip decodings
-  val decoder = WishboneDecoder(io.busIN,outs)
+  val decoder = WishboneDecoder(io.busIN, outs, byteAddressedDecodings = true)
 }
 
 class SpinalSimWishboneDecoderTester extends SpinalAnyFunSuite{
@@ -41,8 +41,11 @@ class SpinalSimWishboneDecoderTester extends SpinalAnyFunSuite{
       val sco = ScoreboardInOrder[WishboneTransaction]()
       val dri = new WishboneDriver(dut.io.busIN, dut.clockDomain)
 
+      // Decodings are in byte addresses; convert to word addresses for the ADR signal.
+      val bytesPerWord = config.dataWidth / 8
+      val wordDecodings = decodings.map(s => SizeMapping(s.base / bytesPerWord, s.size / bytesPerWord))
       val seq = WishboneSequencer{
-        WishboneTransaction().randomAdressInRange(Random.shuffle(decodings).head).randomizeData(Math.pow(2,config.dataWidth).toInt-1)
+        WishboneTransaction().randomAdressInRange(Random.shuffle(wordDecodings).head).randomizeData(Math.pow(2,config.dataWidth).toInt-1)
       }
 
       val monIN = WishboneMonitor(dut.io.busIN, dut.clockDomain){ bus =>


### PR DESCRIPTION
Convert ADR to byte address before hitting AddressMapping, consistent with WishboneSlaveFactory. Removes the manual shift parameter which was error-prone and defaulted silently to 0.

Closes #1846