### PR TITLE
Add SRAM based IMSIC file container

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -436,6 +436,19 @@ trait BusSlaveFactory extends Area{
   }
 
   /**
+   * Emit on that a transaction when a write happen at address, by using data placed at bitOffset in the word.
+   * Block the write transaction until the transaction succeeds (stream becomes ready).
+   */
+  def createAndDriveStream[T <: Data](dataType       : T,
+                                      address        : BigInt,
+                                      bitOffset      : Int = 0,
+                                      documentation  : String = null): Stream[T] = {
+    val stream = Stream(dataType)
+    driveStream(stream, address, bitOffset, documentation)
+    stream
+  }
+
+  /**
     * Create multi-words write register of type dataType
     */
   def createWriteMultiWord[T <: Data](that: T, address: BigInt, documentation: String = null): T = {
@@ -561,7 +574,7 @@ trait BusSlaveFactory extends Area{
    * Emit on that a transaction when a write happen at address, by using data placed at bitOffset in the word.
    * Block the write transaction until the transaction succeeds (stream becomes ready).
    */
-  def driveStream[T <: Data](that: Stream[T], address: BigInt, bitOffset: Int = 0): Unit = {
+  def driveStream[T <: Data](that: Stream[T], address: BigInt, bitOffset: Int = 0, documentation: String = null): Unit = {
     val wordCount = (bitOffset + widthOf(that.payload) - 1) / busDataWidth + 1
     onWritePrimitive(SizeMapping(address, wordCount * wordAddressInc), haltSensitive = false, null) {
       when(!that.ready) {
@@ -569,7 +582,7 @@ trait BusSlaveFactory extends Area{
       }
     }
     val flow = Flow(that.payloadType())
-    driveFlow(flow, address, bitOffset, checkByteEnable = true)
+    driveFlow(flow, address, bitOffset, checkByteEnable = true, documentation = documentation)
     that << flow.toStream
   }
 

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
@@ -115,7 +115,7 @@ object ImsicFile {
 
 
 object ImsicOp extends SpinalEnum {
-  val READ, WRITE, QUERY = newElement()
+  val READ, WRITE = newElement()
 }
 
 case class ImsicCmd(addressWidth: Int, xlen: Int) extends Bundle {
@@ -163,13 +163,16 @@ case class ImsicFileRam(p: ImsicFileParameters) extends Component {
   val ie = Mem.fill(lineNum)(Bits(xlen bits)) initBigInt(Seq.fill(lineNum)(0))
   val ip = Mem.fill(lineNum)(Bits(xlen bits)) initBigInt(Seq.fill(lineNum)(0))
   val iepCache = Vec.fill(lineNum)(RegInit(False))
+  val identity = RegInit(U(0, idWidth bits))
 
   val io = new Bundle {
     val port = Vec.fill(portNum)(slave(ImsicAccess(lineWidth, xlen)))
     val interrupt = out Bool()
+    val identity = out UInt(idWidth bits)
   }
 
-  io.interrupt := iepCache.orR
+  io.interrupt := identity.orR
+  io.identity := identity
 
   val arbiter = StreamArbiterFactory().lowerFirst.transactionLock.buildOn(io.port.map(_.cmd))
   val portOhReg = Reg(Bits(io.port.size bits))
@@ -209,7 +212,7 @@ case class ImsicFileRam(p: ImsicFileParameters) extends Component {
   }
 
   val fsm = new StateMachine {
-    val IDLE, READ, WRITE, QUERY = new State
+    val IDLE, READ, WRITE, QUERY, UPDATE = new State
     setEntry(IDLE)
 
     val op = Reg(ImsicOp())
@@ -223,20 +226,15 @@ case class ImsicFileRam(p: ImsicFileParameters) extends Component {
         port.write.data := arbiter.io.output.payload.data
         port.write.mask := arbiter.io.output.payload.mask
         port.isIp := arbiter.io.output.payload.iep
+        port.address := arbiter.io.output.payload.address
         arbiter.io.output.ready := True
 
         switch (arbiter.io.output.payload.op) {
           is(ImsicOp.READ) {
-            port.address := arbiter.io.output.payload.address
             goto(READ)
           }
           is(ImsicOp.WRITE) {
-            port.address := arbiter.io.output.payload.address
             goto(WRITE)
-          }
-          is(ImsicOp.QUERY) {
-            port.address := CountTrailingZeroes(iepCache.asBits).resized
-            goto(QUERY)
           }
         }
       }
@@ -253,20 +251,21 @@ case class ImsicFileRam(p: ImsicFileParameters) extends Component {
     WRITE whenIsActive {
       port.write.valid := True
       iepCache(port.address) := (port.read.maskedData & port.write.writeData).orR
-      io.port.onMask(portOhReg){port =>
-        port.rsp.valid := True
-      }
 
-      goto(IDLE)
+      goto(QUERY)
     }
 
     QUERY whenIsActive {
+      port.address := CountTrailingZeroes(iepCache.asBits).resized
+      goto(UPDATE)
+    }
+
+    UPDATE whenIsActive {
       val result = port.address @@ CountTrailingZeroes(port.read.ipData & port.read.ieData).resize(log2Up(xlen))
-      val identity = result.resize(idWidth).andMask(threshold === 0 || result < threshold)
+      identity := result.resize(idWidth).andMask(threshold === 0 || result < threshold)
 
       io.port.onMask(portOhReg){port =>
         port.rsp.valid := True
-        port.rsp.data  := identity.asBits.resized
       }
 
       goto(IDLE)

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
@@ -35,16 +35,26 @@ case class ImsicFile(hartId: Int, guestId: Int, sourceNum: Int) extends Area {
 
   require(isPow2(sourceNum))
 
-  val triggers = Bits(sourceIds.size bits)
   val threshold = RegInit(U(0, idWidth bits))
 
   val interrupts = for ((sourceId, idx) <- sourceIds.zipWithIndex) yield new Area {
     val id = sourceId
-    val trigger = triggers(idx)
     val ie = RegInit(False)
-    val ip = RegInit(False) setWhen(trigger)
+    val ip = RegInit(False)
     val iep = ie & ip
   }
+
+  val trigger = Stream(UInt(ImsicTriggerMapper.registerWidth bits))
+  when(trigger.valid) {
+    switch (trigger.payload) {
+      for (interrupt <- interrupts) {
+        is (interrupt.id) {
+          interrupt.ip.set()
+        }
+      }
+    }
+  }
+  trigger.ready := True
 
   val ieps = interrupts.map{i => i.iep}.asBits ## False
   val result = CountTrailingZeroes(ieps)

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
@@ -158,8 +158,6 @@ case class ImsicFileRam(p: ImsicFileParameters) extends Component {
   val lineWidth = log2Up(lineNum)
   val idWidth = log2Up(sourceNum)
 
-  val threshold = RegInit(U(0, idWidth bits))
-  threshold.allowUnsetRegToAvoidLatch()
   val ie = Mem.fill(lineNum)(Bits(xlen bits)) initBigInt(Seq.fill(lineNum)(0))
   val ip = Mem.fill(lineNum)(Bits(xlen bits)) initBigInt(Seq.fill(lineNum)(0))
   val iepCache = Vec.fill(lineNum)(RegInit(False))
@@ -167,11 +165,9 @@ case class ImsicFileRam(p: ImsicFileParameters) extends Component {
 
   val io = new Bundle {
     val port = Vec.fill(portNum)(slave(ImsicAccess(lineWidth, xlen)))
-    val interrupt = out Bool()
     val identity = out UInt(idWidth bits)
   }
 
-  io.interrupt := identity.orR
   io.identity := identity
 
   val arbiter = StreamArbiterFactory().lowerFirst.transactionLock.buildOn(io.port.map(_.cmd))
@@ -262,7 +258,7 @@ case class ImsicFileRam(p: ImsicFileParameters) extends Component {
 
     UPDATE whenIsActive {
       val result = port.address @@ CountTrailingZeroes(port.read.ipData & port.read.ieData).resize(log2Up(xlen))
-      identity := result.resize(idWidth).andMask(threshold === 0 || result < threshold)
+      identity := result.resize(idWidth)
 
       io.port.onMask(portOhReg){port =>
         port.rsp.valid := True

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
@@ -120,7 +120,7 @@ object ImsicOp extends SpinalEnum {
 
 case class ImsicCmd(addressWidth: Int, xlen: Int) extends Bundle {
   val op = ImsicOp()
-  val iep = Bool()
+  val doIp = Bool()
   val address = UInt(addressWidth bits)
   val data = Bits(xlen bits)
   val mask = Bits(xlen bits)
@@ -176,16 +176,16 @@ case class ImsicFileRamLogic(p: ImsicFileParameters) extends Component {
   val port = new Area {
     val address = Reg(U(0, lineWidth bits))
 
-    val isIp = Reg(Bool())
+    val doIp = Reg(Bool())
 
     val dataMask = B(xlen bits, 0 -> address.orR, default -> True)
 
     val read = new Area {
       val ipData = ip.readAsync(address) & dataMask
       val ieData = ie.readAsync(address) & dataMask
-      val data = isIp.mux(ipData, ieData)
+      val data = doIp.mux(ipData, ieData)
 
-      val maskedData = isIp.mux(ieData, ipData)
+      val maskedData = doIp.mux(ieData, ipData)
     }
 
     val write = new Area {
@@ -195,8 +195,8 @@ case class ImsicFileRamLogic(p: ImsicFileParameters) extends Component {
 
       val writeData = ((read.data & ~mask) | data) & dataMask
 
-      ie.write(address, writeData, valid & !isIp)
-      ip.write(address, writeData, valid & isIp)
+      ie.write(address, writeData, valid & !doIp)
+      ip.write(address, writeData, valid & doIp)
     }
   }
 
@@ -221,7 +221,7 @@ case class ImsicFileRamLogic(p: ImsicFileParameters) extends Component {
         op := arbiter.io.output.payload.op
         port.write.data := arbiter.io.output.payload.data
         port.write.mask := arbiter.io.output.payload.mask
-        port.isIp := arbiter.io.output.payload.iep
+        port.doIp := arbiter.io.output.payload.doIp
         port.address := arbiter.io.output.payload.address
         arbiter.io.output.ready := True
 

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
@@ -29,8 +29,11 @@ object ImsicFileInfo {
   )
 }
 
-case class ImsicFile(hartId: Int, guestId: Int, sourceIds: Seq[Int]) extends Area {
-  val idWidth = log2Up((sourceIds ++ Seq(0)).max + 1)
+case class ImsicFile(hartId: Int, guestId: Int, sourceNum: Int) extends Area {
+  val sourceIds = 1 until sourceNum
+  val idWidth = log2Up(sourceNum)
+
+  require(isPow2(sourceNum))
 
   val triggers = Bits(sourceIds.size bits)
   val threshold = RegInit(U(0, idWidth bits))
@@ -40,26 +43,12 @@ case class ImsicFile(hartId: Int, guestId: Int, sourceIds: Seq[Int]) extends Are
     val trigger = triggers(idx)
     val ie = RegInit(False)
     val ip = RegInit(False) setWhen(trigger)
+    val iep = ie & ip
   }
 
-  case class ImsicRequest() extends Bundle {
-    val id = UInt(idWidth bits)
-    val iep = Bool()
-  }
-
-  val requests = interrupts.map{i =>
-    val request = ImsicRequest()
-    request.id := i.id
-    request.iep := i.ie && i.ip
-    request
-  }
-
-  val result = RegNext(requests.reduceBalancedTree((a, b) => {
-    val takeA = !b.iep || (a.iep && a.id < b.id)
-    takeA ? a | b
-  }))
-
-  val identity = (result.iep && (threshold === 0 || result.id < threshold)) ? result.id | U(0, idWidth bits)
+  val ieps = interrupts.map{i => i.iep}.asBits ## False
+  val result = CountTrailingZeroes(ieps)
+  val identity = result.resize(idWidth).andMask(threshold === 0 || result < threshold)
 
   def claim(id: UInt) = new Area {
     switch(id) {
@@ -81,7 +70,7 @@ case class ImsicFile(hartId: Int, guestId: Int, sourceIds: Seq[Int]) extends Are
 }
 
 object ImsicFile {
-  def apply(hartId: Int, sourceIds: Seq[Int]): ImsicFile = ImsicFile(hartId, 0, sourceIds)
+  def apply(hartId: Int, sourceNum: Int): ImsicFile = ImsicFile(hartId, 0, sourceNum)
 
   def currentFileStatus(files: Seq[ImsicFile], mux: UInt) = new Area {
     assert(files.map(_.sourceIds).toSet.size == 1, "All file should have the same source configuration")

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
@@ -2,6 +2,7 @@ package spinal.lib.misc.aia
 
 import spinal.core._
 import spinal.lib._
+import spinal.lib.fsm._
 
 case class ImsicFileInfo(
   hartId        : Int,
@@ -110,4 +111,173 @@ object ImsicFile {
       }
     }
   }
+}
+
+
+object ImsicOp extends SpinalEnum {
+  val READ, WRITE, QUERY = newElement()
+}
+
+case class ImsicCmd(addressWidth: Int, xlen: Int) extends Bundle {
+  val op = ImsicOp()
+  val iep = Bool()
+  val address = UInt(addressWidth bits)
+  val data = Bits(xlen bits)
+  val mask = Bits(xlen bits)
+}
+
+case class ImsicRsp(xlen: Int) extends Bundle {
+  val data = Bits(xlen bits)
+}
+
+case class ImsicAccess(addressWidth: Int, xlen: Int) extends Bundle with IMasterSlave {
+  val cmd = Stream(ImsicCmd(addressWidth, xlen))
+  val rsp = Flow(ImsicRsp(xlen))
+
+  def asMaster() = {
+    master(cmd)
+    slave(rsp)
+  }
+}
+
+case class ImsicFileParameters(
+  hartId: Int,
+  guestId: Int,
+  sourceNum: Int,
+  xlen: Int,
+  portNum: Int = 2
+)
+
+case class ImsicFileRam(p: ImsicFileParameters) extends Component {
+  import p._
+
+  require(isPow2(sourceNum))
+  require(isPow2(xlen))
+
+  val lineNum = sourceNum / xlen
+  val lineWidth = log2Up(lineNum)
+  val idWidth = log2Up(sourceNum)
+
+  val threshold = RegInit(U(0, idWidth bits))
+  threshold.allowUnsetRegToAvoidLatch()
+  val ie = Mem.fill(lineNum)(Bits(xlen bits)) initBigInt(Seq.fill(lineNum)(0))
+  val ip = Mem.fill(lineNum)(Bits(xlen bits)) initBigInt(Seq.fill(lineNum)(0))
+  val iepCache = Vec.fill(lineNum)(RegInit(False))
+
+  val io = new Bundle {
+    val port = Vec.fill(portNum)(slave(ImsicAccess(lineWidth, xlen)))
+    val interrupt = out Bool()
+  }
+
+  io.interrupt := iepCache.orR
+
+  val arbiter = StreamArbiterFactory().lowerFirst.transactionLock.buildOn(io.port.map(_.cmd))
+  val portOhReg = Reg(Bits(io.port.size bits))
+
+  val port = new Area {
+    val address = Reg(U(0, lineWidth bits))
+
+    val isIp = Reg(Bool())
+
+    val dataMask = B(xlen bits, 0 -> address.orR, default -> True)
+
+    val read = new Area {
+      val ipData = ip.readAsync(address) & dataMask
+      val ieData = ie.readAsync(address) & dataMask
+      val data = isIp.mux(ipData, ieData)
+
+      val maskedData = isIp.mux(ieData, ipData)
+    }
+
+    val write = new Area {
+      val valid = False
+      val data = Reg(Bits(xlen bits))
+      val mask = Reg(Bits(xlen bits))
+
+      val writeData = ((read.data & ~mask) | data) & dataMask
+
+      ie.write(address, writeData, valid & !isIp)
+      ip.write(address, writeData, valid & isIp)
+    }
+  }
+
+  arbiter.io.output.ready := False
+
+  io.port.map(_.rsp).foreach { rsp =>
+    rsp.valid := False
+    rsp.data := port.read.data
+  }
+
+  val fsm = new StateMachine {
+    val IDLE, READ, WRITE, QUERY = new State
+    setEntry(IDLE)
+
+    val op = Reg(ImsicOp())
+    val mask = Reg(Bits(xlen bits))
+    val data = Reg(Bits(xlen bits))
+
+    IDLE whenIsActive {
+      when(arbiter.io.output.valid) {
+        portOhReg := arbiter.io.chosenOH
+        op := arbiter.io.output.payload.op
+        port.write.data := arbiter.io.output.payload.data
+        port.write.mask := arbiter.io.output.payload.mask
+        port.isIp := arbiter.io.output.payload.iep
+        arbiter.io.output.ready := True
+
+        switch (arbiter.io.output.payload.op) {
+          is(ImsicOp.READ) {
+            port.address := arbiter.io.output.payload.address
+            goto(READ)
+          }
+          is(ImsicOp.WRITE) {
+            port.address := arbiter.io.output.payload.address
+            goto(WRITE)
+          }
+          is(ImsicOp.QUERY) {
+            port.address := CountTrailingZeroes(iepCache.asBits).resized
+            goto(QUERY)
+          }
+        }
+      }
+    }
+
+    READ whenIsActive {
+      io.port.onMask(portOhReg){port =>
+        port.rsp.valid := True
+      }
+
+      goto(IDLE)
+    }
+
+    WRITE whenIsActive {
+      port.write.valid := True
+      iepCache(port.address) := (port.read.maskedData & port.write.writeData).orR
+      io.port.onMask(portOhReg){port =>
+        port.rsp.valid := True
+      }
+
+      goto(IDLE)
+    }
+
+    QUERY whenIsActive {
+      val result = port.address @@ CountTrailingZeroes(port.read.ipData & port.read.ieData).resize(log2Up(xlen))
+      val identity = result.resize(idWidth).andMask(threshold === 0 || result < threshold)
+
+      io.port.onMask(portOhReg){port =>
+        port.rsp.valid := True
+        port.rsp.data  := identity.asBits.resized
+      }
+
+      goto(IDLE)
+    }
+  }
+
+  def asImsicFileInfo(hartPerGroup: Int = 0): ImsicFileInfo = ImsicFileInfo(
+    hartId      = hartId,
+    guestId     = guestId,
+    sourceIds   = 1 until sourceNum,
+    groupId     = if (hartPerGroup == 0) 0 else (hartId / hartPerGroup),
+    groupHartId = if (hartPerGroup == 0) hartId else (hartId % hartPerGroup)
+  )
 }

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
@@ -174,15 +174,18 @@ case class ImsicFileRamLogic(p: ImsicFileParameters) extends Component {
   val portOhReg = Reg(Bits(io.port.size bits))
 
   val port = new Area {
-    val address = Reg(U(0, lineWidth bits))
+    val fire = False
+    val address = UInt(lineWidth bits)
+    val addressOld = RegNextWhen(address, fire)
+    address := addressOld
 
     val doIp = Reg(Bool())
 
     val dataMask = B(xlen bits, 0 -> address.orR, default -> True)
 
     val read = new Area {
-      val ipData = ip.readAsync(address) & dataMask
-      val ieData = ie.readAsync(address) & dataMask
+      val ipData = ip.readSync(address, fire) & dataMask
+      val ieData = ie.readSync(address, fire) & dataMask
       val data = doIp.mux(ipData, ieData)
 
       val maskedData = doIp.mux(ieData, ipData)
@@ -223,6 +226,7 @@ case class ImsicFileRamLogic(p: ImsicFileParameters) extends Component {
         port.write.mask := arbiter.io.output.payload.mask
         port.doIp := arbiter.io.output.payload.doIp
         port.address := arbiter.io.output.payload.address
+        port.fire := True
         arbiter.io.output.ready := True
 
         switch (arbiter.io.output.payload.op) {
@@ -252,7 +256,9 @@ case class ImsicFileRamLogic(p: ImsicFileParameters) extends Component {
     }
 
     QUERY whenIsActive {
-      port.address := CountTrailingZeroes(iepCache.asBits).resized
+      val queryAddress = CountTrailingZeroes(iepCache.asBits).resized
+      port.address := queryAddress
+      port.fire := True
       goto(UPDATE)
     }
 

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicFile.scala
@@ -148,7 +148,7 @@ case class ImsicFileParameters(
   portNum: Int = 2
 )
 
-case class ImsicFileRam(p: ImsicFileParameters) extends Component {
+case class ImsicFileRamLogic(p: ImsicFileParameters) extends Component {
   import p._
 
   require(isPow2(sourceNum))
@@ -267,6 +267,17 @@ case class ImsicFileRam(p: ImsicFileParameters) extends Component {
       goto(IDLE)
     }
   }
+}
+
+case class ImsicFileRam(p: ImsicFileParameters) extends Area {
+  import p._
+  val logic = ImsicFileRamLogic(p)
+  val idWidth = logic.idWidth
+  val ports = logic.io.port
+  val threshold = RegInit(U(0, idWidth bits))
+  val result = logic.io.identity
+  val identity = result.andMask(threshold === 0 || result < threshold)
+  val interrupt = identity.orR
 
   def asImsicFileInfo(hartPerGroup: Int = 0): ImsicFileInfo = ImsicFileInfo(
     hartId      = hartId,

--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicTrigger.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicTrigger.scala
@@ -4,7 +4,7 @@ import spinal.core._
 import spinal.lib._
 import spinal.lib.bus.misc._
 
-case class ImsicTriggerMapper(sourceIds: Seq[Int], hartId: Int, guestId: Int) extends Component {
+/*case class ImsicTriggerMapper(sourceIds: Seq[Int], hartId: Int, guestId: Int) extends Component {
   val registerWidth = 32
 
   val idWidth = log2Up((sourceIds ++ Seq(0)).max + 1)
@@ -47,6 +47,26 @@ case class ImsicTriggerMapper(sourceIds: Seq[Int], hartId: Int, guestId: Int) ex
     val targetDriveBE = busWithOffset.createAndDriveFlow(UInt(registerWidth bits), address = SETEIPNUM_BE_ADDR, documentation = "Set External Interrupt-Pending bit for %s of hart %d by Big-Endian Number".format(if (guestId == 0) "non-guest" else s"guest ${guestId}", hartId))
 
     io.drivers := Vec(targetDriveLE, targetDriveBE.map(EndiannessSwap(_)))
+  }
+}*/
+
+object ImsicTriggerMapper {
+  def registerWidth = 32
+
+  def driveFrom(bus: BusSlaveFactory, baseAddress: BigInt)(info: ImsicFileInfo)  = new Area {
+    val SETEIPNUM_LE_ADDR = 0x000
+    val SETEIPNUM_BE_ADDR = 0x004
+
+    val busWithOffset = new BusSlaveFactoryAddressWrapper(bus, baseAddress)
+    val targetDriveLE = busWithOffset.createAndDriveStream(UInt(registerWidth bits), address = SETEIPNUM_LE_ADDR, documentation = "Set External Interrupt-Pending bit for %s of hart %d by Little-Endian Number".format(if (info.guestId == 0) "non-guest" else s"guest ${info.guestId}", info.hartId))
+    val targetDriveLEBuffer = targetDriveLE.s2mPipe()
+
+    val targetDriveBE = busWithOffset.createAndDriveStream(UInt(registerWidth bits), address = SETEIPNUM_BE_ADDR, documentation = "Set External Interrupt-Pending bit for %s of hart %d by Big-Endian Number".format(if (info.guestId == 0) "non-guest" else s"guest ${info.guestId}", info.hartId)).map(EndiannessSwap(_))
+    val targetDriveBEBuffer = targetDriveBE.s2mPipe()
+
+    val arbiter = StreamArbiterFactory().roundRobin.transactionLock.buildOn(targetDriveLEBuffer, targetDriveBEBuffer)
+
+    val trigger = arbiter.io.output
   }
 }
 
@@ -150,28 +170,24 @@ object ImsicTrigger {
     val realMapping = mappingCalibrate(mapping, infos)
 
     val mappers = for (info <- infos) yield new Area {
-      val mapper = ImsicTriggerMapper(info.sourceIds, info.hartId, info.guestId)
       val offset = imsicOffset(realMapping, info)
-
-      mapper.driveFrom(bus, offset)
+      val mapper = ImsicTriggerMapper.driveFrom(bus, offset)(info)
 
       setName(f"trigger_g${info.groupId}h${info.groupHartId}v${info.guestId}")
     }
 
-    val triggers = Vec(mappers.map(_.mapper.io.triggers))
+    val triggers = Vec(mappers.map(_.mapper.trigger))
   }
 
   def apply(bus: BusSlaveFactory)(infos: Seq[ImsicFileInfo]) = new Area {
     val mappers = for (info <- infos) yield new Area {
-      val mapper = ImsicTriggerMapper(info.sourceIds, info.hartId, info.guestId)
       val offset = info.guestId * interruptFileSize
-
-      mapper.driveFrom(bus, offset)
+      val mapper = ImsicTriggerMapper.driveFrom(bus, offset)(info)
 
       setName(f"trigger_v${info.guestId}")
     }
 
-    val triggers = Vec(mappers.map(_.mapper.io.triggers))
+    val triggers = Vec(mappers.map(_.mapper.trigger))
   }
 
   def addressWidth(mapping: ImsicMapping, maxGuestId: Int, maxGroupHartId: Int, maxGroupId: Int): Int = {

--- a/lib/src/main/scala/spinal/lib/misc/aia/TilelinkImsicTrigger.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/TilelinkImsicTrigger.scala
@@ -14,14 +14,14 @@ class MappedImsicTrigger[T <: spinal.core.Data with IMasterSlave](infos: Seq[Ims
                                                            factoryGen: T => BusSlaveFactory) extends Component {
   val io = new Bundle {
     val bus = slave(busType())
-    val triggers = out Vec(infos.map(info => Bits(info.sourceIds.size bits)))
+    val triggers = Vec(infos.map(info => master Stream(UInt(ImsicTriggerMapper.registerWidth bits))))
   }
 
   val factory = factoryGen(io.bus)
 
   val logic = ImsicTrigger(factory, mapping)(infos)
 
-  io.triggers := logic.triggers
+  io.triggers.zip(logic.triggers).foreach(t => t._1 << t._2)
 }
 
 case class TilelinkImsicTrigger(infos: Seq[ImsicFileInfo],
@@ -62,13 +62,13 @@ class MappedCoreImsicTrigger[T <: spinal.core.Data with IMasterSlave](
 ) extends Component {
   val io = new Bundle {
     val bus = slave(busType())
-    val triggers = out Vec(infos.map(info => Bits(info.sourceIds.size bits)))
+    val triggers = Vec(infos.map(info => master Stream(UInt(ImsicTriggerMapper.registerWidth bits))))
   }
 
   val factory = factoryGen(io.bus)
   val logic = ImsicTrigger(factory)(infos)
 
-  io.triggers := logic.triggers
+  io.triggers.zip(logic.triggers).foreach(t => t._1 << t._2)
 }
 
 case class TilelinkCoreImsicTrigger(infos: Seq[ImsicFileInfo],
@@ -93,7 +93,7 @@ case class TilelinkCoreImsicTriggerFiber() extends Area {
   val lock = Lock()
 
   case class ImsicFileSource(info: ImsicFileInfo) {
-    val trigger = Bits(info.sourceIds.size bits)
+    val trigger = Stream(UInt(ImsicTriggerMapper.registerWidth bits))
   }
   var sources = ArrayBuffer[ImsicFileSource]()
   def addImsicFileinfo(info: ImsicFileInfo) = {
@@ -113,7 +113,7 @@ case class TilelinkCoreImsicTriggerFiber() extends Area {
 
     core.io.bus <> node.bus
     for ((source, trigger) <- sources.zip(core.io.triggers)) {
-      source.trigger := trigger
+      source.trigger << trigger
     }
   }
 }
@@ -121,10 +121,6 @@ case class TilelinkCoreImsicTriggerFiber() extends Area {
 case class TilelinkImsicTriggerFiber(mapping: ImsicMapping = ImsicMapping()) extends Area {
   val node = bus.tilelink.fabric.Node()
   val lock = Lock()
-
-  case class ImsicFileSource(info: ImsicFileInfo) {
-    val trigger = Bits(info.sourceIds.size bits)
-  }
 
   var cores = LinkedHashMap[Int, TilelinkCoreImsicTriggerFiber]()
   def addImsicFileinfo(info: ImsicFileInfo) = {

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAPlicTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAPlicTester.scala
@@ -67,7 +67,7 @@ case class APlicMSITestFiber(hartIds: Seq[Int], sourceIds: Seq[Int], guestIds: S
     })
     file.identity.simPublic()
     file.result.simPublic()
-    file.triggers.simPublic()
+    file.trigger.simPublic()
     file.threshold.simPublic().allowUnsetRegToAvoidLatch()
 
     file
@@ -109,7 +109,7 @@ case class APlicMSITestFiber(hartIds: Seq[Int], sourceIds: Seq[Int], guestIds: S
     for (hartFile <- files) {
       for (file <- hartFile) {
         val trigger = imsic.addImsicFileinfo(file.asImsicFileInfo())
-        file.triggers := trigger
+        file.trigger << trigger
       }
     }
 

--- a/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAPlicTester.scala
+++ b/tester/src/test/scala/spinal/tester/scalatest/SpinalSimAPlicTester.scala
@@ -58,7 +58,20 @@ case class APlicMSITestFiber(hartIds: Seq[Int], sourceIds: Seq[Int], guestIds: S
   val crossBar = tilelink.fabric.Node()
   crossBar << masterBus.node
 
-  val blocks = hartIds.map(hartId => for (guestId <- guestIds) yield new SxAIABlock(sourceIds, hartId, guestId))
+  val files = hartIds.map(hartId => guestIds.map { guestId =>
+    val file = new ImsicFile(hartId, guestId, sourceIds.size + 1)
+
+    file.interrupts.foreach(i => {
+      i.ie.simPublic()
+      i.ip.simPublic()
+    })
+    file.identity.simPublic()
+    file.result.simPublic()
+    file.triggers.simPublic()
+    file.threshold.simPublic().allowUnsetRegToAvoidLatch()
+
+    file
+  })
 
   val modes = ArrayBuffer[SpinalEnumElement[APlicSourceMode.type]]()
 
@@ -93,10 +106,10 @@ case class APlicMSITestFiber(hartIds: Seq[Int], sourceIds: Seq[Int], guestIds: S
     val imsic = TilelinkImsicTriggerFiber()
     imsic.node at 0x50000000 of access
 
-    for (hartBlock <- blocks) {
-      for (block <- hartBlock) {
-        val trigger = imsic.addImsicFileinfo(block.asImsicFileInfo())
-        val connector = SxAIABlockTrigger(block, trigger)
+    for (hartFile <- files) {
+      for (file <- hartFile) {
+        val trigger = imsic.addImsicFileinfo(file.asImsicFileInfo())
+        file.triggers := trigger
       }
     }
 
@@ -144,8 +157,9 @@ case class APlicMSITestFiber(hartIds: Seq[Int], sourceIds: Seq[Int], guestIds: S
   val io = new Bundle {
     val bus = slave(tilelink.Bus(masterBus.m2sParams.toNodeParameters().toBusParameter()))
     val sources = in Bits(sourceIds.size bits)
-    val ie = in Vec(blocks.map(hartBlock => Vec(hartBlock.map(block => Bits(block.interrupts.size bits)))))
-    val ip = out Vec(blocks.map(hartBlock => Vec(hartBlock.map(block => Bits(block.interrupts.size bits)))))
+    val ie = in Vec(files.map(hartFiles => Vec(hartFiles.map(file => Bits(file.interrupts.size bits)))))
+    val ip = out Vec(files.map(hartFiles => Vec(hartFiles.map(file => Bits(file.interrupts.size bits)))))
+    val identity = out Vec(files.map(hartFiles => Vec(hartFiles.map(file => UInt(file.idWidth bits)))))
     val rootTarget = out Bits(1 bits)
     val masterTarget = out Bits(hartIds.size bits)
     val slave0Target = out Bits(hartIds.size bits)
@@ -163,8 +177,14 @@ case class APlicMSITestFiber(hartIds: Seq[Int], sourceIds: Seq[Int], guestIds: S
   io.slave0Target := peripherals.slave0Target.map(_.flag).asBits()
   io.slave1Target := peripherals.slave1Target.map(_.flag).asBits()
 
-  io.ip := Vec(blocks.map(hartBlock => Vec(hartBlock.map(block => block.interrupts.map(_.ip).asBits()))))
-  Vec(blocks.map(hartBlock => Vec(hartBlock.map(block => block.interrupts.map(_.ie).asBits())))) := io.ie
+  io.ip := Vec(files.map(hartFiles => Vec(hartFiles.map(file => file.interrupts.map(_.ip).asBits()))))
+  io.identity := Vec(files.map(hartFiles => Vec(hartFiles.map(file => file.identity))))
+
+  files.zip(io.ie).foreach{case (hartFile, hartIe) => {
+    hartFile.zip(hartIe).foreach{case (file, ies) => {
+      file.interrupts.zipWithIndex.foreach{case (i, idx) => i.ie := ies(idx)}
+    }}
+  }}
 }
 
 case class APlicDirectTestFiber(hartIds: Seq[Int], sourceIds: Seq[Int], mode: InterruptMode = LEVEL_HIGH) extends Component {
@@ -793,7 +813,8 @@ class SpinalSimAPlicTester extends SpinalSimFunSuite {
         dut.io.sources #= BigInt("0", 16).setBit(sourceId - 1)
         dut.clockDomain.waitRisingEdge(4)
         assertBit(dut.io.ip(thisHartId)(thisGuestId).toBigInt, sourceId - 1, true, s"trigger target at ip($thisHartId)($thisGuestId)")
-        dut.blocks(thisHartId)(thisGuestId).interrupts(sourceId - 1).ip #= false
+        assert(dut.io.identity(thisHartId)(thisGuestId).toBigInt == sourceId, s"check trigger target identity at ip($thisHartId)($thisGuestId)")
+        dut.files(thisHartId)(thisGuestId).interrupts(sourceId - 1).ip #= false
       }
 
       dut.clockDomain.waitRisingEdge(100)
@@ -822,21 +843,21 @@ class SpinalSimAPlicTester extends SpinalSimFunSuite {
         dut.clockDomain.waitRisingEdge(4)
         assertBit(dut.io.ip(thisHartId)(thisGuestId).toBigInt, sourceId - 1, true, s"trigger ip($thisHartId)($thisGuestId)(${sourceId - 1}) by source(${sourceId-1}) when rectified_source = 1")
 
-        dut.blocks(thisHartId)(thisGuestId).interrupts(sourceId - 1).ip #= false
+        dut.files(thisHartId)(thisGuestId).interrupts(sourceId - 1).ip #= false
 
         // setipnum
         agent.putFullData(0, masterAddr + aplicmap.setipnumOffset, SimUInt32(sourceId))
         dut.clockDomain.waitRisingEdge(4)
         assertBit(dut.io.ip(thisHartId)(thisGuestId).toBigInt, sourceId - 1, true, s"trigger ip($thisHartId)($thisGuestId)(${sourceId - 1}) by setipnum when rectified_source = 1")
 
-        dut.blocks(thisHartId)(thisGuestId).interrupts(sourceId - 1).ip #= false
+        dut.files(thisHartId)(thisGuestId).interrupts(sourceId - 1).ip #= false
 
         // setipnum_le
         agent.putFullData(0, masterAddr + aplicmap.setipnum_leOffset, SimUInt32(sourceId))
         dut.clockDomain.waitRisingEdge(4)
         assertBit(dut.io.ip(thisHartId)(thisGuestId).toBigInt, sourceId - 1, true, s"trigger ip($thisHartId)($thisGuestId)(${sourceId - 1}) by setipnum_le when rectified_source = 1")
 
-        dut.blocks(thisHartId)(thisGuestId).interrupts(sourceId - 1).ip #= false
+        dut.files(thisHartId)(thisGuestId).interrupts(sourceId - 1).ip #= false
 
         // rectified_source = 0, can not trigger eip through setipnum
         dut.io.sources #= BigInt("0", 16)
@@ -880,7 +901,7 @@ class SpinalSimAPlicTester extends SpinalSimFunSuite {
         agent.putFullData(0, masterAddr + aplicmap.genmsiOffset, SimUInt32(randomHartid << 18 | sourceId))
         dut.clockDomain.waitRisingEdge(4)
         assertBit(dut.io.ip(randomHartid)(0).toBigInt, sourceId - 1, true, s"trigger ip($randomHartid)(0)(${sourceId - 1}) by genmsi")
-        dut.blocks(randomHartid)(0).interrupts(sourceId - 1).ip #= false
+        dut.files(randomHartid)(0).interrupts(sourceId - 1).ip #= false
       }
 
       dut.clockDomain.waitRisingEdge(100)
@@ -1029,64 +1050,6 @@ object APlicTestHelper {
     assert(data.testBit(id) == expect,
     s"\n  $name: check IO bit failed:\n  data = 0x${data.toString(16)}\n  bit index = $id\n  expected = $expect\n"
     )
-  }
-}
-
-case class SxAIAInterruptSource(sourceId: Int) extends Area {
-  val id = sourceId
-  val ie = RegInit(False)
-  val ip = RegInit(False)
-
-  val profile = new Area {
-    val en = RegInit(False)
-    val counter = Counter(32 bits, en && !ip)
-    val latency = counter.value
-
-    when (!en) {
-      counter.clear()
-    }
-
-    en.simPublic()
-    latency.simPublic()
-  }
-
-  ie.simPublic()
-  ip.simPublic()
-}
-
-case class SxAIABlock(sourceIds: Seq[Int], hartId: Int, guestId: Int) extends Area {
-  val interrupts = for (sourceId <- sourceIds) yield new SxAIAInterruptSource(sourceId)
-
-  def asImsicFileInfo(groupId: Int, groupHartId: Int): ImsicFileInfo = ImsicFileInfo(
-    hartId      = hartId,
-    guestId     = guestId,
-    sourceIds   = interrupts.map(_.id),
-    groupId     = groupId,
-    groupHartId = groupHartId
-  )
-
-  def asImsicFileInfo(hartPerGroup: Int = 0): ImsicFileInfo = {
-    val info = if (hartPerGroup == 0) {
-      asImsicFileInfo(
-        groupId     = 0,
-        groupHartId = hartId
-      )
-    } else {
-      asImsicFileInfo(
-        groupId     = hartId / hartPerGroup,
-        groupHartId = hartId % hartPerGroup
-      )
-    }
-
-    info
-  }
-}
-
-case class SxAIABlockTrigger(block: SxAIABlock, triggers: Bits) extends Area {
-  for ((interrupt, trigger) <- block.interrupts.zip(triggers.asBools)) {
-    when(trigger) {
-      interrupt.ip := True
-    }
   }
 }
 


### PR DESCRIPTION
# Context, Motivation & Description

Current IMSIC implementation in SpinalHDL is very area intensive as it uses register for interrupt generation. This make it hard to use this in RISC-V CPU with multiple IMSIC register files.

There is a implementation result of 4 cores VexiiRiscv on XCKU5P, with 1 M-mode file, 1 S-mode file and 3 VS-mode file. Each file has 256 interrupts. This could be a minimum request for running Qemu.


<img width="880" height="870" alt="Screenshot From 2026-05-13 09-36-24" src="https://github.com/user-attachments/assets/e9924279-525e-4664-b858-8e9bfea6326a" />

It is very area intensive and left no room for other features.

With this PR, a new SRAM based IMSIC register file is introduced, it can simply reduce the area at the cost of some read/write delay.

The performance of current implementation for each operation:
read: 2 cycles
write: 4 cycles
query highest interrupt: immediately, it has a cache for it.

The implementation result with this PR (Each imsic file is marked with different color):

<img width="850" height="840" alt="Screenshot From 2026-05-15 10-53-27" src="https://github.com/user-attachments/assets/3fa085bd-9b4b-445a-b7b6-20cfd30d6212" />

It can also be built with 8 cores:

<img width="854" height="856" alt="Screenshot From 2026-05-15 16-54-48" src="https://github.com/user-attachments/assets/4c779d39-98fb-4ac1-b02c-db4bf338c17f" />

The VexiiRiscv fork of this PR can be found at https://github.com/project-inochi/VexiiRiscv/tree/h-aia

# Impact on code generation

No change on code generation

# Checklist

- [ ] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
