### PR TITLE
fix(lib): fix premature cmd.ready assertion in UnsignedDivider

### DIFF
--- a/lib/src/main/scala/spinal/lib/math/Divider.scala
+++ b/lib/src/main/scala/spinal/lib/math/Divider.scala
@@ -131,9 +131,6 @@ class UnsignedDivider[T <: Data](nWidth : Int, dWidth : Int,storeDenominator : B
     when(counter.willOverflowIfInc){
       done := True
       waitRsp := True
-      if(storeDenominator) {
-        io.cmd.ready := True
-      }
     }
   }
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1916 

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
Please refer to Issue 1916 for details.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

The code that relies on this must have taken certain measures to avoid this bug, so it will not cause compatibility issues.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
