### PR TITLE
Have StreamFork2/3 helper functions generate the full component for tracability

### DIFF
--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -1297,10 +1297,11 @@ object StreamFork {
 }
 
 object StreamFork2 {
-  def apply[T <: Data](input: Stream[T], synchronous: Boolean = false): (Stream[T], Stream[T]) = new Composite(input, "fork2"){
-    val outputs = (cloneOf(input), cloneOf(input))
-    val logic = new StreamForkArea(input, List(outputs._1, outputs._2), synchronous)
-  }.outputs
+  def apply[T <: Data](input: Stream[T], synchronous: Boolean = false): (Stream[T], Stream[T]) = {
+    val fork = new StreamFork(input.payloadType, 2, synchronous).setCompositeName(input, "fork2", true)
+    fork.io.input << input
+    (fork.io.outputs(0), fork.io.outputs(1))
+  }
 
   def takes[T <: Data](input: Stream[T],take0 : Bool, take1 : Bool, synchronous: Boolean = false): (Stream[T], Stream[T]) = new Composite(input, "fork2") {
     val forks = (cloneOf(input), cloneOf(input))
@@ -1310,10 +1311,11 @@ object StreamFork2 {
 }
 
 object StreamFork3 {
-  def apply[T <: Data](input: Stream[T], synchronous: Boolean = false): (Stream[T], Stream[T], Stream[T]) = new Composite(input, "fork3"){
-    val outputs = (cloneOf(input), cloneOf(input), cloneOf(input))
-    val logic = new StreamForkArea(input, List(outputs._1, outputs._2, outputs._3), synchronous)
-  }.outputs
+  def apply[T <: Data](input: Stream[T], synchronous: Boolean = false): (Stream[T], Stream[T], Stream[T]) = {
+    val fork = new StreamFork(input.payloadType, 3, synchronous).setCompositeName(input, "fork3", true)
+    fork.io.input << input
+    (fork.io.outputs(0), fork.io.outputs(1), fork.io.outputs(2))
+  }
 }
 
 /**


### PR DESCRIPTION
# Context, Motivation & Description

This changes how streamFork2 and streamFork3 work so that the create a full component in those helper classes. 

The motivation here is that the StreamFork area contains state, and there is no way to see that state with any kind of interospection with it just as the area. As a component, it's a registered child it participates in the component tree. 

This is probably useful for any tooling, but my specific goal here was to enable a formal testing of components that use [PipelinedMemoryBusArbiter](https://github.com/jdavidberger/SpinalHDLExtras/blob/main/hw/spinal/spinalextras/lib/formal/fillins/PipelinedMemoryBusArbiterFormal.scala#L12). The formal proof does not work though without: [this constraint](https://github.com/jdavidberger/SpinalHDLExtras/blob/main/hw/spinal/spinalextras/lib/formal/fillins/StreamForkFormal.scala#L10). 

# Impact on code generation

Minimal. It generates slightly more code, but the effective net list is the same. 
