### PR TITLE
Fix Counter lazy val naming inconsistency on Scala 2.11

### DIFF
--- a/lib/src/main/scala/spinal/lib/Counter.scala
+++ b/lib/src/main/scala/spinal/lib/Counter.scala
@@ -283,6 +283,8 @@ class Counter(
   when(willClear) { valueNext := U(initVal, w bits) }
 
   enableStandardPruning()
+  willOverflow.setCompositeName(this, "willOverflow", true)
+  willUnderflow.setCompositeName(this, "willUnderflow", true)
 
   def stateCount: BigInt = end - start + 1
 


### PR DESCRIPTION

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->



# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

The test `spinal.core.RepeatabilityTester` fails on scala 2.11.12 while it pass on scala 2.13.12. 

The root cause is that  the valCallbackRec method in Area  is the mechanism that captures Scala variable names via the iDSL compiler plugin. lazy val fields in Scala 2.11 likely don't trigger the valCallbackRec callback, causing them to lose their names. As a result, the `willOverflow` and `willUnderflow` lazy vals in BoundedCounter were not getting proper partial names on Scala 2.11, which leads to signal count mismatches in RepeatabilityTester (97 vs 98). 

Explicitly calling setCompositeName after enableStandardPruning() ensures consistent naming across all Scala versions will fix this.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
No impact on code generation. 
# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
