### PR TITLE
Add scala 2.12.21 and scala 2.13.18 version support

### DIFF
--- a/.github/workflows/run-tests-2_13.yml
+++ b/.github/workflows/run-tests-2_13.yml
@@ -18,7 +18,7 @@ jobs:
   run-test:
     uses: ./.github/workflows/sbt-tests.yml
     with:
-      scala_version: '2.13.12'
+      scala_version: '2.13.18'
       runner_os: 'Linux'
       github_sha: ${{ github.sha }}
       docker_image_version: 'v1.2.0'

--- a/.github/workflows/run-tests-verilator5.yml
+++ b/.github/workflows/run-tests-verilator5.yml
@@ -14,11 +14,11 @@ on:
         required: true
         default: 'warning'
 
-jobs:  
+jobs:
   run-test:
     uses: ./.github/workflows/sbt-tests.yml
     with:
-      scala_version: '2.12.18'
+      scala_version: '2.12.21'
       runner_os: 'Linux'
       github_sha: ${{ github.sha }}
       docker_image_version: 'v1.3.0'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
   run-test:
     uses: ./.github/workflows/sbt-tests.yml
     with:
-      scala_version: '2.12.18'
+      scala_version: '2.12.21'
       runner_os: 'Linux'
       github_sha: ${{ github.sha }}
       docker_image_version: 'v1.2.0'

--- a/project/version.conf
+++ b/project/version.conf
@@ -1,4 +1,4 @@
-compilers = ["2.12.18", "2.13.12"]
+compilers = ["2.12.18", "2.13.12", "2.12.21", "2.13.18"]
 compilerIsRC = false
 
 isDev = true


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Part 2 of #1910

# Context, Motivation & Description

Adding scala 2.12.21 and 2.13.18 to the version. Also change the scala version to test ci.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

Should have no impact, as old version is not dropped. But it may suffer extra deprecated function check as new version is used.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
