### PR TITLE
Expose the flush bus interface of the CacheFiber

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/CacheFiber.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/CacheFiber.scala
@@ -11,11 +11,13 @@ import spinal.lib.system.tag._
 
 
 // TODO remove probe on IO regions
-class CacheFiber(withCtrl : Boolean = false) extends Area{
+class CacheFiber(withCtrl : Boolean = false, flushBusParam : FlushParam = null) extends Area{
   val ctrl = withCtrl generate fabric.Node.up()
   val interrupt = withCtrl generate InterruptNode.master().setAllowNoSlave()
   val up = Node.slave()
   val down = Node.master()
+  val withFlushBus = flushBusParam != null
+  val flush = withFlushBus generate FlushBus(flushBusParam)
 
   var parameter = CacheParam(
     unp = null, // Unknown yet
@@ -25,6 +27,7 @@ class CacheFiber(withCtrl : Boolean = false) extends Area{
     blockSize = -1, // Unknown yet
     probeCount = 4,
     aBufferCount = 4,
+    flushBusParam = flushBusParam,
     coherentRegion = null
   )
 
@@ -123,6 +126,10 @@ class CacheFiber(withCtrl : Boolean = false) extends Area{
     if (withCtrl) {
       cache.io.ctrl << ctrl.bus
       interrupt.flag := cache.io.interrupt
+    }
+    if (withFlushBus) {
+      cache.io.flush.cmd << flush.cmd
+      cache.io.flush.rsp >> flush.rsp
     }
     cache.io.up << up.bus
     cache.io.down >> down.bus

--- a/tester/src/test/scala/spinal/lib/bus/tilelink/CacheTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/tilelink/CacheTester.scala
@@ -7,10 +7,11 @@ import tilelink._
 import tilelink.fabric.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.core.Component
+import spinal.lib.slave
 import spinal.lib.bus.misc.SizeMapping
-import spinal.lib.bus.tilelink.coherent.{CacheFiber, CacheParam, SelfFLush}
+import spinal.lib.bus.tilelink.coherent.{CacheFiber, CacheParam, FlushBus, FlushParam, SelfFLush}
 import spinal.lib.bus.tilelink.fabric.{MasterBus, SlaveBus}
-import spinal.lib.bus.tilelink.sim.{Block, MasterAgent, MasterTester}
+import spinal.lib.bus.tilelink.sim.{Block, MasterAgent, MasterDebugTester, MasterDebugTesterElement, MasterTester}
 import spinal.lib.system.tag.PMA
 import spinal.sim.SimThread
 
@@ -18,8 +19,7 @@ import scala.collection.mutable.ArrayBuffer
 
 class CacheTester extends AnyFunSuite{
 
-
-  def doTest(cp : CacheParam => Unit): Unit = {
+  def doTest(cp : CacheParam => Unit, flushParam : FlushParam = null): Unit = {
     val tester = new TilelinkTester(
       simConfig = SimConfig,
       cGen = new Component {
@@ -62,7 +62,7 @@ class CacheTester extends AnyFunSuite{
         )
         ctrl.node.addTag(tilelinkTesterExcluded)
 
-        val directory = new CacheFiber(withCtrl = true)
+        val directory = new CacheFiber(withCtrl = true, flushBusParam = flushParam)
         directory.parameter.cacheWays = 4
         directory.parameter.cacheBytes = 4096
         directory.parameter.allocateOnMiss = (op, src, addr, size, param) => addr(6)
@@ -71,6 +71,12 @@ class CacheTester extends AnyFunSuite{
         cp(directory.parameter)
         directory.up << m0.node
         directory.ctrl at (0x00, 0x100) of ctrl.node
+
+        val flush = directory.withFlushBus generate slave(FlushBus(directory.parameter.flushBusParam))
+        if(directory.withFlushBus) {
+          directory.flush.cmd << flush.cmd
+          flush.rsp << directory.flush.rsp
+        }
 
         val ctrlInterrupt = out Bool()
         ctrlInterrupt := directory.interrupt.flag
@@ -117,8 +123,67 @@ class CacheTester extends AnyFunSuite{
       }
     }
 
+    def initFlushBus(flush : FlushBus): Unit = {
+      flush.cmd.valid #= false
+      flush.cmd.address #= 0
+      flush.cmd.source #= 0
+      flush.rsp.ready #= true
+    }
+
+    def doDirected(name : String)(body : MasterDebugTester => Unit): Unit = {
+      tester.doSim(name) { tb =>
+        if(flushParam != null) initFlushBus(tb.dut.flush)
+        val directed = new MasterDebugTester(
+          (tb.masterSpecs, tb.mastersStuff).zipped.map((s, t) => new MasterDebugTesterElement(s, t.agent))
+        )
+        body(directed)
+      }
+    }
+
+    def flushCheck[T <: Component](tb: TilelinkTestbenchBase[T], m0: MasterAgent, doFlush: (Int, Int, Boolean) => Unit) = {
+      for(address <- List(0x10000, 0x10040)) {
+        val offset = address - 0x10000
+        var block : Block = null
+
+        // Dirty
+        m0.putInt(0, address, 0x1)
+        assert(tb.slavesStuff(0).model.mem.readInt(offset) != 0x1)
+        doFlush(0, address, false)
+        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
+
+        // Clean
+        m0.getInt(0, address)
+        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
+        doFlush(0, address, false)
+        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
+
+        // Clean probe
+        block = m0.acquireBlock(0, Param.Grow.NtoT, address, 0x40)
+        doFlush(0, address, true)
+        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
+
+        // Clean probe2
+        block = m0.acquireBlock(0, Param.Grow.NtoT, address, 0x40)
+        m0.release(0, Param.Cap.toB, block)
+        doFlush(0, address, true)
+        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
+
+        // Dirty probe
+        block = m0.acquireBlock(0, Param.Grow.NtoT, address, 0x40)
+        block.data(0) = 0x02
+        block.dirty = true
+        doFlush(0, address, true)
+        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x2)
+
+
+        assert(m0.getInt(0, address) == 0x2)
+      }
+    }
+
     tester.doSim("manual") { tb =>
       disableSimWave()
+
+      if(flushParam != null) initFlushBus(tb.dut.flush)
 
       periodically(10000) {
         tb.mastersStuff.foreach(_.agent.driver.driver.randomizeStallRate())
@@ -186,80 +251,68 @@ class CacheTester extends AnyFunSuite{
 
     tester.doSim("flush") { tb =>
       val ctrl = new MasterAgent(tb.dut.ctrl.node.bus, tb.dut.ctrl.node.clockDomain)(tb.idAllocator)
+      if(flushParam != null) initFlushBus(tb.dut.flush)
       val m0 = tb.mastersStuff(0).agent
-      for(address <- List(0x10000, 0x10040)) {
-        val offset = address - 0x10000
-        var block : Block = null
 
-        // Dirty
-        m0.putInt(0, address, 0x1)
-        assert(tb.slavesStuff(0).model.mem.readInt(offset) != 0x1)
-        doFlush(ctrl, 0, address, 0x40)
-        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
+      def doFlushWithCtrl(sourceId : Int, address : Int, needInterrupt: Boolean): Unit = doFlush(ctrl, sourceId, address, 0x40, if (needInterrupt) tb.dut.ctrlInterrupt else null)
 
-        // Clean
-        m0.getInt(0, address)
-        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
-        doFlush(ctrl, 0, address, 0x40)
-        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
-
-        // Clean probe
-        block = m0.acquireBlock(0, Param.Grow.NtoT, address, 0x40)
-        doFlush(ctrl, 0, address, 0x40, tb.dut.ctrlInterrupt)
-        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
-
-        // Clean probe2
-        block = m0.acquireBlock(0, Param.Grow.NtoT, address, 0x40)
-        m0.release(0, Param.Cap.toB, block)
-        doFlush(ctrl, 0, address, 0x40, tb.dut.ctrlInterrupt)
-        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x1)
-
-        // Dirty probe
-        block = m0.acquireBlock(0, Param.Grow.NtoT, address, 0x40)
-        block.data(0) = 0x02
-        block.dirty = true
-        doFlush(ctrl, 0, address, 0x40, tb.dut.ctrlInterrupt)
-        assert(tb.slavesStuff(0).model.mem.readInt(offset) == 0x2)
-
-
-        assert(m0.getInt(0, address) == 0x2)
-      }
+      flushCheck(tb, m0, doFlushWithCtrl)
     }
 
-    tester.doSimDirected("get"){_.coverGet(32)}
-    tester.doSimDirected("putFull") {_.coverPutFullData(32)}
-    tester.doSimDirected("putPartial") {_.coverPutPartialData(32)}
-    tester.doSimDirected("acquireB")(_.coverAcquireB(32))
-    tester.doSimDirected("acquireT")(_.coverAcquireT(32))
-    tester.doSimDirected("acquireBT")(_.coverAcquireBT(32))
-    tester.doSimDirected("acquireTB")(_.coverAcquireTB(32))
-    tester.doSimDirected("acquirePerm")(_.coverAcquirePerm(32))
-    tester.doSimDirected("coherencyBx2")(_.coverCoherencyBx2(32))
-    tester.doSimDirected("coherencyTx2")(_.coverCoherencyTx2(32))
-    tester.doSimDirected("coherencyT_B")(_.coverCoherencyT_B(32))
-    tester.doSimDirected("coherencyBx2_T_Bx2")(_.coverCoherencyBx2_T_Bx2(32))
+    if(flushParam != null) tester.doSim("flushBus") { tb =>
+      initFlushBus(tb.dut.flush)
+      val flush = tb.dut.flush
+      val m0 = tb.mastersStuff(0).agent
+
+      def doFlushWithBus(sourceId : Int, address : Int, needInterrupt: Boolean): Unit = {
+        flush.cmd.valid #= true
+        flush.cmd.address #= address
+        flush.cmd.source #= sourceId
+        m0.cd.waitSamplingWhere(flush.cmd.ready.toBoolean)
+        flush.cmd.valid #= false
+        m0.cd.waitSamplingWhere(flush.rsp.valid.toBoolean && flush.rsp.source.toBigInt == sourceId)
+        m0.cd.waitSampling()
+      }
+
+      flushCheck(tb, m0, doFlushWithBus)
+
+      tb.waitCheckers()
+    }
+
+    doDirected("get"){_.coverGet(32)}
+    doDirected("putFull") {_.coverPutFullData(32)}
+    doDirected("putPartial") {_.coverPutPartialData(32)}
+    doDirected("acquireB")(_.coverAcquireB(32))
+    doDirected("acquireT")(_.coverAcquireT(32))
+    doDirected("acquireBT")(_.coverAcquireBT(32))
+    doDirected("acquireTB")(_.coverAcquireTB(32))
+    doDirected("acquirePerm")(_.coverAcquirePerm(32))
+    doDirected("coherencyBx2")(_.coverCoherencyBx2(32))
+    doDirected("coherencyTx2")(_.coverCoherencyTx2(32))
+    doDirected("coherencyT_B")(_.coverCoherencyT_B(32))
+    doDirected("coherencyBx2_T_Bx2")(_.coverCoherencyBx2_T_Bx2(32))
 
 
 
     tester.checkErrors()
   }
 
-  test("dp 1bank"){
-    doTest{p => }
-  }
-  test("dp 1bank non-pow2"){
-    doTest{p => p.generalSlotCount = 9}
-  }
-  test("dp 2bank"){
-    doTest{p => p.cacheBanks = 2}
-  }
-  test("sp 1bank"){
-    doTest{p => p.withDualPortRam = false}
-  }
-  test("sp 2bank"){
-    doTest{p => p.withDualPortRam = false; p.cacheBanks = 2}
-  }
-  test("sp 4bank"){
-    doTest{p => p.withDualPortRam = false; p.cacheBanks = 4}
+  val cps = ArrayBuffer[(String, CacheParam => Unit)](
+    "dp 1bank"          -> {p => },
+    "dp 1bank non-pow2" -> {p => p.generalSlotCount = 9},
+    "dp 2bank"          -> {p => p.cacheBanks = 2},
+    "sp 1bank"          -> {p => p.withDualPortRam = false},
+    "sp 2bank"          -> {p => p.withDualPortRam = false; p.cacheBanks = 2},
+    "sp 4bank"          -> {p => p.withDualPortRam = false; p.cacheBanks = 4}
+  )
+
+  for ((name, cp) <- cps) {
+    test(name) {
+      doTest(cp, null)
+    }
+
+    test(name + " flush") {
+      doTest(cp, FlushParam(32, 2))
+    }
   }
 }


### PR DESCRIPTION
# Context, Motivation & Description

Expose the flushBus interface of the CacheFiber fiber so the caller can send FlushCmd via this (For example, The LsuPlugin of the VexiiRiscv).

Also add this parameter to all existed CacheFiber test.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
