### PR TITLE
SIM:VerilatorBackend: Fix 5.xx missing WData

### DIFF
--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -100,6 +100,7 @@ class VerilatorBackend(val config: VerilatorBackendConfig) extends Backend {
 #include <memory>
 #include <jni.h>
 #include <iostream>
+#include <verilated.h>
 
 #include "V${config.toplevelName}.h"
 #ifdef TRACE
@@ -108,6 +109,10 @@ class VerilatorBackend(val config: VerilatorBackendConfig) extends Backend {
 #include "V${config.toplevelName}__Syms.h"
 
 using namespace std;
+
+#if defined(VERILATOR_VERSION_INTEGER) && (VERILATOR_VERSION_INTEGER >= 5047000)
+using WData = EData;
+#endif
 
 class ISignalAccess{
 public:


### PR DESCRIPTION
    SIM:VerilatorBackend: Fix 5.xx missing WData
    
    Issue: https://github.com/SpinalHDL/SpinalHDL/issues/1919#issue-4514940087
    
    Add check condition to use WData type.
    Current Verilator require users to add this manually which is bad to new
    users. And this also break the work out of box idea.
    
    Signed-off-by: Brian Sune <briansune@gmail.com>