### PR TITLE
regif: Fix HTML header

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/regif/Doc/Template.scala
+++ b/lib/src/main/scala/spinal/lib/bus/regif/Doc/Template.scala
@@ -169,7 +169,7 @@ object HtmlTemplate {
        |  </head>
        |  <body>
        |  <header>
-       |  <p class="regif-title"> ${moduleName} register interface </p>
+       |  <p class="regif-title"> ${moduleName}</p>
        |  </header>
        |  <div class="table">
        |  <table  align="center" class="theme-default">


### PR DESCRIPTION
Remove the redundant string "register interface" from the table header.

Fixes #1921