### PR TITLE
feat: Add readAsyncWrite port inference for Mem

### DIFF
--- a/core/src/main/scala/spinal/core/Mem.scala
+++ b/core/src/main/scala/spinal/core/Mem.scala
@@ -545,6 +545,54 @@ class Mem[T <: Data](val wordType: HardType[T], val wordCount: Int) extends Decl
 //    readWord
   }
 
+  def readAsyncWrite(address       : UInt,
+                     data          : T,
+                     write         : Bool,
+                     mask          : Bits = null,
+                     readUnderWrite: ReadUnderWritePolicy = dontCare,
+                     clockCrossing : Boolean = false,
+                     duringWrite   : DuringWritePolicy = dontCare): T = {
+    readAsyncWriteImpl(address,data,write,mask,readUnderWrite,clockCrossing,false, duringWrite = duringWrite)
+  }
+
+  def readAsyncWriteMixedWidth[U <: Data](address       : UInt,
+                                          data          : U,
+                                          write         : Bool,
+                                          mask          : Bits = null,
+                                          readUnderWrite: ReadUnderWritePolicy = dontCare,
+                                          clockCrossing : Boolean = false,
+                                          duringWrite : DuringWritePolicy = dontCare): U = {
+    readAsyncWriteImpl(address, data, write, mask, readUnderWrite, clockCrossing, true, duringWrite = duringWrite)
+  }
+
+  def readAsyncWriteImpl[U <: Data](address         : UInt,
+                                    data            : U,
+                                    write           : Bool,
+                                    mask            : Bits = null,
+                                    readUnderWrite  : ReadUnderWritePolicy = dontCare,
+                                    clockCrossing   : Boolean = false,
+                                    allowMixedWidth : Boolean = false,
+                                    duringWrite : DuringWritePolicy = dontCare): U = {
+
+    val readWritePort = MemReadAsyncWrite(this, address, data.asBits, mask, write, if(allowMixedWidth) data.getBitsWidth else getWidth ,ClockDomain.current, readUnderWrite, duringWrite)
+
+    this.parentScope.append(readWritePort)
+    this.dlcAppend(readWritePort)
+
+    val readWord = cloneOf(data)
+    val readBits = (if(allowMixedWidth) Bits() else Bits(getWidth bits))
+
+    if(allowMixedWidth) readWritePort.addTag(AllowMixedWidth)
+    if(clockCrossing) {
+      readWritePort.addTag(crossClockDomain)
+      readWritePort.addTag(new crossClockMaxDelay(1, true))
+    }
+
+    readBits.assignFrom(readWritePort)
+    readWord.assignFromBits(readBits)
+    readWord
+  }
+
   override def addAttribute(attribute: Attribute): this.type = addTag(attribute)
 
   private[core] def getMemSymbolWidth(): Int = {
@@ -563,6 +611,16 @@ class Mem[T <: Data](val wordType: HardType[T], val wordCount: Int) extends Decl
           }
         }
       case port: MemReadWrite =>
+        if(port.mask != null){
+          val portSymbolWidth = getWidth/port.mask.getWidth
+          if(symbolWidthSet){
+            if(symbolWidth != portSymbolWidth) SpinalError(s"Mem with different aspect ratio at\n${this.getScalaLocationLong}")
+          }else{
+            symbolWidth = portSymbolWidth
+            symbolWidthSet = true
+          }
+        }
+      case port: MemReadAsyncWrite =>
         if(port.mask != null){
           val portSymbolWidth = getWidth/port.mask.getWidth
           if(symbolWidthSet){
@@ -951,6 +1009,108 @@ class MemReadWrite() extends MemPortStatement with WidthProvider with ContextUse
   override def foreachClockDomain(func: (ClockDomain) => Unit): Unit = func(clockDomain)
   override def remapClockDomain(func: ClockDomain => ClockDomain) = clockDomain = func(clockDomain)
 }
+
+
+object MemReadAsyncWrite {
+  def apply(mem: Mem[_], address: UInt, data: Bits, mask: Bits, writeEnable: Bool, width: Int, clockDomain: ClockDomain, readUnderWrite: ReadUnderWritePolicy, duringWrite: DuringWritePolicy): MemReadAsyncWrite = {
+    val ret = new MemReadAsyncWrite
+    ret.mem         = mem
+    ret.address     = address
+    ret.mask        = mask
+    ret.writeEnable = writeEnable
+    ret.clockDomain = clockDomain
+    ret.width       = width
+    ret.data        = data
+    ret.readUnderWrite = readUnderWrite
+    ret.duringWrite = duringWrite
+    ret
+  }
+}
+
+
+class MemReadAsyncWrite() extends MemPortStatement with WidthProvider with ContextUser with Expression {
+  var width        : Int = -1
+  var address      : Expression with WidthProvider = null
+  var data         : Expression with WidthProvider = null
+  var mask         : Expression with WidthProvider = null
+  var writeEnable  : Expression  = null
+  var clockDomain  : ClockDomain = null
+  var readUnderWrite : ReadUnderWritePolicy = null
+  var duringWrite : DuringWritePolicy = null
+
+  def getMaskWidth(default : Int = 1) = if(mask != null) mask.getWidth else default
+  def getSymbolWidth = if (mask != null) width / mask.getWidth else 1
+  def getWordsCount = mem.wordCount*mem.width/getWidth
+  def getAddressWidth = log2Up(getWordsCount)
+
+  override def opName = "Mem.readAsyncWriteSync(x)"
+
+  override def getTypeObject = TypeBits
+
+  override def dlcParent = mem
+
+  override def addAttribute(attribute: Attribute): this.type = addTag(attribute)
+
+  override def getWidth = width
+
+  override def remapExpressions(func: Expression => Expression): Unit = {
+    address = stabilized(func, address).asInstanceOf[Expression with WidthProvider]
+    data = stabilized(func, data).asInstanceOf[Expression with WidthProvider]
+    if(mask != null) mask = stabilized(func, mask).asInstanceOf[Expression with WidthProvider]
+    writeEnable = stabilized(func, writeEnable)
+  }
+
+  override def foreachExpression(func: Expression => Unit): Unit = {
+    func(address)
+    func(data)
+    if(mask != null) func(mask)
+    func(writeEnable)
+  }
+
+
+  override def foreachDrivingExpression(func: Expression => Unit): Unit = {
+    func(address)
+    func(data)
+    if(mask != null) func(mask)
+    func(writeEnable)
+  }
+
+  override def normalizeInputs: Unit = {
+    if(getWidth == 0) return
+    val addressReq = mem.addressWidth + log2Up(aspectRatio)
+    address = InputNormalize.resizedOrUnfixedLit(address,addressReq,new ResizeUInt,address, this)
+
+    if (readUnderWrite == readFirst) PendingError(s"readFirst mode for asynchronous read is not allowed\n ${this.getScalaLocationLong}")
+
+    if(mem.getWidth != getWidth){
+      if(!hasTag(AllowMixedWidth)) {
+        PendingError(s"Write data width (${data.getWidth} bits) is not the same as the memory one ($mem) at\n${this.getScalaLocationLong}")
+        return
+      }
+      if(mem.getWidth / getWidth * getWidth != mem.getWidth) {
+        PendingError(s"The aspect ratio between written data and the memory should be a power of two. currently it's ${mem.getWidth}/${getWidth}. Memory : $mem, written at\n${this.getScalaLocationLong}")
+        return
+      }
+    }
+
+    if(mask != null && getWidth % mask.getWidth != 0) {
+      PendingError(s"Memory write_data_width % write_data_mask_width != 0 at\n${this.getScalaLocationLong}")
+      return
+    }
+
+
+    if(address.getWidth != addressReq) {
+      PendingError(s"Address used to write $mem doesn't match the required width, ${address.getWidth} bits in place of ${mem.addressWidth + log2Up(aspectRatio)} bits\n${this.getScalaLocationLong}")
+      return
+    }
+  }
+
+  def aspectRatio = mem.getWidth / getWidth
+
+  override def foreachClockDomain(func: (ClockDomain) => Unit): Unit = func(clockDomain)
+  override def remapClockDomain(func: ClockDomain => ClockDomain) = clockDomain = func(clockDomain)
+}
+
 
 case class MemSymbolesMapping(name : String, range: Range){
   val width = range.size

--- a/core/src/main/scala/spinal/core/Mem.scala
+++ b/core/src/main/scala/spinal/core/Mem.scala
@@ -1043,7 +1043,7 @@ class MemReadAsyncWrite() extends MemPortStatement with WidthProvider with Conte
   def getWordsCount = mem.wordCount*mem.width/getWidth
   def getAddressWidth = log2Up(getWordsCount)
 
-  override def opName = "Mem.readAsyncWriteSync(x)"
+  override def opName = "Mem.readAsyncWrite(x)"
 
   override def getTypeObject = TypeBits
 

--- a/core/src/main/scala/spinal/core/MemBlackBox.scala
+++ b/core/src/main/scala/spinal/core/MemBlackBox.scala
@@ -334,6 +334,43 @@ class Ram_1wrs(
 }
 
 
+class Ram_1wra(
+  val wordWidth      : Int,
+  val wordCount      : Int,
+  val technology     : MemTechnologyKind,
+  val readUnderWrite : ReadUnderWritePolicy = dontCare,
+  val duringWrite    : DuringWritePolicy = dontCare,
+  val maskWidth      : Int,
+  val maskEnable     : Boolean
+) extends BlackBox {
+
+  if (readUnderWrite == readFirst) SpinalError("readFirst mode for asynchronous read is not allowed")
+
+  addGenerics(
+    "wordCount"      -> Ram_1wra.this.wordCount,
+    "wordWidth"      -> Ram_1wra.this.wordWidth,
+    "readUnderWrite" -> Ram_1wra.this.readUnderWrite.readUnderWriteString,
+    "duringWrite"    -> Ram_1wra.this.duringWrite.duringWriteString,
+    "technology"     -> Ram_1wra.this.technology.technologyKind,
+    "maskWidth"      -> Ram_1wra.this.maskWidth,
+    "maskEnable"     -> Ram_1wra.this.maskEnable
+  )
+
+  val io = new Bundle {
+    val clk    =  in Bool()
+    val en     =  in Bool()
+    val wr     =  in Bool()
+    val addr   =  in UInt(log2Up(wordCount) bit)
+    val mask   =  in Bits(maskWidth bits)
+    val wrData =  in Bits(wordWidth bit)
+    val rdData = out Bits(wordWidth bit)
+  }
+
+  mapCurrentClockDomain(io.clk)
+  noIoPrefix()
+}
+
+
 class Ram_2wrs(
   val wordWidth            : Int,
   val wordCount            : Int,
@@ -472,6 +509,26 @@ class Ram_Generic(val topo : MemTopology, utils : PhaseMemBlackBoxingWithPolicy)
     parent.rework {
       addr.assignFrom(p.address)
       en.assignFrom(wrapBool(p.chipSelect) && p.clockDomain.isClockEnableActive)
+      wr.assignFrom(p.writeEnable)
+      wrData.assignFrom(p.data)
+      mask.assignFrom((if (p.mask != null) p.mask else B"1"))
+      wrapConsumers(p, rdData)
+    }
+  }
+
+  val raw = for(p <- topo.readAsyncWrite) yield new Area{
+    val maskWidth = p.getMaskWidth()
+    val clk  = in Bool()
+    val en   = in Bool()
+    val wr   = in Bool()
+    val mask = in Bits(maskWidth bits)
+    val addr = in UInt(p.getAddressWidth bits)
+    val wrData = in Bits(p.getWidth bits)
+    val rdData = out Bits(p.getWidth bits)
+    mapClockDomain(p.clockDomain, clk)
+    parent.rework {
+      addr.assignFrom(p.address)
+      en.assignFrom(p.clockDomain.isClockEnableActive)
       wr.assignFrom(p.writeEnable)
       wrData.assignFrom(p.data)
       mask.assignFrom((if (p.mask != null) p.mask else B"1"))

--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -85,7 +85,7 @@ trait MemBlackboxingPolicy {
   def onUnblackboxable(topology: MemTopology, who: Any, message: String): Unit
 
   def generateUnblackboxableError(topology: MemTopology, who: Any, message: String): Unit = {
-    PendingError(s"${this.getClass} is not able to blackbox ${topology.mem}\n  write ports : ${topology.writes.size} \n  readAsync ports : ${topology.readsAsync.size} \n  readSync ports : ${topology.readsSync.size} \n  readWrite ports : ${topology.readWriteSync.size}\n  -> $message")
+    PendingError(s"${this.getClass} is not able to blackbox ${topology.mem}\n  write ports : ${topology.writes.size} \n  readAsync ports : ${topology.readsAsync.size} \n  readSync ports : ${topology.readsSync.size} \n  readWrite ports : ${topology.readWriteSync.size} \n  readAsyncWrite ports : ${topology.readAsyncWrite.size}\n  -> $message")
   }
 }
 

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -162,6 +162,10 @@ class ComponentEmitterVerilog(
             val name = component.localNamingScope.allocateName(portName)
             declarations ++= emitExpressionWrap(s, name, "reg")
             wrappedExpressionToName(s) = name
+          case s: MemReadAsyncWrite =>
+            val name = component.localNamingScope.allocateName(portName)
+            declarations ++= emitExpressionWrap(s, name)
+            wrappedExpressionToName(s) = name
           case s: MemWrite    =>
         }
         portId += 1
@@ -1550,8 +1554,21 @@ end
               case _ => SpinalError(s"memReadWrite can only be emited as readFirst, writeFirst, noChange or dontCare into Verilog $memReadWrite")
             }
         }
+      case memReadAsyncWrite: MemReadAsyncWrite  =>
+        if(memReadAsyncWrite.aspectRatio != 1) SpinalError(s"Verilog backend can't emit ${memReadAsyncWrite.mem} because of its mixed width ports")
 
+        if (memReadAsyncWrite.readUnderWrite != writeFirst) SpinalWarning(s"mem.readAsyncWrite can only be write first into Verilog")
 
+        val symbolCount = memReadAsyncWrite.mem.getMemSymbolCount()
+        if(memBitsMaskKind == SINGLE_RAM || symbolCount == 1)
+          tmpBuilder ++= s"  assign ${emitExpression(memReadAsyncWrite)} = ${emitReference(memReadAsyncWrite.mem, false)}[${emitExpression(memReadAsyncWrite.address)}];\n"
+        else
+          (0 until symbolCount).foreach(i => tmpBuilder  ++= s"  assign ${emitExpression(memReadAsyncWrite)}[${(i + 1) * symbolWidth - 1} : ${i * symbolWidth}] = ${emitReference(memReadAsyncWrite.mem, false)}_symbol$i[${emitExpression(memReadAsyncWrite.address)}];\n")
+
+        emitClockedProcess((tab, b) => {
+          val symbolCount = memReadAsyncWrite.mem.getMemSymbolCount()
+          emitWrite(b, memReadAsyncWrite.mem, emitExpression(memReadAsyncWrite.writeEnable), memReadAsyncWrite.address, memReadAsyncWrite.data, memReadAsyncWrite.mask, memReadAsyncWrite.mem.getMemSymbolCount(), memReadAsyncWrite.mem.getMemSymbolWidth(),tab)
+        }, null, tmpBuilder, memReadAsyncWrite.clockDomain, false)
       case memReadSync: MemReadSync   =>
         if(memReadSync.aspectRatio != 1) SpinalError(s"Verilog backend can't emit ${memReadSync.mem} because of its mixed width ports")
         if(memReadSync.readUnderWrite == writeFirst) SpinalError(s"memReadSync with writeFirst is as dontCare into Verilog $memReadSync")

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -164,6 +164,10 @@ class ComponentEmitterVhdl(
             val name = component.localNamingScope.allocateName(portName)
             declarations ++= s"  signal $name : ${emitType(s)};\n"
             wrappedExpressionToName(s) = name
+          case s: MemReadAsyncWrite =>
+            val name = component.localNamingScope.allocateName(portName)
+            declarations ++= s"  signal $name : ${emitType(s)};\n"
+            wrappedExpressionToName(s) = name
           case s: MemWrite =>
         }
       })
@@ -1240,6 +1244,9 @@ class ComponentEmitterVhdl(
         b ++= s"${tab}if ${emitExpression(memReadWrite.chipSelect)} = '1' then\n"
         emitRead(b, memReadWrite.mem, memReadWrite.address, memReadWrite, tab + "  ")
         b ++= s"${tab}end if;\n"
+      case memReadAsyncWrite: MemReadAsyncWrite =>
+        if(memReadAsyncWrite.aspectRatio != 1) SpinalError(s"VHDL backend can't emit ${memReadAsyncWrite.mem} because of its mixed width ports")
+        emitWrite(b, memReadAsyncWrite.mem,s"${emitExpression(memReadAsyncWrite.writeEnable)} = '1'", memReadAsyncWrite.address, memReadAsyncWrite.data, memReadAsyncWrite.mask, memReadAsyncWrite.mem.getMemSymbolCount, memReadAsyncWrite.mem.getMemSymbolWidth(),tab)
     }
 
     val cdTasks = mutable.LinkedHashMap[ClockDomain, ArrayBuffer[MemPortStatement]]()
@@ -1281,6 +1288,20 @@ class ComponentEmitterVhdl(
             emitRead(b, memReadSync.mem, memReadSync.address, memReadSync, tab)
           }
         }, null, tmpBuilder, memReadSync.clockDomain, false)
+      case memReadAsyncWrite: MemReadAsyncWrite  =>
+        if(memReadAsyncWrite.aspectRatio != 1) SpinalError(s"VHDL backend can't emit ${memReadAsyncWrite.mem} because of its mixed width ports")
+        if (memReadAsyncWrite.readUnderWrite != writeFirst) SpinalWarning(s"memReadAsyncWrite can only be write first into VHDL")
+        val symbolCount = memReadAsyncWrite.mem.getMemSymbolCount
+        if(memBitsMaskKind == SINGLE_RAM || symbolCount == 1)
+          tmpBuilder ++= s"  ${emitExpression(memReadAsyncWrite)} <= ${emitReference(memReadAsyncWrite.mem, false)}(to_integer(${emitExpression(memReadAsyncWrite.address)}));\n"
+        else
+          (0 until symbolCount).foreach(i => tmpBuilder  ++= s"  ${emitExpression(memReadAsyncWrite)}(${(i + 1) * symbolWidth - 1} downto ${i * symbolWidth}) <= ${emitReference(memReadAsyncWrite.mem, false)}_symbol$i(to_integer(${emitExpression(memReadAsyncWrite.address)}));\n")
+
+        emitClockedProcess((tab, b) => {
+          val symbolCount = memReadAsyncWrite.mem.getMemSymbolCount()
+          emitWrite(b, memReadAsyncWrite.mem,s"${emitExpression(memReadAsyncWrite.writeEnable)} = '1'", memReadAsyncWrite.address, memReadAsyncWrite.data, memReadAsyncWrite.mask, memReadAsyncWrite.mem.getMemSymbolCount, memReadAsyncWrite.mem.getMemSymbolWidth(),tab)
+        }, null, tmpBuilder, memReadAsyncWrite.clockDomain, false)
+
       case port: MemReadAsync  =>
         if(port.aspectRatio != 1) SpinalError(s"VHDL backend can't emit ${port.mem} because of its mixed width ports")
         if (port.readUnderWrite != writeFirst) SpinalWarning(s"memReadAsync can only be write first into VHDL")
@@ -1298,6 +1319,7 @@ class ComponentEmitterVhdl(
           case port: MemWrite     => emitPort(port, tab, b)
           case port: MemReadSync  => if(port.readUnderWrite != dontCare) emitPort(port, tab, b)
           case port: MemReadWrite => emitPort(port, tab, b)
+          case port: MemReadAsyncWrite => emitPort(port, tab, b)
         }
         emitClockedProcess(syncLogic, null, tmpBuilder, cd, false)
       }

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -2281,7 +2281,7 @@ class PhaseRemoveUselessStuff(postClockPulling: Boolean, tagVitals: Boolean) ext
             smrw.walkExpression { case e: Statement => propagateInner(e); case _ => }
           case smrwas: MemReadAsyncWrite =>
             smrwas.isVital |= vital
-            if (smrwas.mem != null) propagateInner(smrwas.mem) else SpinalWarning(s"MemReadAsyncWriteSync statement [$smrwas] has null mem reference.")
+            if (smrwas.mem != null) propagateInner(smrwas.mem) else SpinalWarning(s"MemReadAsyncWrite statement [$smrwas] has null mem reference.")
             smrwas.walkExpression { case e: Statement => propagateInner(e); case _ => }
           case smrs: MemReadSync =>
             smrs.isVital |= vital

--- a/core/src/main/scala/spinal/core/internals/Phase.scala
+++ b/core/src/main/scala/spinal/core/internals/Phase.scala
@@ -706,6 +706,7 @@ class MemTopology(val mem: Mem[_], val consumers : mutable.HashMap[Expression, A
   val readsAsync               = ArrayBuffer[MemReadAsync]()
   val readsSync                = ArrayBuffer[MemReadSync]()
   val readWriteSync            = ArrayBuffer[MemReadWrite]()
+  val readAsyncWrite           = ArrayBuffer[MemReadAsyncWrite]()
   val writeReadSameAddressSync = ArrayBuffer[(MemWrite, MemReadSync)]() //DISABLED
 
   var portCount = 0
@@ -716,6 +717,7 @@ class MemTopology(val mem: Mem[_], val consumers : mutable.HashMap[Expression, A
       case p: MemReadAsync => readsAsync += p
       case p: MemReadSync  => readsSync += p
       case p: MemReadWrite => readWriteSync += p
+      case p: MemReadAsyncWrite => readAsyncWrite += p
     }
   })
 }
@@ -832,6 +834,34 @@ trait PhaseMemBlackboxing extends PhaseNetlist {
                 }
               }
               wrapConsumers(port, buffer)
+            }
+            case port : MemReadAsyncWrite => {
+              assert(port.aspectRatio == 1)
+              assert(port.readUnderWrite == dontCare || port.readUnderWrite == writeFirst)
+              val storage = port.clockDomain(Reg(Bits(mem.width bits)))
+              storage.addTags(mem.getTags())
+              if(mem.initialContent != null){
+                assert(mem.initialContent.size == 1)
+                storage.init(mem.initialContent.head)
+              }
+              content := storage
+              val readValue = Bits(mem.width bits)
+              readValue := content
+              readValue.addTags(port.getTags())
+              wrapConsumers(port, readValue)
+              when(port.writeEnable.asInstanceOf[Bool]){
+                if(port.mask == null) {
+                  storage := port.data.asInstanceOf[Bits]
+                } else {
+                  val dst = storage.subdivideIn(port.mask.getWidth slices)
+                  val src = port.data.asInstanceOf[Bits].subdivideIn(port.mask.getWidth slices)
+                  for(i <- 0 until port.mask.getWidth) {
+                    when(port.mask.asInstanceOf[Bits](i)) {
+                      dst(i) := src(i)
+                    }
+                  }
+                }
+              }
             }
           }
 
@@ -990,7 +1020,7 @@ class PhaseMemBlackBoxingDefault(policy: MemBlackboxingPolicy) extends PhaseMemB
     if (mem.initialContent != null) {
       return "Can't blackbox ROM"  //TODO
       //      } else if (topo.writes.size == 1 && topo.readsAsync.size == 1 && topo.portCount == 2) {
-    } else if (topo.writes.size == 1 && (topo.readsAsync.nonEmpty || topo.readsSync.nonEmpty) && topo.writeReadSameAddressSync.isEmpty && topo.readWriteSync.isEmpty) {
+    } else if (topo.writes.size == 1 && (topo.readsAsync.nonEmpty || topo.readsSync.nonEmpty) && topo.writeReadSameAddressSync.isEmpty && topo.readWriteSync.isEmpty && topo.readAsyncWrite.isEmpty) {
       mem.component.rework {
         val wr = topo.writes(0)
         for (rd <- topo.readsAsync) {
@@ -1094,6 +1124,39 @@ class PhaseMemBlackBoxingDefault(policy: MemBlackboxingPolicy) extends PhaseMemB
           ram.setName(mem.getName())
         }
 
+        removeMem()
+      }
+
+    } else if (topo.portCount == 1 && topo.readAsyncWrite.size == 1) {
+
+      mem.component.rework {
+        val port = topo.readAsyncWrite.head
+
+        val ram = port.clockDomain on new Ram_1wra(
+          wordWidth = port.width,
+          wordCount = mem.wordCount*mem.width/port.width,
+          technology = mem.technology,
+          readUnderWrite = port.readUnderWrite,
+          duringWrite = port.duringWrite,
+          maskWidth = if (port.mask != null) port.mask.getWidth else 1,
+          maskEnable = port.mask != null
+        )
+
+        ram.addTag(new MemBlackboxOf(topo.mem.asInstanceOf[Mem[Data]]))
+
+        ram.io.addr.assignFrom(port.address)
+        ram.io.en.assignFrom(port.clockDomain.isClockEnableActive)
+        ram.io.wr.assignFrom(port.writeEnable)
+        ram.io.wrData.assignFrom(port.data)
+
+        if (port.mask != null)
+          ram.io.mask.assignFrom(port.mask)
+        else
+          ram.io.mask := B"1"
+
+        wrapConsumers(port, ram.io.rdData)
+
+        ram.setName(mem.getName())
         removeMem()
       }
     } else if (topo.portCount == 1 && topo.readWriteSync.size == 1) {
@@ -1578,6 +1641,7 @@ class PhaseDevice(pc : PhaseContext) extends PhaseMisc{
           case port: MemReadAsync => hit = true
           case port: MemWrite => withWrite = true
           case port: MemReadWrite => withWrite = true
+          case port: MemReadAsyncWrite => withWrite = true
           case port: MemReadSync =>
         }
         val alreadyTagged = mem.getTags().exists{
@@ -1590,6 +1654,7 @@ class PhaseDevice(pc : PhaseContext) extends PhaseMisc{
         mem.dlcForeach(e => e match {
           case port: MemWrite      =>
           case port: MemReadWrite  => onlyDontCare &= port.readUnderWrite == dontCare
+          case port: MemReadAsyncWrite => onlyDontCare &= port.readUnderWrite == dontCare
           case port: MemReadSync   => onlyDontCare &= port.readUnderWrite == dontCare
           case port: MemReadAsync  => onlyDontCare &= port.readUnderWrite == dontCare
         })
@@ -1628,6 +1693,7 @@ class PhaseDevice(pc : PhaseContext) extends PhaseMisc{
           }
           case e: MemReadSync =>
           case e: MemReadWrite =>
+          case e: MemReadAsyncWrite =>
           case e: Expression => e.foreachDrivingExpression(forExp)
         }
         s.walkParentTreeStatementsUntilRootScope{sParent =>
@@ -1830,6 +1896,7 @@ class PhaseCheckCombinationalLoops() extends PhaseCheck{
           case node: Mem[_]       =>
           case node: MemReadSync  =>
           case node: MemReadWrite =>
+          case node: MemReadAsyncWrite =>
           case node: MemWrite     =>
           case node: Expression   =>
             node.foreachDrivingExpression(e => walk(newPath, e))
@@ -1882,6 +1949,7 @@ class PhaseCheckCrossClock() extends PhaseCheck{
           case node: MemReadAsync => node.foreachDrivingExpression(e => walk(e))
           case node: MemReadSync => cds += node.clockDomain
           case node: MemReadWrite => cds += node.clockDomain
+          case node: MemReadAsyncWrite => cds += node.clockDomain
           case node: Expression => node.foreachDrivingExpression(e => walk(e))
         }
       }
@@ -1934,6 +2002,7 @@ class PhaseCheckCrossClock() extends PhaseCheck{
           case s : MemReadAsync =>
           case s : MemWrite => if(!areSynchronous(s.clockDomain, targetCd)) issueRaw(s, s.clockDomain, newPath, targetCd)
           case s : MemReadWrite => if(!areSynchronous(s.clockDomain, targetCd)) issueRaw(s, s.clockDomain, newPath, targetCd)
+          case s : MemReadAsyncWrite => if(!areSynchronous(s.clockDomain, targetCd)) issueRaw(s, s.clockDomain, newPath, targetCd)
         }
       }
 
@@ -1989,6 +2058,10 @@ class PhaseCheckCrossClock() extends PhaseCheck{
             if(!areSynchronous(node.clockDomain, clockDomain)) {
               issue(node, node.clockDomain)
             }
+          case node: MemReadAsyncWrite =>
+            if(!areSynchronous(node.clockDomain, clockDomain)) {
+              issue(node, node.clockDomain)
+            }
           case node: Expression =>
             node.foreachDrivingExpression(e => walk(e, newPath, clockDomain))
         }
@@ -2017,6 +2090,13 @@ class PhaseCheckCrossClock() extends PhaseCheck{
           s.foreachDrivingExpression(as => walk(as, as :: s :: Nil, s.clockDomain))
           checkMem(s.mem, s :: Nil, s.clockDomain)
         case s: MemReadWrite if !s.hasTag(crossClockDomain) =>
+          if (s.hasTag(classOf[ClockDomainTag])) {
+            PendingError(s"Can't add ClockDomainTag to memory ports:\n" + s.getScalaLocationLong)
+          }
+          walked = GlobalData.get.allocateAlgoIncremental()
+          s.foreachDrivingExpression(as => walk(as, as :: s :: Nil, s.clockDomain))
+          checkMem(s.mem, s :: Nil, s.clockDomain)
+        case s: MemReadAsyncWrite if !s.hasTag(crossClockDomain) =>
           if (s.hasTag(classOf[ClockDomainTag])) {
             PendingError(s"Can't add ClockDomainTag to memory ports:\n" + s.getScalaLocationLong)
           }
@@ -2187,6 +2267,7 @@ class PhaseRemoveUselessStuff(postClockPulling: Boolean, tagVitals: Boolean) ext
           case smem: Mem[_] => smem.foreachStatements {
             case p: MemWrite => propagateInner(p)
             case p: MemReadWrite => propagateInner(p)
+            case p: MemReadAsyncWrite => propagateInner(p)
             case p: MemReadSync if p.isInstanceOf[Statement] => propagateInner(p.asInstanceOf[Statement])
             case p: MemReadAsync if p.isInstanceOf[Statement] => propagateInner(p.asInstanceOf[Statement])
             case _ =>
@@ -2198,6 +2279,10 @@ class PhaseRemoveUselessStuff(postClockPulling: Boolean, tagVitals: Boolean) ext
             smrw.isVital |= vital
             if (smrw.mem != null) propagateInner(smrw.mem) else SpinalWarning(s"MemReadWrite statement [$smrw] has null mem reference.")
             smrw.walkExpression { case e: Statement => propagateInner(e); case _ => }
+          case smrwas: MemReadAsyncWrite =>
+            smrwas.isVital |= vital
+            if (smrwas.mem != null) propagateInner(smrwas.mem) else SpinalWarning(s"MemReadAsyncWriteSync statement [$smrwas] has null mem reference.")
+            smrwas.walkExpression { case e: Statement => propagateInner(e); case _ => }
           case smrs: MemReadSync =>
             smrs.isVital |= vital
             if (smrs.mem != null) propagateInner(smrs.mem) else SpinalWarning(s"MemReadSync statement [$smrs] has null mem reference.")
@@ -2230,6 +2315,7 @@ class PhaseRemoveUselessStuff(postClockPulling: Boolean, tagVitals: Boolean) ext
       case s: AssignmentStatement  =>
       case s: MemWrite             =>
       case s: MemReadWrite         =>
+      case s: MemReadAsyncWrite    =>
       case s: MemReadSync          =>
       case s: MemReadAsync         =>
     }
@@ -2867,6 +2953,7 @@ class PhaseGetInfoRTL(prunedSignals: mutable.Set[BaseType], unusedSignals: mutab
         case s: MemReadSync  => s.algoIncremental = usedId
         case s: MemReadAsync => s.algoIncremental = usedId
         case s: MemReadWrite => s.algoIncremental = usedId
+        case s: MemReadAsyncWrite => s.algoIncremental = usedId
         case s =>
       }
     })

--- a/lib/src/main/scala/spinal/lib/Mem.scala
+++ b/lib/src/main/scala/spinal/lib/Mem.scala
@@ -156,6 +156,29 @@ class MemPimped[T <: Data](mem: Mem[T]) {
     )
     ret
   }
+
+  /** Return a master/slave interface to the [[Mem]] */
+  def readAsyncWritePort(
+    maskWidth     : Int = -1,
+    readUnderWrite: ReadUnderWritePolicy = dontCare,
+    clockCrossing : Boolean = false,
+    duringWrite   : DuringWritePolicy = dontCare) : MemReadAsyncWritePort[T] = {
+    val ret : MemReadAsyncWritePort[T] = MemReadAsyncWritePort(
+      mem.wordType(),
+      mem.addressWidth,
+      maskWidth = maskWidth
+    )
+    ret.rdata := mem.readAsyncWrite(
+      ret.address,
+      ret.wdata,
+      ret.write,
+      ret.mask,
+      readUnderWrite= readUnderWrite,
+      clockCrossing = clockCrossing ,
+      duringWrite   = duringWrite
+    )
+    ret
+  }
 }
 
 
@@ -258,6 +281,27 @@ case class MemReadWritePort[T <: Data](
   val mask    = ifGen(useMask)(Bits(maskWidth bits))
   override def asMaster(): Unit = {
     out(address,wdata,enable,write)
+    if(useMask) out(mask)
+    in(rdata)
+  }
+}
+
+
+/** Master/slave interface to a [[Mem]].
+  * @see [[Mem.readAsyncWritePort()]]
+  */
+case class MemReadAsyncWritePort[T <: Data](
+  dataType : T,
+  addressWidth : Int,
+  maskWidth     : Int = -1) extends Bundle with IMasterSlave {
+  def useMask = maskWidth >= 0
+  val address = UInt(addressWidth bit)
+  val rdata   = cloneOf(dataType)
+  val wdata   = cloneOf(dataType)
+  val write   = Bool()
+  val mask    = ifGen(useMask)(Bits(maskWidth bits))
+  override def asMaster(): Unit = {
+    out(address,wdata,write)
     if(useMask) out(mask)
     in(rdata)
   }

--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -660,6 +660,7 @@ object AnalysisUtils{
     }
     case e: MemReadSync => body(e)
     case e: MemReadWrite =>  body(e)
+    case e: MemReadAsyncWrite =>  body(e)
     case e : Expression => e.foreachDrivingExpression(seekNonCombDriversFromSelf(_)(body))
   }
 
@@ -741,6 +742,10 @@ object LatencyAnalysis {
               port.foreachDrivingExpression(input => {
                 pendingQueues(1) += input
               })
+            case port : MemReadAsyncWrite =>
+              port.foreachDrivingExpression(input => {
+                pendingQueues(1) += input
+              })
             case port : MemReadSync =>
             case port : MemReadAsync =>
               //TODO other ports
@@ -779,6 +784,14 @@ object LatencyAnalysis {
             pendingQueues(lat) += input
           }
           pendingQueues(1) += that.mem
+          return false
+        case that : MemReadAsyncWrite =>
+          that.foreachDrivingExpression(input => {
+            if(walk(input))
+              return true
+          })
+          if(walk(that.mem))
+            return true
           return false
         case that : MemReadAsync =>
           that.foreachDrivingExpression(input => {

--- a/lib/src/main/scala/spinal/lib/eda/TimingExtractor.scala
+++ b/lib/src/main/scala/spinal/lib/eda/TimingExtractor.scala
@@ -158,6 +158,7 @@ object TimingExtractor {
     case s : Mem[_] => None
     case p : MemReadSync => Some(p.clockDomain)
     case p : MemReadWrite => Some(p.clockDomain)
+    case p : MemReadAsyncWrite => Some(p.clockDomain)
     case p : MemWrite => Some(p.clockDomain)
     case p : AssertStatement => Some(p.clockDomain)
   }

--- a/lib/src/main/scala/spinal/lib/misc/PathTracer.scala
+++ b/lib/src/main/scala/spinal/lib/misc/PathTracer.scala
@@ -120,6 +120,10 @@ object PathTracer {
               port.foreachDrivingExpression(input => {
                 onUp(input, 1)
               })
+            case port : MemReadAsyncWrite =>
+              port.foreachDrivingExpression(input => {
+                onUp(input, 1)
+              })
             case port : MemReadSync =>
             case port : MemReadAsync =>
             //TODO other ports
@@ -153,6 +157,9 @@ object PathTracer {
             onUp(input, 1)
           }
           onUp(that.mem, 1)
+        case that : MemReadAsyncWrite =>
+          that.foreachDrivingExpression(input => onUp(input, 1))
+          onUp(that.mem, 0)
         case that : MemReadAsync =>
           that.foreachDrivingExpression(input => {
             onUp(input, 0)


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

Currently, there is a lack of a model for single-port asynchronous read and synchronous write memory. This makes it inconvenient during the black-boxing process.

I added the relevant code for readAsyncWrite by following the same approach as for other types of ports. If there are any mistakes, please let me know.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

Only new additions without any modifications will not affect the existing code. The pattern matching branches have all been covered as well.

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
