### PR TITLE
SIM:VerilatorBackend: Fix >= 5.050 casting

### DIFF
--- a/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
+++ b/sim/src/main/scala/spinal/sim/VerilatorBackend.scala
@@ -293,11 +293,11 @@ ${    val signalInits = for((signal, id) <- config.signals.zipWithIndex) yield {
       else if(signal.dataType.width <= 32) "IData"
       else if(signal.dataType.width <= 64) "QData"
       else "WData"
-      val enforcedCast = if(signal.dataType.width > 64) "(WData*)" else ""
+      val enforcedCast = if(signal.dataType.width > 64) ".data()" else ""
       val signalReference = s"top->${signal.path.map(_.replace("$", "__024").replace("__", "___05F")).mkString("->")}"
       val memPatch = if(signal.dataType.isMem) "[0]" else ""
 
-      s"      signalAccess[$id] = new ${typePrefix}SignalAccess($enforcedCast $signalReference$memPatch ${if(signal.dataType.width > 64) s" , ${signal.dataType.width}, ${if(signal.dataType.isInstanceOf[SIntDataType]) "true" else "false"}" else ""});\n"
+      s"      signalAccess[$id] = new ${typePrefix}SignalAccess($signalReference$memPatch$enforcedCast ${if(signal.dataType.width > 64) s" , ${signal.dataType.width}, ${if(signal.dataType.isInstanceOf[SIntDataType]) "true" else "false"}" else ""});\n"
 
     }
 


### PR DESCRIPTION
    SIM:VerilatorBackend: Fix 5.xx casting
    
    Issue: https://github.com/SpinalHDL/SpinalHDL/issues/1919#issuecomment-4937239512
    
    The original WData (old) expect > 64 use case, where the casting is via
    "C-style cast".
    
    Try using .data() instead, where matching class VlWide.
    
    Signed-off-by: Brian Sune <briansune@gmail.com>