### PR TITLE
add ceil log2 and floor log2 for UInt.

### DIFF
--- a/lib/src/main/scala/spinal/lib/Utils.scala
+++ b/lib/src/main/scala/spinal/lib/Utils.scala
@@ -161,6 +161,20 @@ object Clamp {
   def apply[T <: Data with Num[T]](nums: Seq[T], low: T, high: T): Seq[T] = nums.map(apply(_, low, high))
 }
 
+object Log2 {
+  def ceil(x: UInt): UInt = new Composite(x, "clog2") {
+    val symbol_oh = OHMasking.last(x)
+    val symbol_mask = (~symbol_oh) & x
+    val oh_ceil = (symbol_mask === 0) ? (U(0, 1 bits) @@ symbol_oh) | (symbol_oh << 1)
+    val result = OHToUInt(oh_ceil)
+  }.result
+
+  def floor(x: UInt): UInt = new Composite(x, "flog2") {
+    val symbol_oh = OHMasking.last(x)
+    val result = OHToUInt(symbol_oh)
+  }.result
+}
+
 object SetFromFirstOne{
   def apply[T <: Data](that : T, firstOrder: Int = LutInputs.get) : T = {
     val lutSize = firstOrder


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->


# Context, Motivation & Description

Add ceil log2 and floor log2 utility for **UInt** 



<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation
No.
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

Since the math is not complicated and based on existing qualified **OHMasking** implementation,  unit tests were not added.  Local tests have passed before this PR. 

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
