### PR TITLE
Feature/okay spelling

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3.scala
@@ -123,7 +123,7 @@ case class AhbLite3(config: AhbLite3Config) extends Bundle with IMasterSlave {
   val HREADYOUT = Bool()
   val HRESP     = Bool()
 
-  def setOKEY  = HRESP := False
+  def setOKAY  = HRESP := False
   def setERROR = HRESP := True
 
   override def asMaster(): Unit = {
@@ -131,7 +131,7 @@ case class AhbLite3(config: AhbLite3Config) extends Bundle with IMasterSlave {
     in(HREADYOUT, HRESP, HRDATA)
   }
 
-  def OKEY   = !HRESP
+  def OKAY   = !HRESP
   def ERROR  = HRESP
   def isIdle = HTRANS === AhbLite3.IDLE
 

--- a/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3OnChipRam.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3OnChipRam.scala
@@ -61,7 +61,7 @@ case class AhbLite3OnChipRam(AhbLite3Config: AhbLite3Config, byteCount: BigInt) 
     pendingWrite.mask    := io.ahb.writeMask
   }
 
-  io.ahb.setOKEY
+  io.ahb.setOKAY
 
   // Avoid write to read hazards
   io.ahb.HREADYOUT := !(io.ahb.HSEL && io.ahb.HTRANS(1) && !io.ahb.HWRITE && pendingWrite.valid && io.ahb.HADDR(wordRange) === pendingWrite.address)
@@ -113,7 +113,7 @@ case class AhbLite3OnChipRamMultiPort(portCount : Int, AhbLite3Config: AhbLite3C
       pending.mask := ahb.writeMask
     }
 
-    ahb.setOKEY
+    ahb.setOKAY
 
     // Avoid write to read hazards
     ahb.HREADYOUT := !(ahb.HSEL && ahb.HTRANS(1) && !ahb.HWRITE && pending.valid && pending.write && ahb.HADDR(wordRange) === pending.address) && !(pending.valid && pending.readInvalid)

--- a/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3OnChipRom.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba3/ahblite/AhbLite3OnChipRom.scala
@@ -44,7 +44,7 @@ class AhbLite3OnChipRom(AhbLite3Config: AhbLite3Config, content: => Seq[Bits]) e
 
   val wordRange = ram.addressWidth + log2Up(AhbLite3Config.bytePerWord)-1 downto log2Up(AhbLite3Config.bytePerWord)
 
-  io.ahb.setOKEY
+  io.ahb.setOKAY
 
   io.ahb.HREADYOUT := True
   io.ahb.HRDATA    := ram.readSync(

--- a/lib/src/main/scala/spinal/lib/bus/avalon/Avalon.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/Avalon.scala
@@ -138,7 +138,7 @@ case class AvalonMM(config : AvalonMMConfig) extends Bundle with IMasterSlave{
   def isReady = (if(useWaitRequestn) waitRequestn else True)
   def fire = isValid && isReady
 
-  def setOKEY : Unit = response := AvalonMM.Response.OKAY
+  def setOKAY : Unit = response := AvalonMM.Response.OKAY
 
   def setSLVERR: Unit = response := AvalonMM.Response.SLAVEERROR
 

--- a/lib/src/main/scala/spinal/lib/bus/avalon/AvalonMMSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/avalon/AvalonMMSlaveFactory.scala
@@ -43,7 +43,7 @@ class AvalonMMSlaveFactory(bus: AvalonMM) extends BusSlaveFactoryDelayed{
     }elsewhen (readErrorFlag && doRead) {
       bus.setSLVERR
     }otherwise {
-      bus.setOKEY
+      bus.setOKAY
     }
   }
 


### PR DESCRIPTION
This changes the spelling of "OKEY" to "OKAY".
This change is motivated by the fact that "OKEY" is an incorrect spelling as well as that both the AMBA and the Avalon spec spell it as "OKAY".

Fixes #932