### PR TITLE
Add default for uninitialized register in jtag

### DIFF
--- a/lib/src/main/scala/spinal/lib/com/jtag/JtagTap.scala
+++ b/lib/src/main/scala/spinal/lib/com/jtag/JtagTap.scala
@@ -65,6 +65,8 @@ class JtagFsm(jtag: Jtag) extends Area {
     add(DR_PAUSE  , DR_EXIT2 , DR_PAUSE)
     add(DR_EXIT2  , DR_UPDATE, DR_SHIFT)
     add(DR_UPDATE , DR_SELECT, IDLE)
+
+    default(stateNext := RESET)
   }
 }
 


### PR DESCRIPTION
# Context, Motivation & Description

JTag fails to work properly on some hardware based on startup conditions. 

I tested the exact same verilog with and without this change, and the change fixed my jtag issue. 

I think this is the result of overzealous optimization passes (specifically Lattice based Synplify) since the state here does fully cover its bitset. 

# Impact on code generation

Minimal. It adds a default statement to a fully covered switch statement.
