### PR TITLE
Use Whitelist for the dot file in the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,14 @@ command
 sim/yolo/rtl/__simulation_def.v
 sim/simulation_plugins/*
 !sim/simulation_plugins/.gitignore
+
+# Whitelist for the dot file
+.*
+!.gitattributes
+!.github
+!.gitignore
+!.gitmodules
+!.jvmopts
+!.mill-version
+!.scalafmt.conf
+!.travis.yml


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

It is kind of annoying and easy to make mistake for adding extra file generated by the some IDE, AI agent and some builder. 

This PR just masks all the dot file and use a gitignore whitelist to ensure only the thing we need is added.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

No

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
