### PR TITLE
Refactor the TileLink peripherals with new pipeline API

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Ram.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Ram.scala
@@ -3,7 +3,7 @@ import spinal.core._
 import spinal.core.sim.SimMemPimper
 import spinal.lib._
 import spinal.lib.bus.tilelink.coherent.OrderingCmd
-import spinal.lib.pipeline._
+import spinal.lib.misc.pipeline._
 
 class Ram (p : NodeParameters,
            bytes : Int) extends Component {
@@ -14,18 +14,19 @@ class Ram (p : NodeParameters,
   val mem = Mem.fill(bytes/p.m.dataBytes)(Bits(p.m.dataWidth bits))
   val port = mem.readWriteSyncPort(p.m.dataBytes)
 
-  val pipeline = new Pipeline {
-    val cmd = new Stage {
+  val pipeline = new StageCtrlPipeline {
+    val cmdNode = ctrl(0)
+    val cmd = new cmdNode.Area {
       val IS_GET = insert(Opcode.A.isGet(io.up.a.opcode))
       val SIZE = insert(io.up.a.size)
       val SOURCE = insert(io.up.a.source)
       val LAST = insert(True)
 
-      valid := io.up.a.valid
-      io.up.a.ready := isReady
+      up.valid := io.up.a.valid
+      io.up.a.ready := up.isReady
 
       val addressShifted = (io.up.a.address >> log2Up(p.m.dataBytes))
-      port.enable := isFiring
+      port.enable := up.isFiring
       port.write := !IS_GET
       port.wdata := io.up.a.data
       port.mask := io.up.a.mask
@@ -41,7 +42,7 @@ class Ram (p : NodeParameters,
         val busy = counter =/= 0
         when(busy && isGet) {
           io.up.a.ready := False
-          valid := True
+          up.valid := True
         }
 
         when(io.up.a.fire && !busy){
@@ -57,7 +58,7 @@ class Ram (p : NodeParameters,
           SOURCE := source
           IS_GET := isGet
         }
-        when(isFiring) {
+        when(up.isFiring) {
           counter := counter + 1
           when(LAST) {
             counter := 0
@@ -68,10 +69,11 @@ class Ram (p : NodeParameters,
 
     }
 
-    val rsp = new Stage(Connection.M2S()) {
+    val rspNode = ctrl(1)
+    val rsp = new rspNode.Area {
       val takeIt = cmd.LAST || cmd.IS_GET
       haltWhen(!io.up.d.ready && takeIt)
-      io.up.d.valid := valid && takeIt
+      io.up.d.valid := up.valid && takeIt
       io.up.d.opcode := cmd.IS_GET.mux(Opcode.D.ACCESS_ACK_DATA, Opcode.D.ACCESS_ACK)
       io.up.d.param := 0
       io.up.d.source := cmd.SOURCE

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/Cache.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/Cache.scala
@@ -6,7 +6,7 @@ import spinal.lib.bus.misc.SizeMapping
 import spinal.lib.bus.tilelink._
 import spinal.lib.fsm.{State, StateDelay, StateMachine}
 import spinal.lib.misc.Plru
-import spinal.lib.pipeline._
+import spinal.lib.misc.pipeline._
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -190,10 +190,10 @@ class Cache(val p : CacheParam) extends Component {
   val coherentMasterCount = coherentMasters.size
   val coherentMasterToSource = coherentMasters.map(_.bSourceId)
 
-  val SET_ID = Stageable(UInt(log2Up(lockSets) bits))
-  val LOCK_CTX = Stageable(Bool())
-  val ADDRESS = Stageable(ubp.address)
-  val GS_ID = Stageable(UInt(log2Up(generalSlotCount) bits))
+  val SET_ID = Payload(UInt(log2Up(lockSets) bits))
+  val LOCK_CTX = Payload(Bool())
+  val ADDRESS = Payload(ubp.address)
+  val GS_ID = Payload(UInt(log2Up(generalSlotCount) bits))
 
   val emptyId = 0
   def isBlockEmpty(blockId : UInt) = blockId === emptyId
@@ -377,8 +377,8 @@ class Cache(val p : CacheParam) extends Component {
   }
 
 
-  val CTRL_CMD = Stageable(new CtrlCmd())
-  val BUFFER_A_ID = Stageable(UInt((if(ubp.withDataA) log2Up(aBufferCount).toInt else 0) bits))
+  val CTRL_CMD = Payload(new CtrlCmd())
+  val BUFFER_A_ID = Payload(UInt((if(ubp.withDataA) log2Up(aBufferCount).toInt else 0) bits))
 
 
 
@@ -777,14 +777,14 @@ class Cache(val p : CacheParam) extends Component {
   }
 
   // TODO check older way is allocated
-  val ctrl = new Pipeline{
-    val stages = newChained(3, Connection.M2S())
-    val inserterStage = stages(0)
-    val addressStage = stages(0)
-    val dataStage = stages(1)
-    val tagStage = stages(1)
-    val prepStage = stages(1)
-    val processStage = stages(2)
+  val ctrl = new StageCtrlPipeline{
+    val inserterStage = ctrl(0)
+    val addressStage = ctrl(0)
+    val dataStage = ctrl(1)
+    val tagStage = ctrl(1)
+    val prepStage = ctrl(1)
+    val processStage = ctrl(2)
+    val stages = List(inserterStage, dataStage, processStage)
 
     import CtrlOpcode._
 
@@ -795,11 +795,9 @@ class Cache(val p : CacheParam) extends Component {
       val fifo = StreamFifo(new CtrlCmd, ctrlLoopbackDepth, forFMax = true)
     }
 
-    val inserter = new Area {
-      import inserterStage._
-
+    val inserter = new inserterStage.Area {
       def hazardHalt(that : Stream[CtrlCmd]) = {
-        val hits = stages.tail.map(s => s.valid && s(CTRL_CMD).address(setsRange) === that.address(setsRange))
+        val hits = stages.tail.map(s => s.up.valid && s(CTRL_CMD).address(setsRange) === that.address(setsRange))
         that.haltWhen(hits.orR)
       }
 
@@ -860,30 +858,28 @@ class Cache(val p : CacheParam) extends Component {
         loopback.occupancy.increment()
       }
 
-      driveFrom(hazardHalt(arbiter.io.output))
+      up.arbitrateFrom(hazardHalt(arbiter.io.output))
       inserterStage(CTRL_CMD) := arbiter.io.output
 
       val SOURCE_OH = insert(B(coherentMasters.map(_.sourceHit(CTRL_CMD.source))))
     }
 
-    cache.tags.read.cmd.valid := addressStage.isFiring
+    cache.tags.read.cmd.valid := addressStage.up.isFiring
     cache.tags.read.cmd.payload := addressStage(CTRL_CMD).address(lineRange)
     val CACHE_TAGS = dataStage.insert(cache.tags.read.rsp)
 
-    cache.plru.read.cmd.valid := addressStage.isFiring
+    cache.plru.read.cmd.valid := addressStage.up.isFiring
     cache.plru.read.cmd.payload := addressStage(CTRL_CMD).address(setsRange)
     val CACHE_PLRU = dataStage.insert(cache.plru.read.rsp)
 
 
-    val tags = new Area{
-      import tagStage._
-      val read = tagStage(CACHE_TAGS)
+    val tags = new tagStage.Area{
+      val read = CACHE_TAGS
       val CACHE_HITS  = insert(read.map(t => t.loaded && t.tag === CTRL_CMD.address(tagRange)).asBits)
       val SOURCE_HITS = insert(read.map(t => (t.owners & inserter.SOURCE_OH).orR).asBits)
     }
 
-    val preCtrl = new Area{
-      import prepStage._
+    val preCtrl = new prepStage.Area{
       val PROBE_REGION = insert(p.coherentRegion(CTRL_CMD.address))
       val ALLOCATE_ON_MISS = insert(p.allocateOnMiss(CTRL_CMD.opcode, CTRL_CMD.source, CTRL_CMD.address, CTRL_CMD.size, CTRL_CMD.upParam)) //TODO
       val FROM_A = insert(List(GET(), PUT_FULL_DATA(), PUT_PARTIAL_DATA(), ACQUIRE_BLOCK(), ACQUIRE_PERM(), FLUSH()).sContains(CTRL_CMD.opcode))
@@ -908,22 +904,19 @@ class Cache(val p : CacheParam) extends Component {
       }
     }
 
-    val process = new Area {
-      import processStage._
-
-
+    val process = new processStage.Area {
       val redoUpA = False
       assert(!(isValid && redoUpA && !preCtrl.FROM_A))
-      throwIt(redoUpA)
+      throwWhen(redoUpA)
 
       redoUpA.setWhen(preCtrl.FROM_A && !CTRL_CMD.probed && preCtrl.GS_HIT) // TODO could be less pessimistic
 
 
       val stallIt = False
       assert(!(isValid && stallIt && preCtrl.FROM_A))
-      haltIt(stallIt)
+      haltWhen(stallIt)
 
-      val firstCycle = RegNext(!isStuck || stallIt) init (True)
+      val firstCycle = RegNext(!isValid || up.isReady || stallIt) init (True)
 
       val gsHitVictim = CTRL_CMD.opcode === RELEASE_DATA && (preCtrl.GS_HITS & B(gs.slots.map(_.pending.victimWrite))).orR
       stallIt setWhen(gsHitVictim)
@@ -946,16 +939,16 @@ class Cache(val p : CacheParam) extends Component {
         }
       }
 
-      when(isFiring && preCtrl.FROM_A && askGs && !redoUpA){
+      when(up.isFiring && preCtrl.FROM_A && askGs && !redoUpA){
         loopback.occupancy.decrement()
       }
 
-//      val toProbe = forkStream(askProbe && !redoUpA).swapPayload(new ProbeCmd())
-      val toReadDown = forkStream(askReadDown && !redoUpA).swapPayload(new ReadDownCmd)
-      val toReadBackend = forkStream(askReadBackend && !redoUpA).swapPayload(new ReadBackendCmd)
-      val toWriteBackend = forkStream(askWriteBackend && !redoUpA && !stallIt).swapPayload(new WriteBackendCmd)
-      val toUpD = forkStream(askUpD && !redoUpA).swapPayload(io.up.d.payloadType)
-      val toOrdering = forkFlow(askOrdering && !redoUpA).swapPayload(io.ordering.ctrlProcess.payloadType)
+//      val toProbe = forkStream(enabled = askProbe && !redoUpA).swapPayload(new ProbeCmd())
+      val toReadDown = forkStream(enabled = askReadDown && !redoUpA).swapPayload(new ReadDownCmd)
+      val toReadBackend = forkStream(enabled = askReadBackend && !redoUpA).swapPayload(new ReadBackendCmd)
+      val toWriteBackend = forkStream(enabled = askWriteBackend && !redoUpA && !stallIt).swapPayload(new WriteBackendCmd)
+      val toUpD = forkStream(enabled = askUpD && !redoUpA).swapPayload(io.up.d.payloadType)
+      val toOrdering = forkFlow(enabled = askOrdering && !redoUpA).swapPayload(io.ordering.ctrlProcess.payloadType)
 
       val CACHE_HIT = insert(tags.CACHE_HITS.orR)
       val CACHE_HIT_WAY_ID = insert(OHToUInt(tags.CACHE_HITS))
@@ -1000,7 +993,7 @@ class Cache(val p : CacheParam) extends Component {
 
 
       val clearPrimary = False
-      val oldClearPrimary = RegNext(clearPrimary && isFiring && !isRemoved) init(False)
+      val oldClearPrimary = RegNext(clearPrimary && up.isFiring) init(False)
       val oldGsId = RegNext(gsId)
       when(oldClearPrimary) {
         gs.slots.onSel(oldGsId)(_.pending.primary := False)
@@ -1020,7 +1013,7 @@ class Cache(val p : CacheParam) extends Component {
       redoUpA setWhen(!CTRL_CMD.probed && preCtrl.FROM_A && !prober.cmd.ready && firstCycle)
       assert(!(isValid && redoUpA && !loopback.fifo.io.push.ready))
 
-      val doIt = isFiring && !isRemoved
+      val doIt = up.isFiring
 
       val olderWay = new Area{
         val plru = new Plru(cacheWays, false)
@@ -1034,7 +1027,7 @@ class Cache(val p : CacheParam) extends Component {
           plru.io.update.id := plru.io.evict.id
         }
 
-        cache.plru.write.valid clearWhen (!isFiring)
+        cache.plru.write.valid clearWhen (!up.isFiring)
         cache.plru.write.address := CTRL_CMD.address(setsRange)
         cache.plru.write.data := plru.io.update.state
 
@@ -1078,12 +1071,12 @@ class Cache(val p : CacheParam) extends Component {
             s.sourceId := CTRL_CMD.source
             if(withFlushBus) s.pending.flushBus := gsFlushBus
           }
-          when(isReady) {
+          when(up.isReady) {
             s.valid := True
           }
         }
       }
-      gotGs clearWhen (isFiring)
+      gotGs clearWhen (up.isFiring)
 
       toReadBackend.address := CTRL_CMD.address
       toReadBackend.size := CTRL_CMD.size
@@ -1118,7 +1111,7 @@ class Cache(val p : CacheParam) extends Component {
         toReadDown.size := log2Up(blockSize)
       }
 
-      val ctxDownDWritten = RegInit(False) setWhen (gs.ctxDownD.write.valid) clearWhen (isFiring)
+      val ctxDownDWritten = RegInit(False) setWhen (gs.ctxDownD.write.valid) clearWhen (up.isFiring)
       val ctxDownD = gs.ctxDownD.write
       ctxDownD.valid := isValid && askGs && !redoUpA && !stallIt && !ctxDownDWritten
       ctxDownD.address            := gsId
@@ -1240,7 +1233,7 @@ class Cache(val p : CacheParam) extends Component {
       }
 
       when(preCtrl.IS_RELEASE){
-        when(isFiring){
+        when(up.isFiring){
           for(s <- prober.slots){
             when(s.address === CTRL_CMD.address(blockRange)){
               when(preCtrl.WRITE_DATA) {
@@ -1396,6 +1389,8 @@ class Cache(val p : CacheParam) extends Component {
         askProbe := False
       }
     }
+
+    build()
   }
 
   val readDown = new Area {
@@ -1429,32 +1424,29 @@ class Cache(val p : CacheParam) extends Component {
   - writeBackend from writing cache
   - fromDownD from writing cache
    */
-  val readBackend = new Pipeline {
-    val stages = newChained(p.readProcessAt+1, Connection.M2S(collapse = true))
-    val inserterStage = stages(0)
-    val fetchStage = stages(0)
-    val readStage = stages(1)
-    val processStage = stages(p.readProcessAt)
+  val readBackend = new StageCtrlPipeline {
+    val inserterStage = ctrl(0)
+    val fetchStage = inserterStage
+    val readStage = ctrl(1)
+    val processStage = ctrl(p.readProcessAt)
 
-    val CMD = Stageable(new ReadBackendCmd())
+    val CMD = Payload(new ReadBackendCmd())
 
-    def victimAddress(stage : Stage) = stage(CMD).gsId @@ stage(CMD).address(wordRange)
+    def victimAddress(stage : CtrlApi) = stage(CMD).gsId @@ stage(CMD).address(wordRange)
 
-    val inserter = new Area {
-      import inserterStage._
-
-      val cmd = ctrl.process.toReadBackend.pipelined(m2s = true, s2m = true)
+    val inserter = new inserterStage.Area {
+      val cmd = Cache.this.ctrl.process.toReadBackend.pipelined(m2s = true, s2m = true)
       val counter = Reg(io.up.p.beat()) init (0)
       val LAST = insert(counter === sizeToBeatMinusOne(io.up.p, cmd.size))
       val FIRST = insert(counter === 0)
       val WRITE_FORK = insert(CMD.toWriteBackend && FIRST)
 
-      cmd.ready := isReady && LAST
-      valid := cmd.valid
+      cmd.ready := up.isReady && LAST
+      up.valid := cmd.valid
       inserterStage(CMD) := cmd.payload
       CMD.address.removeAssignments() := cmd.address | (counter << log2Up(p.dataBytes)).resized
 
-      when(isFiring) {
+      when(up.isFiring) {
         counter := counter + 1
         when(LAST) {
           counter := 0
@@ -1462,13 +1454,11 @@ class Cache(val p : CacheParam) extends Component {
       }
     }
 
-    val fetcher = new Area {
-      import fetchStage._
-
-      cache.data.upRead.valid := isFiring
+    val fetcher = new fetchStage.Area {
+      cache.data.upRead.valid := up.isFiring
       cache.data.upRead.payload := CMD.wayId @@ CMD.address(setsRange.high downto wordRange.low)
 
-      when(isFiring && CMD.toVictim && inserter.FIRST) {
+      when(up.isFiring && CMD.toVictim && inserter.FIRST) {
         gs.slots.onSel(CMD.gsId) { s =>
           s.pending.victimRead := False
         }
@@ -1477,12 +1467,10 @@ class Cache(val p : CacheParam) extends Component {
 
     val CACHED = readStage.insert(Vec(cache.data.banks.map(_.readed))) //May want KEEP attribute
 
-    val process = new Area {
-      import processStage._
-
+    val process = new processStage.Area {
       val DATA = insert(CACHED(CMD.address(log2Up(p.dataBytes), log2Up(cacheBanks) bits)))
 
-      val toUpDFork = forkStream(CMD.toUpD)
+      val toUpDFork = forkStream(enabled = CMD.toUpD)
       val toUpD = toUpDFork swapPayload io.up.d.payloadType()
       toUpD.opcode := CMD.upD.opcode
       toUpD.param := CMD.upD.param
@@ -1494,27 +1482,27 @@ class Cache(val p : CacheParam) extends Component {
       toUpD.corrupt := False
 
 
-      val toVictimFork = forkFlow(CMD.toVictim)
+      val toVictimFork = forkFlow(enabled = CMD.toVictim)
       victimBuffer.write.valid := toVictimFork.valid
       victimBuffer.write.address := victimAddress(processStage)
       victimBuffer.write.data := DATA
 
       val gsOh = UIntToOh(CMD.gsId, generalSlotCount)
 
-      when(isFiring && CMD.toVictim && inserter.FIRST) {
+      when(up.isFiring && CMD.toVictim && inserter.FIRST) {
         gs.slots.onMask(gsOh) { s =>
           s.pending.victimWrite := False
         }
       }
 
-      when(isFiring && inserter.LAST) {
+      when(up.isFiring && inserter.LAST) {
         when(CMD.toUpD) {
           gs.slots.onMask(gsOh)(_.pending.primary := False)
         }
       }
 
 
-      val toWriteBackendFork = forkStream(inserter.WRITE_FORK)
+      val toWriteBackendFork = forkStream(enabled = inserter.WRITE_FORK)
       val toWriteBackend = toWriteBackendFork.swapPayload(new WriteBackendCmd())
       toWriteBackend.fromUpA    := False
       toWriteBackend.fromUpC    := False
@@ -1531,16 +1519,17 @@ class Cache(val p : CacheParam) extends Component {
       toWriteBackend.evict      := True
       toWriteBackend.debugId    := 0
     }
+
+    build()
   }
 
-  val writeBackend = new Pipeline {
-    val stages = newChained(3, Connection.M2S())
-    val inserterStage = stages(0)
-    val fetchStage = stages(0)
-    val readStage = stages(1)
-    val processStage = stages(2)
+  val writeBackend = new StageCtrlPipeline {
+    val inserterStage = ctrl(0)
+    val fetchStage = ctrl(0)
+    val readStage = ctrl(1)
+    val processStage = ctrl(2)
 
-    val CMD = Stageable(new WriteBackendCmd())
+    val CMD = Payload(new WriteBackendCmd())
 
     // Put merge is used on upA put which trigger a cache line load
     val putMerges = ubp.withDataA generate new Area {
@@ -1566,10 +1555,8 @@ class Cache(val p : CacheParam) extends Component {
       cmd.evict := False
     }
 
-    val inserter = new Area {
-      import inserterStage._
-
-      val ctrlBuffered = ctrl.process.toWriteBackend
+    val inserter = new inserterStage.Area {
+      val ctrlBuffered = Cache.this.ctrl.process.toWriteBackend
       val fromReadBackend = readBackend.process.toWriteBackend.s2mPipe().queue(generalSlotCount).halfPipe()//TODO not that great for area
       val arbiterInputs = ArrayBuffer[Stream[WriteBackendCmd]]()
       arbiterInputs += ctrlBuffered
@@ -1585,14 +1572,14 @@ class Cache(val p : CacheParam) extends Component {
       val addressWord = cmd.address(wordRange)
       val IN_UP_A = insert(!CMD.fromUpC || counter >= addressWord && counter <= addressWord + upABeatsMinusOne)
 
-      cmd.ready := isReady && LAST
-      valid := cmd.valid
+      cmd.ready := up.isReady && LAST
+      up.valid := cmd.valid
       inserterStage(CMD) := cmd.payload
       val addressBase = cmd.address(refillRange) @@ cmd.address(refillRange.low-1 downto 0).andMask(!CMD.fromUpC)
       CMD.address.removeAssignments() := addressBase | (counter << log2Up(p.dataBytes)).resized
       val tlWord = insert(addressBase(wordRange))
 
-      when(isFiring) {
+      when(up.isFiring) {
         counter := counter + 1
         when(LAST) {
           counter := 0
@@ -1601,23 +1588,21 @@ class Cache(val p : CacheParam) extends Component {
     }
 
 
-    val fetch = new Area{
-      import fetchStage._
-
+    val fetch = new fetchStage.Area{
       if(ubp.withDataA) {
-        fromUpA.buffer.read.cmd.valid := fetchStage.isFiring
-        fromUpA.buffer.read.cmd.payload := fetchStage(CMD).bufferAId @@ fetchStage(CMD).address(wordRange)
-        when(isFiring && inserter.LAST && CMD.fromUpA) {
-          fromUpA.buffer.clear(fetchStage(CMD).bufferAId) := True
+        fromUpA.buffer.read.cmd.valid := up.isFiring
+        fromUpA.buffer.read.cmd.payload := CMD.bufferAId @@ CMD.address(wordRange)
+        when(up.isFiring && inserter.LAST && CMD.fromUpA) {
+          fromUpA.buffer.clear(CMD.bufferAId) := True
         }
       }
 
-      victimBuffer.read.cmd.valid := fetchStage.isFiring
-      victimBuffer.read.cmd.payload := fetchStage(CMD).gsId @@ fetchStage(CMD).address(wordRange)
+      victimBuffer.read.cmd.valid := up.isFiring
+      victimBuffer.read.cmd.payload := CMD.gsId @@ CMD.address(wordRange)
 
       val vh = readBackend.processStage
       val victimWrite = gs.slots.reader(CMD.gsId)(_.pending.victimWrite)
-      val victimWriteOnGoing = vh.valid &&
+      val victimWriteOnGoing = vh.up.valid &&
         vh(readBackend.CMD).toVictim &&
         readBackend.victimAddress(vh) === (CMD.gsId @@ CMD.address(wordRange))
       val victimHazard = CMD.evict && (victimWrite || victimWriteOnGoing)
@@ -1627,9 +1612,7 @@ class Cache(val p : CacheParam) extends Component {
     val BUFFER_A = ubp.withDataA generate readStage.insert(fromUpA.buffer.read.rsp)
     val VICTIM = readStage.insert(victimBuffer.read.rsp)
 
-    val process = new Area {
-      import processStage._
-
+    val process = new processStage.Area {
       val acMergeLogic = ubp.withDataA generate new Area {
         val aSplit = BUFFER_A.data.subdivideIn(8 bits)
         val cSplit = upCSplit.dataPop.payload.subdivideIn(8 bits)
@@ -1642,23 +1625,23 @@ class Cache(val p : CacheParam) extends Component {
         UP_MASK := BUFFER_A.mask
       }
       val hazardUpC = CMD.fromUpC && !upCSplit.dataPop.valid
-      upCSplit.dataPop.ready := CMD.fromUpC && isFiring
+      upCSplit.dataPop.ready := CMD.fromUpC && up.isFiring
 
 
       val vh = readBackend.fetchStage
       val victimRead = gs.slots.reader(CMD.gsId)(_.pending.victimRead)
-      val victimReadOnGoing = vh.valid &&
+      val victimReadOnGoing = vh.up.valid &&
         vh(readBackend.CMD).toVictim &&
         readBackend.victimAddress(vh) === (CMD.gsId @@ CMD.address(wordRange))
       val victimHazard = CMD.toCache && (victimRead || victimReadOnGoing)
 
-      val toCacheFork = forkStream(CMD.toCache)
+      val toCacheFork = forkStream(enabled = CMD.toCache)
       cache.data.upWrite.arbitrationFrom(toCacheFork.haltWhen(hazardUpC || victimHazard))
       cache.data.upWrite.address := CMD.wayId @@ CMD.address(setsRange.high downto wordRange.low)
       cache.data.upWrite.data := UP_DATA
       cache.data.upWrite.mask := UP_MASK
 
-      val toDownAFork = forkStream(CMD.toDownA)
+      val toDownAFork = forkStream(enabled = CMD.toDownA)
       val toDownA = toDownAFork.haltWhen(hazardUpC).swapPayload(io.down.a.payloadType)
       toDownA.opcode := (CMD.fromUpA && CMD.partialUpA).mux(Opcode.A.PUT_PARTIAL_DATA, Opcode.A.PUT_FULL_DATA)
       toDownA.param := 0
@@ -1681,7 +1664,7 @@ class Cache(val p : CacheParam) extends Component {
         ACCESS_ACK_DATA -> inserter.IN_UP_A,
         GRANT_DATA      -> True
       )
-      val toUpDFork = forkStream(needForkToUpD)
+      val toUpDFork = forkStream(enabled = needForkToUpD)
       val toUpD = toUpDFork.haltWhen(victimHazard || hazardUpC || CMD.toUpD === RELEASE_ACK && toCacheFork.isStall).swapPayload(io.up.d.payloadType)
       toUpD.opcode  := CMD.toUpD.muxDc(
         ACCESS_ACK      -> Opcode.D.ACCESS_ACK(),
@@ -1700,7 +1683,7 @@ class Cache(val p : CacheParam) extends Component {
 
       val toUpDBuffered = toUpD.stage() //Necessary to ensure release data is written to memory before notifying up D  (haltWhen (!isReady))
 
-      when(isFiring && inserter.LAST) {
+      when(up.isFiring && inserter.LAST) {
         when(CMD.toUpD =/= NONE) {
           gs.slots.onSel(CMD.gsId) { s =>
             s.pending.primary := False
@@ -1714,6 +1697,8 @@ class Cache(val p : CacheParam) extends Component {
       toOrdering.bytes := (U(1) << CMD.size).resized
       toOrdering >> io.ordering.writeBackend
     }
+
+    build()
   }
 
 
@@ -1725,19 +1710,16 @@ class Cache(val p : CacheParam) extends Component {
     io.down.a << arbiter.io.output
   }
 
-  val fromDownD = new Pipeline{
-    val stages = newChained(3, Connection.M2S())
-    val inserterStage = stages(0)
-    val fetchStage = stages(0)
-    val readStage = stages(1)
-    val preprocessStage = stages(1)
-    val processStage = stages(2)
+  val fromDownD = new StageCtrlPipeline{
+    val inserterStage = ctrl(0)
+    val fetchStage = ctrl(0)
+    val readStage = ctrl(1)
+    val preprocessStage = ctrl(1)
+    val processStage = ctrl(2)
 
-    val CTX = Stageable(new CtxDownD())
-    val inserter = new Area{
-      import inserterStage._
-
-      driveFrom(io.down.d)
+    val CTX = Payload(new CtxDownD())
+    val inserter = new inserterStage.Area{
+      up.arbitrateFrom(io.down.d)
       val CMD = insert(io.down.d.payload)
       val LAST = insert(io.down.d.isLast())
       val BEAT = insert(io.down.d.beatCounter())
@@ -1746,20 +1728,17 @@ class Cache(val p : CacheParam) extends Component {
     import inserter._
 
     val readPort = gs.ctxDownD.ram.readSyncPort()
-    readPort.cmd.valid := fetchStage.isFiring
+    readPort.cmd.valid := fetchStage.up.isFiring
     readPort.cmd.payload := fetchStage(CMD).source.resized
     readStage(CTX) := readPort.rsp
 
-    val preprocess = new Area{
-      import preprocessStage._
-
+    val preprocess = new preprocessStage.Area{
       val withData = insert(CMD.opcode === Opcode.D.ACCESS_ACK_DATA)
       val toUpDHead = insert(!withData || !CTX.toCache || (BEAT >= CTX.wordOffset && BEAT <= CTX.wordOffset + sizeToBeatMinusOne(io.down.p, CTX.size)))
     }
 
-    val process = new Area{
+    val process = new processStage.Area{
       import preprocess._
-      import processStage._
 
       val isVictim = CMD.source.msb
 
@@ -1768,7 +1747,7 @@ class Cache(val p : CacheParam) extends Component {
         val gsId = UInt(log2Up(generalSlotCount) bits)
         val last = Bool()
       }
-      val toCache = forkStream(!isVictim && CTX.toCache).swapPayload(ToCache())
+      val toCache = forkStream(enabled = !isVictim && CTX.toCache).swapPayload(ToCache())
       toCache.cmd.address := CTX.wayId @@ CTX.setId @@ BEAT
       toCache.cmd.data := CMD.data
       toCache.cmd.mask.setAll()
@@ -1778,7 +1757,7 @@ class Cache(val p : CacheParam) extends Component {
       val gsId = CMD.source.resize(log2Up(gs.slots.size))
       val vh = readBackend.fetchStage
       val victimRead = gs.slots.reader(gsId)(_.pending.victimWrite) //Here we pick victim write to be sure we don't create a dead lock
-      val victimOnGoing = vh.valid && vh(readBackend.CMD).toVictim && readBackend.victimAddress(vh) === (gsId @@ BEAT)
+      val victimOnGoing = vh.up.valid && vh(readBackend.CMD).toVictim && readBackend.victimAddress(vh) === (gsId @@ BEAT)
       val victimHazard = victimRead || victimOnGoing
 
       val toCacheBuffered = toCache.haltWhen(victimHazard).stage()
@@ -1792,7 +1771,7 @@ class Cache(val p : CacheParam) extends Component {
 
       //TODO handle refill while partial get to upD
 
-      val toUpDFork = forkStream(!isVictim && CTX.toUpD && toUpDHead)
+      val toUpDFork = forkStream(enabled = !isVictim && CTX.toUpD && toUpDHead)
       val toUpD = toUpDFork.haltWhen(toCache.valid && victimHazard).swapPayload(io.up.d.payloadType)
 
       toUpD.opcode  := CTX.acquire.mux(
@@ -1826,7 +1805,7 @@ class Cache(val p : CacheParam) extends Component {
         assert(!writeBackend.putMerges.push.isStall)
       }
 
-      when(isFiring && LAST) {
+      when(up.isFiring && LAST) {
         when(isVictim) {
           gs.slots.onSel(CMD.source.resized)(_.pending.victim := False)
         } otherwise {
@@ -1838,6 +1817,8 @@ class Cache(val p : CacheParam) extends Component {
         }
       }
     }
+
+    build()
   }
 
   val toUpD = new Area{
@@ -1874,11 +1855,6 @@ class Cache(val p : CacheParam) extends Component {
 
     io.flush.rsp <-< rsp //Ensure stable payload
   }
-
-  ctrl.build()
-  readBackend.build()
-  writeBackend.build()
-  fromDownD.build()
 
   when(!initializer.done) {
     cache.tags.write.valid := True

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/Hub.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/Hub.scala
@@ -4,7 +4,7 @@ import spinal.core._
 import spinal.lib._
 import spinal.lib.bus.misc.SizeMapping
 import spinal.lib.bus.tilelink._
-import spinal.lib.pipeline._
+import spinal.lib.misc.pipeline._
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -170,25 +170,25 @@ class Hub(p : HubParameters) extends Component{
     val data = ubp.data()
   }
 
-  val FROM_C = Stageable(Bool())
-  val ADDRESS  = Stageable(ubp.address)
-//  val CAP  = Stageable(UInt(2 bits))
-  val SET_ID  = Stageable(UInt(setsRange.size bits))
-  val PROBE_ID  = Stageable(UInt(log2Up(probeCount) bits))
-  val SLOT_ALLOCATE = Stageable(Bool())
-  val SIZE  = Stageable(ubp.size)
-  val SOURCE  = Stageable(ubp.source)
-  val BUFFER_ID = Stageable(UInt(log2Up(aBufferCount) bits))
-  val PARTIAL_DATA = Stageable(Bool())
-  val WRITE_DATA = Stageable(Bool())
-  val READ_DATA = Stageable(Bool())
-  val LAST, FIRST = Stageable(Bool())
-  val PAYLOAD_C, PAYLOAD = Stageable(DataPayload())
-  val SLOT_ID = Stageable(UInt(log2Up(downPendingMax) bits))
-  val TO_DOWN = Stageable(Bool())
-  val FROM_NONE = Stageable(Bool())
-  val UNIQUE = Stageable(Bool())
-  val CONFLICT_CTX = Stageable(Bool())
+  val FROM_C = Payload(Bool())
+  val ADDRESS  = Payload(ubp.address)
+//  val CAP  = Payload(UInt(2 bits))
+  val SET_ID  = Payload(UInt(setsRange.size bits))
+  val PROBE_ID  = Payload(UInt(log2Up(probeCount) bits))
+  val SLOT_ALLOCATE = Payload(Bool())
+  val SIZE  = Payload(ubp.size)
+  val SOURCE  = Payload(ubp.source)
+  val BUFFER_ID = Payload(UInt(log2Up(aBufferCount) bits))
+  val PARTIAL_DATA = Payload(Bool())
+  val WRITE_DATA = Payload(Bool())
+  val READ_DATA = Payload(Bool())
+  val LAST, FIRST = Payload(Bool())
+  val PAYLOAD_C, PAYLOAD = Payload(DataPayload())
+  val SLOT_ID = Payload(UInt(log2Up(downPendingMax) bits))
+  val TO_DOWN = Payload(Bool())
+  val FROM_NONE = Payload(Bool())
+  val UNIQUE = Payload(Bool())
+  val CONFLICT_CTX = Payload(Bool())
 
   val initializer = new Area{
     val initCycles = p.sets
@@ -230,11 +230,9 @@ class Hub(p : HubParameters) extends Component{
     }
   }
 
-  val frontendA = new Pipeline{
-    val stages = newChained(2, Connection.M2S())
-
-    val PAYLOAD = Stageable(DataPayload())
-    val BUFFER_ID = Stageable(UInt(log2Up(aBufferCount) bits))
+  val frontendA = new StageCtrlPipeline{
+    val PAYLOAD = Payload(DataPayload())
+    val BUFFER_ID = Payload(UInt(log2Up(aBufferCount) bits))
 
     val buffer =  ubp.withDataA generate new Area{
       val ram = Mem.fill(aBufferCount*p.blockSize/p.unp.m.dataBytes)(DataPayload())
@@ -247,11 +245,9 @@ class Hub(p : HubParameters) extends Component{
       allocated := (allocated | set) & ~clear
     }
 
-    val spawn = new Area{
-      val stage = stages(0)
-      import stage._
-
-      driveFrom(io.up.a)
+    val spawnNode = ctrl(0)
+    val spawn = new spawnNode.Area{
+      up.arbitrateFrom(io.up.a)
       haltWhen(!initializer.done)
 
       val CMD = insert(io.up.a.payload.asNoData())
@@ -264,16 +260,16 @@ class Hub(p : HubParameters) extends Component{
       val dataSplit = ubp.withDataA generate new Area{
         val withBeats = io.up.a.payload.withBeats
         val hazard = withBeats && buffer.full
-        haltIt(hazard)
-        throwIt(!hazard && !LAST)
+        haltWhen(hazard)
+        throwWhen(!hazard && !LAST)
 
         val locked = RegInit(False) setWhen(buffer.write.valid)
         val lockedValue = RegNextWhen(buffer.firstFree, !locked)
         BUFFER_ID := locked ? lockedValue | buffer.firstFree
-        buffer.write.valid := valid && withBeats && !hazard
+        buffer.write.valid := up.valid && withBeats && !hazard
         buffer.write.address := BUFFER_ID @@ io.up.a.beatAddress(wordRange)
         buffer.write.data := PAYLOAD
-        when(isFiring && LAST && withBeats){
+        when(up.isFiring && LAST && withBeats){
           buffer.set(BUFFER_ID) := True
           buffer.source.onSel(BUFFER_ID)(_ := io.up.a.payload.source)
           locked := False
@@ -281,37 +277,34 @@ class Hub(p : HubParameters) extends Component{
       }
     }
 
-    val readConflicts = new Area{
-      val stage = stages(0)
-      import stage._
-
+    val readConflictsNode = ctrl(0)
+    val readConflicts = new readConflictsNode.Area{
       val readAddress = spawn.CMD.address(setsRange)
       val JUST_BUSY = insert(setsBusy.target.write.valid && setsBusy.target.write.address === readAddress)
       val JUST_FREE = insert(setsBusy.hit.write.valid && setsBusy.hit.write.address === readAddress)
     }
 
-    val checkConflicts = new Area{
-      val stage = stages(1)
-      import stage._
+    val checkConflictsNode = ctrl(1)
+    val checkConflicts = new checkConflictsNode.Area{
       import readConflicts._
 
       val hitPort = setsBusy.hit.mem.readSyncPort()
-      hitPort.cmd.valid := !stage.isStuck
+      hitPort.cmd.valid := !up.isValid || up.isMoving
       hitPort.cmd.payload := readAddress
       hitPort.writeFirstAndUpdate(setsBusy.hit.write)
 
       val targetPort = setsBusy.target.mem.readSyncPort()
-      targetPort.cmd.valid := !stage.isStuck
+      targetPort.cmd.valid := !up.isValid || up.isMoving
       targetPort.cmd.payload := readAddress
       targetPort.writeFirstAndUpdate(setsBusy.target.write)
 
       val hit    = hitPort.rsp
       val target = targetPort.rsp
       val hazard = hit =/= target
-      haltIt(hazard)
+      haltWhen(hazard)
 
       when(initializer.done) {
-        setsBusy.target.write.valid := isFiring
+        setsBusy.target.write.valid := up.isFiring
         setsBusy.target.write.address := spawn.CMD.address(setsRange)
         setsBusy.target.write.data := !target
       }
@@ -360,12 +353,12 @@ class Hub(p : HubParameters) extends Component{
   }
 
   val probe = new Area{
-    val isl = frontendA.stages.last
+    val isl = frontendA.last
     val push = Stream(ProbeCmd())
     val pushCmd = isl(frontendA.spawn.CMD)
     val isAcquire = Opcode.A.isAcquire(pushCmd.opcode)
-    push.valid := isl.isValid && !isl.internals.request.halts.orR
-    isl.haltIt(!push.ready)
+    push.valid := isl.isValid && !isl.requests.halts.orR
+    isl.haltWhen(!push.ready)
     push.ctx.opcode     := pushCmd.opcode
     push.ctx.address    := pushCmd.address
     push.ctx.toTrunk    := pushCmd.param =/= Param.Grow.NtoB
@@ -508,22 +501,19 @@ class Hub(p : HubParameters) extends Component{
       input.ready := !(hitBackend && !toBackend.ready) && !(hitUpD && !toUpD.ready)
     }
 
-    val wake = new Pipeline{
-      val stages = newChained(2, Connection.M2S())
-      val CTX = Stageable(new ProbeCtx())
+    val wake = new StageCtrlPipeline{
+      val CTX = Payload(new ProbeCtx())
       val toBackend = Stream(new ProbeCtxFull())
       val toUpD = cloneOf(io.up.d)
 
-      val insertion = new Area {
-        val stage = stages(0)
-        import stage._
-
+      val insertionNode = ctrl(0)
+      val insertion = new insertionNode.Area {
         val hits = slots.map(_.done).asBits
-        valid := hits.orR
-        val hitOh = OHMasking.roundRobinNext(hits, isFiring)
+        up.valid := hits.orR
+        val hitOh = OHMasking.roundRobinNext(hits, up.isFiring)
         val hitId = OHToUInt(hitOh)
         PROBE_ID := hitId
-        when(isFiring){
+        when(up.isFiring){
           slots.onMask(hitOh){ s =>
             s.fire := True
           }
@@ -532,11 +522,9 @@ class Hub(p : HubParameters) extends Component{
         UNIQUE := OhMux.or(hitOh, slots.map(_.unique))
       }
 
-      val ctxFetcher = new Area {
-        val stage = stages(1)
-        import stage._
-
-        stage(CTX) := ctxMem.readSync(insertion.hitId, !isStuck)
+      val ctxFetcherNode = ctrl(1)
+      val ctxFetcher = new ctxFetcherNode.Area {
+        CTX := ctxMem.readSync(insertion.hitId, !up.isValid || up.isMoving)
         val hitUpD = CTX.opcode === Opcode.A.ACQUIRE_PERM ||
                      CTX.opcode === Opcode.A.ACQUIRE_BLOCK && !FROM_NONE
 
@@ -568,31 +556,28 @@ class Hub(p : HubParameters) extends Component{
 
 
 
-  val backend = new Pipeline {
-    val stages = newChained(3, Connection.M2S())
-
-    val insertion = new Area{
-      val stage = stages(0)
-      import stage._
+  val backend = new StageCtrlPipeline {
+    val insertionNode = ctrl(0)
+    val insertion = new insertionNode.Area{
       val c = probe.rsp.toBackend
       val cProbeId = probe.rsp.toBackendProbeId
       val a = probe.wake.toBackend
 
-      val lockValid = RegInit(False) setWhen(valid) clearWhen(isFiring && LAST)
+      val lockValid = RegInit(False) setWhen(up.valid) clearWhen(up.isFiring && LAST)
       val lockSel = Reg(Bool())
       val selC = lockValid ? lockSel | c.valid
       lockSel := selC
 
 
       val counter = Reg(UInt(wordRange.size bits)) init(0)
-      when(isFiring){
+      when(up.isFiring){
         counter := counter + 1
         when(LAST){
           counter := 0
         }
       }
 
-      valid := selC ? c.valid | a.valid
+      up.valid := selC ? c.valid | a.valid
       FROM_C :=  selC
       when(selC){
         WRITE_DATA := c.withBeats
@@ -616,13 +601,13 @@ class Hub(p : HubParameters) extends Component{
       if(ubp.withDataA) BUFFER_ID := a.bufferId
       CONFLICT_CTX := a.conflictCtx
 
-      c.ready := isReady &&  selC
-      a.ready := isReady && !selC && LAST
+      c.ready := up.isReady &&  selC
+      a.ready := up.isReady && !selC && LAST
 
       PAYLOAD_C.data := c.data
       PAYLOAD_C.mask.setAll()
 
-      val first = RegNextWhen[Bool](LAST, isFiring) init(True)
+      val first = RegNextWhen[Bool](LAST, up.isFiring) init(True)
       FIRST := first
 
       val A_GET_PUT  = insert(Opcode.A.isGetPut(a.opcode))
@@ -633,32 +618,30 @@ class Hub(p : HubParameters) extends Component{
       TO_DOWN := WRITE_DATA | READ_DATA
       SLOT_ALLOCATE := TO_DOWN
 
-      io.backendOrdering.valid := isFiring && !FROM_C
+      io.backendOrdering.valid := up.isFiring && !FROM_C
       io.backendOrdering.debugId := a.debugId
       io.backendOrdering.bytes := (U(1) << a.size).resized
     }
 
     val aPayloadSyncRead = new Area{
-      val s0 = stages(0)
-      val s1 = stages(1)
+      val s0 = ctrl(0)
+      val s1 = ctrl(1)
       val wordAddress = s0(BUFFER_ID) @@ s0(ADDRESS)(wordRange)
 
       s1(PAYLOAD) := s1(PAYLOAD_C)
       if(ubp.withDataA) {
         when(!s1(FROM_C)){
-          s1(PAYLOAD) := frontendA.buffer.ram.readSync(wordAddress, !s1.isStuck)
+          s1(PAYLOAD) := frontendA.buffer.ram.readSync(wordAddress, !s1.up.isValid || s1.up.isMoving)
         }
-        when(s1.isFiring && s1(LAST) && !s1(FROM_C) && s1(WRITE_DATA)){
+        when(s1.up.isFiring && s1(LAST) && !s1(FROM_C) && s1(WRITE_DATA)){
           frontendA.buffer.clear(s1(BUFFER_ID)) := True
         }
       }
     }
 
-    val allocateSlot = new Area{
-      val stage = stages(0)
-      import stage._
-
-      val slotLock = RegNextWhen(!LAST, isFiring) init(False)
+    val allocateNode = ctrl(0)
+    val allocateSlot = new allocateNode.Area{
+      val slotLock = RegNextWhen(!LAST, up.isFiring) init(False)
       val slotReg = RegNextWhen(slots.freeId, !slotLock)
       SLOT_ID := slotLock ? slotReg | slots.freeId
       haltWhen(SLOT_ALLOCATE && slots.full)
@@ -675,8 +658,8 @@ class Hub(p : HubParameters) extends Component{
       c.isProbeData := insertion.C_IS_PROBE_DATA
       c.probeId     := PROBE_ID
 
-      slots.allocate := isFiring && SLOT_ALLOCATE && FIRST
-      slots.ctxWrite.valid := isFiring && SLOT_ALLOCATE
+      slots.allocate := up.isFiring && SLOT_ALLOCATE && FIRST
+      slots.ctxWrite.valid := up.isFiring && SLOT_ALLOCATE
       slots.ctxWrite.address := SLOT_ID
       slots.ctxWrite.data.assignDontCare()
       slots.ctxWrite.data(0) := FROM_C
@@ -689,11 +672,11 @@ class Hub(p : HubParameters) extends Component{
       assert(widthOf(c) < widthOf(slots.ctxWrite.data))
     }
 
-    val toDown = new Area{
-      val stage = stages.last
-      import stage._
+    /* The origianl pipeline is 3-stage, so this should be stage 2 instead of the use pipeline last stage */
+    val downNode = ctrl(2)
+    val toDown = new downNode.Area{
       haltWhen(TO_DOWN && !io.down.a.ready)
-      io.down.a.valid := valid && TO_DOWN
+      io.down.a.valid := up.valid && TO_DOWN
       io.down.a.opcode := WRITE_DATA ? (PARTIAL_DATA ? Opcode.A.PUT_PARTIAL_DATA | Opcode.A.PUT_FULL_DATA) | Opcode.A.GET
       io.down.a.param := 0
       io.down.a.source := SLOT_ID
@@ -704,31 +687,30 @@ class Hub(p : HubParameters) extends Component{
       io.down.a.corrupt := False
       io.down.a.debugId := DebugId.withPostfix(io.down.a.source)
 
-      val first = RegNextWhen[Bool](LAST, isFiring) init(True)
-      val base = RegNextWhen(ADDRESS(wordRange), isFiring && first)
+      val first = RegNextWhen[Bool](LAST, up.isFiring) init(True)
+      val base = RegNextWhen(ADDRESS(wordRange), up.isFiring && first)
       when(!first){
         io.down.a.address(wordRange) := base
       }
     }
   }
 
-  val downD = new Pipeline{
-    val stages = newChained(2, Connection.M2S())
-    val D_PAYLOAD = Stageable(io.down.d.payloadType)
-    val CTX = Stageable(slots.ctx.wordType)
+  val downD = new StageCtrlPipeline{
+    val D_PAYLOAD = Payload(io.down.d.payloadType)
+    val CTX = Payload(slots.ctx.wordType)
 
-    val insert = new Area{
-      val stage = stages.head
-      stage.driveFrom(io.down.d)
-      stage(D_PAYLOAD) := io.down.d
-      stage(LAST) := io.down.d.isLast()
+    val insertNode = ctrl(0)
+    val insert = new insertNode.Area{
+      up.arbitrateFrom(io.down.d)
+      D_PAYLOAD := io.down.d
+      LAST := io.down.d.isLast()
     }
 
     val ctxReadSync = new Area{
-      val s0 = stages(0)
-      val s1 = stages(1)
+      val s0 = ctrl(0)
+      val s1 = ctrl(1)
       val wordAddress = s0(D_PAYLOAD).source
-      s1(CTX) := slots.ctx.readSync(wordAddress, !s1.isStuck)
+      s1(CTX) := slots.ctx.readSync(wordAddress, !s1.up.isValid || s1.up.isMoving)
     }
 
     def decodeCtx(ctx : Bits) = new Area{
@@ -738,52 +720,45 @@ class Hub(p : HubParameters) extends Component{
       val hit = fromC ? (!c.isProbeData) | True
     }
 
-    val slotRelease = new Area{
-      val stage = stages(1)
-      import stage._
+    val slotNode = ctrl(1)
+    val slotRelease = new slotNode.Area{
       val ctx = decodeCtx(CTX)
 
-      val fired = RegInit(False) setWhen(isValid) clearWhen(isReady)
+      val fired = RegInit(False) setWhen(isValid) clearWhen(up.isReady)
 
-      slots.release.valid := valid && !fired && LAST
+      slots.release.valid := up.valid && !fired && LAST
       slots.release.payload := D_PAYLOAD.source
     }
 
-    val toSetsBusy = new Area{
-      val stage = stages(1)
-      import stage._
-
+    val busyNode = ctrl(1)
+    val toSetsBusy = new busyNode.Area{
       val ctx = decodeCtx(CTX)
-      val fired = RegInit(False) setWhen(setsBusy.hit.downD.fire) clearWhen(isReady)
+      val fired = RegInit(False) setWhen(setsBusy.hit.downD.fire) clearWhen(up.isReady)
       val hit = !ctx.fromC && ctx.a.getPut && LAST && !fired
 
-      setsBusy.hit.downD.valid := valid && hit
+      setsBusy.hit.downD.valid := up.valid && hit
       setsBusy.hit.downD.address := ctx.a.set
       setsBusy.hit.downD.data := ctx.a.conflictCtx
 
-      haltIt(hit && !setsBusy.hit.downD.ready)
+      haltWhen(hit && !setsBusy.hit.downD.ready)
     }
 
-    val toProbe = new Area{
-      val stage = stages(1)
-      import stage._
-
+    val probeNode = ctrl(1)
+    val toProbe = new probeNode.Area{
       val ctx = decodeCtx(CTX)
       val hit = ctx.fromC && ctx.c.isProbeData
-      val fired = RegInit(False) setWhen(probe.rsp.bypass.fire) clearWhen(isReady)
-      probe.rsp.bypass.valid := valid && hit && ! fired
+      val fired = RegInit(False) setWhen(probe.rsp.bypass.fire) clearWhen(up.isReady)
+      probe.rsp.bypass.valid := up.valid && hit && ! fired
       probe.rsp.bypass.payload := ctx.c.probeId
     }
 
-    val toUp = new Area{
-      val stage = stages(1)
-      import stage._
-
+    val upNode = ctrl(1)
+    val toUp = new upNode.Area{
       val upD = cloneOf(io.up.d)
 
       val ctx = decodeCtx(CTX)
       val hit = ctx.fromC ? (!ctx.c.isProbeData) | True
-      val fired = RegInit(False) setWhen(upD.fire) clearWhen(isReady)
+      val fired = RegInit(False) setWhen(upD.fire) clearWhen(up.isReady)
       upD.valid := isValid && hit && !fired
       upD.payload := D_PAYLOAD
       upD.param.removeAssignments() := 0
@@ -799,7 +774,7 @@ class Hub(p : HubParameters) extends Component{
           upD.param := ctx.a.toTrunk ? B(Param.Cap.toT, 3 bits) | B(Param.Cap.toB, 3 bits)
         }
       }
-      haltIt(!fired && hit && !upD.ready)
+      haltWhen(!fired && hit && !upD.ready)
     }
   }
 

--- a/lib/src/main/scala/spinal/lib/misc/pipeline/Builder.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/Builder.scala
@@ -82,6 +82,9 @@ class StagePipeline() extends Area {
   def node(i : Int) = nodes.getOrElseUpdate(i, new Node().setCompositeName(this, s"node_${i.toString}"))
   class Area(i : Int) extends NodeMirror(node(i)) with spinal.core.Area
 
+  def first = node(nodes.keys.min)
+  def last = node(nodes.keys.max)
+
   def build(withoutCollapse : Boolean = false): Unit = {
     for(i <- nodes.keys.min until nodes.keys.max){
       val stage = StageLink(node(i), node(i+1)).setCompositeName(this, s"stage_${i+1}")
@@ -99,6 +102,9 @@ class StageCtrlPipeline() extends Area {
   def ctrl(i : Int) = ctrls.getOrElseUpdate(i, CtrlLink().setCompositeName(this, s"ctrl_${i.toString}"))
   class Ctrl(i : Int) extends CtrlLinkMirror(ctrl(i))
   class InsertArea extends NodeMirror(ctrl(0).up) with spinal.core.Area
+
+  def first = ctrl(ctrls.keys.min)
+  def last = ctrl(ctrls.keys.max)
 
   def build(): Unit = {
     for(i <- ctrls.keys.min until ctrls.keys.max){

--- a/lib/src/main/scala/spinal/lib/misc/pipeline/CtrlLink.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/CtrlLink.scala
@@ -125,6 +125,19 @@ trait CtrlApi {
     ret
   }
 
+  /**
+   * Fork a flow from the current transaction.
+   *
+   * @param enabled Additional condition to allow the pipeline to enable/disable the forked flow
+   */
+  def forkFlow(enabled : Bool = True): Flow[NoData] = {
+    val ret = Flow(NoData())
+    val fired = RegInit(False) setCompositeName(ret, "fired")
+    ret.valid := isValid && !fired && enabled
+    fired setWhen(ret.fire) clearWhen(up.isMoving)
+    ret
+  }
+
   implicit def stageablePiped2[T <: Data](stageable: Payload[T]): T = this (stageable)
 
   class BundlePimper[T <: Bundle](pimped: T) {

--- a/lib/src/main/scala/spinal/lib/misc/pipeline/CtrlLink.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/CtrlLink.scala
@@ -41,13 +41,13 @@ trait CtrlApi {
   def insert[T <: Data](that: T): Payload[T] = down.insert(that)
 
   /** Allows to conditionally override a [[Payload]] value between `link.up` -> `link.down`.
-   * 
+   *
    * This can be used to fix data hazard in CPU pipelines for instance.
    */
   def bypass[T <: Data](that: Payload[T]): T =  bypass(that, defaultKey)
 
   /** Allows to conditionally override a ([[Payload]], subKey) value between `link.up` -> `link.down`.
-   * 
+   *
    * This can be used to fix data hazard in CPU pipelines for instance.
    */
   def bypass[T <: Data](that: Payload[T], subKey : Any): T =  bypass(NamedTypeKey(that.asInstanceOf[Payload[Data]], subKey)).asInstanceOf[T]
@@ -76,9 +76,9 @@ trait CtrlApi {
 
   /** Ignore the downstream ready when `True` (set `up.ready`) */
   def ignoreReadyWhen(cond: Bool)(implicit loc: Location): Bool = requests.ignoresReady addRet nameFromLocation(CombInit(cond), "ignoreReadyRequest")
-  
+
   /** Cancel the current transaction from the pipeline when `True`.
-   * 
+   *
    * It clear `down.valid` and make the transaction driver forget its current state.
    */
   def throwWhen(cond : Bool, usingReady : Boolean = false)    (implicit loc: Location) : Unit = {
@@ -104,12 +104,19 @@ trait CtrlApi {
   /** Same as [[ignoreReadyWhen()]] but for use in `when` block */
   def ignoreReadyNow()(implicit loc: Location): Unit = ignoreReadyWhen(ConditionalContext.isTrue)
 
-  def forkStream[T <: Data](forceSpawn : Option[Bool] = Option.empty[Bool]): Stream[NoData] = {
+  /**
+   * Fork a stream from the current transaction.
+   * The transaction is blocked if the stream is enabled but not fired.
+   *
+   * @param forceSpawn Allow the caller reset the send state
+   * @param enabled Additional condition to allow the pipeline to enable/disable the forked stream
+   */
+  def forkStream[T <: Data](forceSpawn : Option[Bool] = Option.empty[Bool], enabled : Bool = True): Stream[NoData] = {
     val ret = Stream(NoData())
     val fired = RegInit(False) setCompositeName(ret, "fired")
     val firedComb = CombInit(fired)
-    ret.valid := isValid && !firedComb
-    haltWhen(!firedComb && !ret.ready)
+    ret.valid := isValid && !firedComb && enabled
+    haltWhen(!firedComb && !ret.ready && enabled)
     if (forceSpawn.nonEmpty) when(forceSpawn.get) {
       fired := False
       firedComb := False
@@ -128,11 +135,11 @@ trait CtrlApi {
 }
 
 /** A kind of special [[Link]] that connects two nodes with optional flow control / bypass logic.
-  * 
+  *
   * Its API should be flexible enough to implement a CPU stage with it.
-  * 
+  *
   * It as an [[up]] and a [[down]] node.
-  * 
+  *
   * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/Pipeline/introduction.html#ctrllink CtrlLink documentation]]
   */
 class CtrlLink(override val up : Node, override val down : Node) extends Link with CtrlApi {


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

As noticed, the current implementation of RAM, Cache and Hub use the old pipeline API, porting them to the new pipeline API so it can benefit from the improvement of the new design.

Adding some utility functions to the CtrlLink and the pipeline class.

Tested with the VexiiRiscv and litex.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

No impact on the public interface, but the internal interface is changed to the new design.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
