### PR TITLE
COM: SPI: XDR: Improve coherency between levels

### DIFF
--- a/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
@@ -408,13 +408,33 @@ object SpiXdrMasterCtrl {
 
     def fromPipelinedMemoryBus() = {
       val accessBus = new PipelinedMemoryBus(PipelinedMemoryBusConfig(24,32))
-      ???
-//      cmd.valid <> (accessBus.cmd.valid && !accessBus.cmd.write)
-//      cmd.ready <> accessBus.cmd.ready
-//      cmd.payload <> accessBus.cmd.address
-//
-//      rsp.valid <> accessBus.rsp.valid
-//      rsp.payload <> accessBus.rsp.data
+      cmd.valid <> (accessBus.cmd.valid && !accessBus.cmd.write)
+      cmd.address <> accessBus.cmd.address
+      accessBus.cmd.ready := cmd.ready
+
+      cmd.length := 3
+
+      val buffer  = Reg(Bits(32 bits)) init(0)
+      val counter = Reg(UInt(2 bits)) init(0)
+
+      accessBus.rsp.valid := False
+      accessBus.rsp.data := rsp.fragment ## buffer(23 downto 0)
+
+      rsp.ready := True
+
+      when(rsp.fire) {
+        counter := counter + 1
+
+        switch(counter) {
+          is(0) { buffer(7 downto 0)   := rsp.fragment }
+          is(1) { buffer(15 downto 8)  := rsp.fragment }
+          is(2) { buffer(23 downto 16) := rsp.fragment }
+          is(3) { buffer(31 downto 24) := rsp.fragment
+            accessBus.rsp.valid := True
+          }
+        }
+      }
+
       accessBus
     }
 

--- a/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
@@ -896,8 +896,8 @@ object SpiXdrMasterCtrl {
     val inputPhy = new Area{
       def sync[T <: Data](that : T, init : T = null) = Delay(that,2,init=init)
       val mod = sync(io.config.mod)
-      // val readFill = sync(fsm.readFill, False)
-      // val readDone = sync(fsm.readDone, False)
+      val readFill = sync(fsm.readFill, False)
+      val readDone = sync(fsm.readDone, False)
       val buffer = Reg(Bits(p.dataWidth - p.mods.map(_.bitrate).min bits))
       val bufferNext = Bits(p.dataWidth bits).assignDontCare().allowOverride
       val widthSel = mod.muxListDc(p.mods.map(m => m.id -> U(widths.indexOf(m.bitrate), log2Up(widthMax + 1) bits)))
@@ -926,12 +926,12 @@ object SpiXdrMasterCtrl {
         for ((width,widthId) <- widths.zipWithIndex) {
           is(widthId) {
             bufferNext := (buffer ## dataRead(0, width bits)).resized
-            when(fsm.readFill) { buffer := bufferNext.resized }
+            when(readFill) { buffer := bufferNext.resized }
           }
         }
       }
 
-      io.rsp.valid := fsm.readDone
+      io.rsp.valid := readDone
       io.rsp.data := bufferNext
 
       switch(mod){

--- a/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
@@ -895,8 +895,7 @@ object SpiXdrMasterCtrl {
 
     val inputPhy = new Area{
       def sync[T <: Data](that : T, init : T = null) = Delay(that,2,init=init)
-      // val mod = sync(io.config.mod)
-      val mod = io.config.mod
+      val mod = sync(io.config.mod)
       // val readFill = sync(fsm.readFill, False)
       // val readDone = sync(fsm.readDone, False)
       val buffer = Reg(Bits(p.dataWidth - p.mods.map(_.bitrate).min bits))

--- a/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
@@ -896,8 +896,8 @@ object SpiXdrMasterCtrl {
     val inputPhy = new Area{
       def sync[T <: Data](that : T, init : T = null) = Delay(that,2,init=init)
       val mod = sync(io.config.mod)
-      val readFill = sync(fsm.readFill, False)
-      val readDone = sync(fsm.readDone, False)
+      // val readFill = sync(fsm.readFill, False)
+      // val readDone = sync(fsm.readDone, False)
       val buffer = Reg(Bits(p.dataWidth - p.mods.map(_.bitrate).min bits))
       val bufferNext = Bits(p.dataWidth bits).assignDontCare().allowOverride
       val widthSel = mod.muxListDc(p.mods.map(m => m.id -> U(widths.indexOf(m.bitrate), log2Up(widthMax + 1) bits)))
@@ -926,12 +926,12 @@ object SpiXdrMasterCtrl {
         for ((width,widthId) <- widths.zipWithIndex) {
           is(widthId) {
             bufferNext := (buffer ## dataRead(0, width bits)).resized
-            when(readFill) { buffer := bufferNext.resized }
+            when(fsm.readFill) { buffer := bufferNext.resized }
           }
         }
       }
 
-      io.rsp.valid := readDone
+      io.rsp.valid := fsm.readDone
       io.rsp.data := bufferNext
 
       switch(mod){

--- a/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
@@ -895,7 +895,8 @@ object SpiXdrMasterCtrl {
 
     val inputPhy = new Area{
       def sync[T <: Data](that : T, init : T = null) = Delay(that,2,init=init)
-      val mod = sync(io.config.mod)
+      // val mod = sync(io.config.mod)
+      val mod = io.config.mod
       // val readFill = sync(fsm.readFill, False)
       // val readDone = sync(fsm.readDone, False)
       val buffer = Reg(Bits(p.dataWidth - p.mods.map(_.bitrate).min bits))

--- a/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/spi/xdr/SpiXdrMasterCtrl.scala
@@ -60,7 +60,9 @@ case class XdrPin(rate : Int) extends Bundle with IMasterSlave{
 
 case class SpiXdrParameter(dataWidth : Int,
                            ioRate : Int,
-                           ssWidth : Int)
+                           ssWidth : Int,
+                           inLatency : Int = 1,
+                           outLatency : Int = 1)
 
 case class SpiXdrMaster(val p : SpiXdrParameter) extends Bundle with IMasterSlave{
   import p._
@@ -894,7 +896,12 @@ object SpiXdrMasterCtrl {
 
 
     val inputPhy = new Area{
-      def sync[T <: Data](that : T, init : T = null) = Delay(that,2,init=init)
+      def sync[T <: Data](that : T, init : T = null) : T = {
+        if( (p.spi.inLatency + p.spi.outLatency) > 0)
+          Delay(that,(p.spi.inLatency + p.spi.outLatency),init=init)
+        else
+          that
+      }
       val mod = sync(io.config.mod)
       val readFill = sync(fsm.readFill, False)
       val readDone = sync(fsm.readDone, False)

--- a/tester/src/test/scala/spinal/lib/com/spi/xdr/SpinalSimSpiXdr.scala
+++ b/tester/src/test/scala/spinal/lib/com/spi/xdr/SpinalSimSpiXdr.scala
@@ -106,24 +106,9 @@ class SpinalSimSpiXdrMaster extends SpinalAnyFunSuite {
             dut.io.config.sclkToggle #= sclkToggle
 
             if (read) rspScoreboard.pushRef(readData)
-
-            for ((pin, tasks) <- mod.readMapping.groupBy(_.pin)) {
-              val initialDriveVal = tasks.filter { m =>
-                ((readData >> (m.target + mod.dataWidth - mod.bitrate)) & 1) != 0
-              }.map(1 << _.phase).fold(0)(_ | _)
-              dut.io.spi.data(pin).read #= initialDriveVal
-            }
-
             val spiThread = fork {
               for (beat <- 0 until mod.dataWidth / mod.bitrate) {
                 for (counter <- 0 until (if (mod.clkRate == 1) (sclkToggle + 1) * (if (mod.slowDdr) 1 else 2) else 1)) {
-
-                  if (!(beat == 0 && counter == 0)) {
-                    for ((pin, tasks) <- mod.readMapping.groupBy(_.pin)) {
-                      dut.io.spi.data(pin).read #= tasks.filter(m => ((readData >> m.target + mod.dataWidth - (beat + 1) * mod.bitrate) & 1) != 0).map(1 << _.phase).fold(0)(_ | _)
-                    }
-                  }
-
                   dut.clockDomain.waitSampling()
                   if (mod.clkRate != 1) {
                     assert(dut.io.spi.sclk.write.toInt == ((0 until dut.p.spi.ioRate).filter(i => i / (dut.p.spi.ioRate / mod.clkRate) % 2 == 1).map(1 << _).reduce(_ | _) ^ (if (cpol ^ cpha) (1 << dut.p.spi.ioRate) - 1 else 0)))
@@ -133,12 +118,19 @@ class SpinalSimSpiXdrMaster extends SpinalAnyFunSuite {
                     else
                       assert(dut.io.spi.sclk.write.toInt == (if (cpol ^ cpha ^ (counter > sclkToggle)) (1 << dut.p.spi.ioRate) - 1 else 0))
                   }
+                  val beatBuffer = beat
+                  fork {
+                    dut.clockDomain.waitSampling()
+                    for ((pin, tasks) <- mod.readMapping.groupBy(_.pin)) {
+                      dut.io.spi.data(pin).read #= tasks.filter(m => ((readData >> m.target + mod.dataWidth - (beatBuffer + 1) * mod.bitrate) & 1) != 0).map(1 << _.phase).fold(0)(_ | _)
+                    }
+                  }
                   for (m <- mod.writeMapping) {
                     assert(dut.io.spi.data(m.pin).writeEnable.toBoolean == write || mod.ouputHighWhenIdle)
                     if (!write && mod.ouputHighWhenIdle) {
                       assert(((dut.io.spi.data(m.pin).write.toInt >> m.phase) & 1) == 1)
                     } else {
-                      assert(((dut.io.spi.data(m.pin).write.toInt >> m.phase) & 1) == ((writeData >> m.source + mod.dataWidth - (beat + 1) * mod.bitrate) & 1))
+                      assert(((dut.io.spi.data(m.pin).write.toInt >> m.phase) & 1) == ((writeData >> m.source + mod.dataWidth - (beatBuffer + 1) * mod.bitrate) & 1))
                     }
                   }
                 }

--- a/tester/src/test/scala/spinal/lib/com/spi/xdr/SpinalSimSpiXdr.scala
+++ b/tester/src/test/scala/spinal/lib/com/spi/xdr/SpinalSimSpiXdr.scala
@@ -106,9 +106,24 @@ class SpinalSimSpiXdrMaster extends SpinalAnyFunSuite {
             dut.io.config.sclkToggle #= sclkToggle
 
             if (read) rspScoreboard.pushRef(readData)
+
+            for ((pin, tasks) <- mod.readMapping.groupBy(_.pin)) {
+              val initialDriveVal = tasks.filter { m =>
+                ((readData >> (m.target + mod.dataWidth - mod.bitrate)) & 1) != 0
+              }.map(1 << _.phase).fold(0)(_ | _)
+              dut.io.spi.data(pin).read #= initialDriveVal
+            }
+
             val spiThread = fork {
               for (beat <- 0 until mod.dataWidth / mod.bitrate) {
                 for (counter <- 0 until (if (mod.clkRate == 1) (sclkToggle + 1) * (if (mod.slowDdr) 1 else 2) else 1)) {
+
+                  if (!(beat == 0 && counter == 0)) {
+                    for ((pin, tasks) <- mod.readMapping.groupBy(_.pin)) {
+                      dut.io.spi.data(pin).read #= tasks.filter(m => ((readData >> m.target + mod.dataWidth - (beat + 1) * mod.bitrate) & 1) != 0).map(1 << _.phase).fold(0)(_ | _)
+                    }
+                  }
+
                   dut.clockDomain.waitSampling()
                   if (mod.clkRate != 1) {
                     assert(dut.io.spi.sclk.write.toInt == ((0 until dut.p.spi.ioRate).filter(i => i / (dut.p.spi.ioRate / mod.clkRate) % 2 == 1).map(1 << _).reduce(_ | _) ^ (if (cpol ^ cpha) (1 << dut.p.spi.ioRate) - 1 else 0)))
@@ -118,19 +133,12 @@ class SpinalSimSpiXdrMaster extends SpinalAnyFunSuite {
                     else
                       assert(dut.io.spi.sclk.write.toInt == (if (cpol ^ cpha ^ (counter > sclkToggle)) (1 << dut.p.spi.ioRate) - 1 else 0))
                   }
-                  val beatBuffer = beat
-                  fork {
-                    dut.clockDomain.waitSampling()
-                    for ((pin, tasks) <- mod.readMapping.groupBy(_.pin)) {
-                      dut.io.spi.data(pin).read #= tasks.filter(m => ((readData >> m.target + mod.dataWidth - (beatBuffer + 1) * mod.bitrate) & 1) != 0).map(1 << _.phase).fold(0)(_ | _)
-                    }
-                  }
                   for (m <- mod.writeMapping) {
                     assert(dut.io.spi.data(m.pin).writeEnable.toBoolean == write || mod.ouputHighWhenIdle)
                     if (!write && mod.ouputHighWhenIdle) {
                       assert(((dut.io.spi.data(m.pin).write.toInt >> m.phase) & 1) == 1)
                     } else {
-                      assert(((dut.io.spi.data(m.pin).write.toInt >> m.phase) & 1) == ((writeData >> m.source + mod.dataWidth - (beatBuffer + 1) * mod.bitrate) & 1))
+                      assert(((dut.io.spi.data(m.pin).write.toInt >> m.phase) & 1) == ((writeData >> m.source + mod.dataWidth - (beat + 1) * mod.bitrate) & 1))
                     }
                   }
                 }


### PR DESCRIPTION
    com: spi: xdr: Fix byte readout alignment
    
    Current SpinalHDL SPI controller payload is aligned with the cmd valid
    while the rsp.valid is registered by additional latches.
    This introduce data corruption which only 7bits register are use to
    latch the SPI readout and the last bit is simply combine via
    combinational logic.
    Such design is fast but timing slack is highly reduced.
    In order to fix this misalignment removing latches and simply gated by
    the necessary top logic level.
    
    Signed-off-by: Brian Sune <briansune@gmail.com>

    com: spi: xdr: Add Pipeline Bus Logic
    
    Current SPI XDR Master is missing necessary logic in
    "fromPipelinedMemoryBus" with ??? marked. In order to function properly
    on QSPI NOR flash or SPI NOR flash each quad bytes fast read must pack
    into a word 32bits. This allow the instruction bus execute properly from
    a big-endian SPI NOR flash read. With the formation completes,
    necessary valid signal is given out in sync with the word instruction.
    
    Signed-off-by: Brian Sune <briansune@gmail.com>

Real VEX RISC-V hardware test NOR FLASH W25Q64

<img width="1536" height="255" alt="image" src="https://github.com/user-attachments/assets/7329f5ae-ac47-45ea-aea8-a3307a1ea321" />

For testbench I am not too convinced by the functionality, where it is somehow glitchy.