### PR TITLE
Allow to change defaultKey of up/down of the CtrlLink

### DIFF
--- a/lib/src/main/scala/spinal/lib/misc/pipeline/Builder.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/Builder.scala
@@ -74,12 +74,12 @@ class NodesBuilder() extends Area {
   }
 }
 
-class StagePipeline() extends Area {
+class StagePipeline(defaultKey: Any = null) extends Area {
   val nodes = mutable.LinkedHashMap[Int, Node]()
   val links = mutable.ArrayBuffer[StageLink]()
 
   def apply(i : Int) = node(i)
-  def node(i : Int) = nodes.getOrElseUpdate(i, new Node().setCompositeName(this, s"node_${i.toString}"))
+  def node(i : Int) = nodes.getOrElseUpdate(i, new Node(defaultKey).setCompositeName(this, s"node_${i.toString}"))
   class Area(i : Int) extends NodeMirror(node(i)) with spinal.core.Area
 
   def first = node(nodes.keys.min)
@@ -95,11 +95,21 @@ class StagePipeline() extends Area {
   }
 }
 
-class StageCtrlPipeline() extends Area {
+class StageCtrlPipeline(defaultKey: Any = null) extends Area {
   val ctrls = mutable.LinkedHashMap[Int, CtrlLink]()
   val links = mutable.ArrayBuffer[StageLink]()
 
-  def ctrl(i : Int) = ctrls.getOrElseUpdate(i, CtrlLink().setCompositeName(this, s"ctrl_${i.toString}"))
+  /* This can be simplified if defaultKey/useSingleDefaultKey is removed */
+  private def newCtrl() = {
+    val c = new CtrlLink(new Node(defaultKey), new Node(defaultKey)) {
+      override def defaultKey: Any = StageCtrlPipeline.this.defaultKey
+      override def useSingleDefaultKey: Boolean = false
+    }
+    c.up.setCompositeName(c, "up")
+    c.down.setCompositeName(c, "down")
+    c
+  }
+  def ctrl(i : Int) = ctrls.getOrElseUpdate(i, newCtrl().setCompositeName(this, s"ctrl_${i.toString}"))
   class Ctrl(i : Int) extends CtrlLinkMirror(ctrl(i))
   class InsertArea extends NodeMirror(ctrl(0).up) with spinal.core.Area
 
@@ -113,5 +123,4 @@ class StageCtrlPipeline() extends Area {
     Builder(links ++ ctrls.values)
   }
 }
-
 

--- a/lib/src/main/scala/spinal/lib/misc/pipeline/CtrlLink.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/CtrlLink.scala
@@ -9,8 +9,8 @@ import scala.collection.Seq
 
 object CtrlLink {
   def apply(up : Node, down : Node) = new CtrlLink(up, down)
-  def apply() = {
-    val c = new CtrlLink(new Node(), new Node())
+  def apply(defaultKey: Any = null) = {
+    val c = new CtrlLink(new Node(defaultKey), new Node(defaultKey))
     c.up.setCompositeName(c, "up")
     c.down.setCompositeName(c, "down")
     c
@@ -22,7 +22,15 @@ trait CtrlApi {
   private val _c = getCtrl
   import _c._
 
+  @deprecated("Use the defaultKey of node up and down instead, or override upDefaultKey/downDefaultKey instead.", "1.15.0")
   def defaultKey : Any = null
+
+  @deprecated("The gate is only used for passing defaultKey to up/down node, override upDefaultKey/downDefaultKey instead.", "1.15.0")
+  def useSingleDefaultKey: Boolean = true
+
+  def upDefaultKey: Any = if (useSingleDefaultKey) defaultKey else up.defaultKey
+
+  def downDefaultKey: Any = if (useSingleDefaultKey) defaultKey else down.defaultKey
 
   def up : NodeApi = _c.up
   def down : NodeApi = _c.down
@@ -31,7 +39,7 @@ trait CtrlApi {
   def isReady = down.isReady
 
   /** Same as `Link.down(Payload)` */
-  def apply[T <: Data](that: Payload[T]): T = down(that, defaultKey)
+  def apply[T <: Data](that: Payload[T]): T = down(that, downDefaultKey)
 
   /** Same as `Link.down(Payload, subKey)` */
   def apply[T <: Data](that: Payload[T], subKey: Any): T = down(that, subKey)
@@ -44,7 +52,7 @@ trait CtrlApi {
    *
    * This can be used to fix data hazard in CPU pipelines for instance.
    */
-  def bypass[T <: Data](that: Payload[T]): T =  bypass(that, defaultKey)
+  def bypass[T <: Data](that: Payload[T]): T =  bypass(that, upDefaultKey)
 
   /** Allows to conditionally override a ([[Payload]], subKey) value between `link.up` -> `link.down`.
    *
@@ -232,12 +240,42 @@ class CtrlLink(override val up : Node, override val down : Node) extends Link wi
     }
   }
 
-  class Area(override val defaultKey : Any = null)  extends spinal.core.Area with CtrlApi {
+  class Area private (
+    _upDefaultKey: Any,
+    _downDefaultKey: Any,
+    _useSingleDefaultKey: Boolean,
+    _defaultKey: Any,
+  ) extends spinal.core.Area with CtrlApi {
+    def this(_upDefaultKey : Any, _downDefaultKey: Any) = this(_upDefaultKey, _downDefaultKey, false, null)
+
+    @deprecated("Use constructor this(_upDefaultKey, _downDefaultKey) instead", "1.15.0")
+    def this(_defaultKey : Any) = this(_defaultKey, _defaultKey, true, _defaultKey)
+
+    def this() = this(CtrlLink.this.upDefaultKey, CtrlLink.this.downDefaultKey, false, null)
+
     override def getCtrl: CtrlLink = CtrlLink.this
+
+    @deprecated("Use upDefaultKey/downDefaultKey instead.", "1.15.0")
+    override def defaultKey: Any = _defaultKey
+
+    @deprecated("Use upDefaultKey/downDefaultKey instead.", "1.15.0")
+    override def useSingleDefaultKey: Boolean = _useSingleDefaultKey
+
+    override def upDefaultKey: Any = if (useSingleDefaultKey) defaultKey else _upDefaultKey
+
+    override def downDefaultKey: Any = if (useSingleDefaultKey) defaultKey else _downDefaultKey
   }
 }
 
 
 class CtrlLinkMirror(from : CtrlLink) extends spinal.core.Area with CtrlApi {
   override def getCtrl: CtrlLink = from
+
+  @deprecated("Use upDefaultKey/downDefaultKey instead.", "1.15.0")
+  override def defaultKey: Any = from.defaultKey
+  @deprecated("Use upDefaultKey/downDefaultKey instead.", "1.15.0")
+  override def useSingleDefaultKey: Boolean = from.useSingleDefaultKey
+
+  override def upDefaultKey: Any = from.upDefaultKey
+  override def downDefaultKey: Any = from.downDefaultKey
 }

--- a/lib/src/main/scala/spinal/lib/misc/pipeline/Node.scala
+++ b/lib/src/main/scala/spinal/lib/misc/pipeline/Node.scala
@@ -7,6 +7,7 @@ import spinal.lib._
 
 object Node{
   def apply() : Node = new Node
+  def apply(defaultKey: Any): Node = new Node(defaultKey)
 
   class OffsetApi(subKeys: Seq[Any], node: Node) {
     def apply[T <: Data](that: Payload[T]): Seq[T] = {
@@ -37,10 +38,10 @@ trait NodeBaseApi {
 
   /** Return the hardware signal for this [[Payload]] key at the point of this [[Node]] in the pipeline.*/
   def apply[T <: Data](key: Payload[T]): T
-  
+
   /** Return the hardware signal for this ([[Payload]], subKey) key at the point of this [[Node]] in the pipeline.
-    * 
-    * This eases the construction of multi-lane hardware. For instance, when you have a 
+    *
+    * This eases the construction of multi-lane hardware. For instance, when you have a
     * multi-issue CPU pipeline, you can use the lane `Int` id as secondary key.
     */
   def apply[T <: Data](key: Payload[T], subKey: Any): T = {
@@ -49,7 +50,7 @@ trait NodeBaseApi {
 
   /** Allows converting a list of key into values. ex : node(1 to 2)(MY_STAGEABLE) */
   def apply(subKey: Seq[Any]) : Node.OffsetApi
-  
+
   /** Return a new [[Payload]] which is connected to the given `Data` hardware signal starting from this Node in the pipeline. */
   def insert[T <: Data](that: T): Payload[T] = {
     val s = Payload(cloneOf(that))
@@ -73,10 +74,10 @@ trait NodeApi extends NodeBaseApi {
   def defaultKey : Any = null
 
   /** The signal which specifies if a transaction is present on the node.
-    * 
+    *
     * It is driven by the upstream. Once asserted, it must only be de-asserted the cycle after which
     * either both [[valid]] and [[ready]] or [[cancel]] are high. [[valid]] must not depend on [[ready]].
-    * 
+    *
     * Created on demand, thus it's important to use [[isValid]] to get the signal value.
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/Pipeline/introduction.html#node Node documentation]]
     */
@@ -86,17 +87,17 @@ trait NodeApi extends NodeBaseApi {
     *
     * It is driven by the downstream to create backpressure. The signal has no meaning when there
     * is no transaction ([[valid]] being deasserted).
-    * 
+    *
     * Created on demand, thus it's important to use [[isReady]] to get the signal value.
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/Pipeline/introduction.html#node Node documentation]]
     */
   def ready : Bool = getNode.ready
 
   /** The signal which specifies if the node’s transaction in being canceled from the pipeline.
-    * 
+    *
     * It is driven by the downstream. The signal has no meaning when there is no transaction
     * ([[valid]] being deasserted).
-    * 
+    *
     * Created on demand, thus it's important to use [[isReady]] to get the signal value.
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/Pipeline/introduction.html#node Node documentation]]
     */
@@ -115,20 +116,20 @@ trait NodeApi extends NodeBaseApi {
   }
 
   /** `True` when the current transaction is successfully moving forward (`isReady && !isRemoved`).
-    * 
+    *
     * Useful to validate state changes.
-    */ 
+    */
   def isFiring : Bool = {
     if (status.isFiring.isEmpty) status.isFiring = Some(ContextSwapper.outsideCondScopeData(Bool().setCompositeName(getNode, "isFiring")))
     status.isFiring.get
   }
 
-  /** True when it is the last cycle that the current transaction is present on this node. 
-    * 
-    * More precisely, `True` when the node transaction will not be present anymore on the node 
-    * (starting from the next cycle), either because downstream is ready to take the transaction, or 
+  /** True when it is the last cycle that the current transaction is present on this node.
+    *
+    * More precisely, `True` when the node transaction will not be present anymore on the node
+    * (starting from the next cycle), either because downstream is ready to take the transaction, or
     * because the transaction is canceled from the pipeline. (`valid && (ready || cancel)`).
-    * 
+    *
     * Useful to “reset” states.
     */
   def isMoving : Bool = {
@@ -138,7 +139,7 @@ trait NodeApi extends NodeBaseApi {
 
   /**
     * `True` when the node transaction is being cleaned up.
-    * 
+    *
     * Meaning that it will not appear anywhere in the pipeline in future cycles.
     * It is equivalent to `isValid && isCancel`.
     */
@@ -217,21 +218,21 @@ trait NodeApi extends NodeBaseApi {
   def toStream[T <: Data](con: (Node) => T): Stream[T] = {
     val newPayload = con(getNode)
     val that = Stream(cloneOf(newPayload))
-    that.payload := newPayload 
+    that.payload := newPayload
     arbitrateTo(that)
     that
   }
-  
+
   def toFlow[T <: Data](con: (Node) => T): Flow[T] = {
     val newPayload = con(getNode)
     val that = Flow(cloneOf(newPayload))
-    that.payload := newPayload 
+    that.payload := newPayload
     arbitrateTo(that)
     that
   }
 }
 
-class Node() extends Area with NodeApi {
+class Node(override val defaultKey: Any = null) extends Area with NodeApi {
   override def getNode: Node = this
 
   override def valid = {
@@ -296,12 +297,14 @@ class Node() extends Area with NodeApi {
     status.isCanceling.foreach(_ := status.isCancel.map(isValid && _).getOrElse(False))
   }
 
-  class Area(override val defaultKey : Any = null) extends spinal.core.Area with NodeApi {
+  class Area(override val defaultKey : Any = Node.this.defaultKey) extends spinal.core.Area with NodeApi {
     override def getNode: Node = Node.this
   }
 }
 
 
-class NodeMirror(node : Node) extends NodeApi {
+class NodeMirror(node : Node, override val defaultKey : Any) extends NodeApi {
+  def this(node: Node) = this(node, node.defaultKey)
+
   def getNode: Node = node
 }

--- a/tester/src/test/scala/spinal/lib/misc/pipeline/PipelineTester.scala
+++ b/tester/src/test/scala/spinal/lib/misc/pipeline/PipelineTester.scala
@@ -192,6 +192,59 @@ class PipelineTester extends SpinalAnyFunSuite{
     }
   }
 
+  test("defaultKey") {
+    SimConfig.compile(new Component {
+      val pip = new StagePipeline("lane")
+      val IN = Payload(UInt(16 bits))
+      val OUT = Payload(UInt(16 bits))
+      val source = slave Stream(IN)
+      val sink = master Stream(OUT)
+      val inserter = new pip.Area(0) {
+        arbitrateFrom(source)
+        this(IN) := source.payload
+      }
+      val calc = new pip.Area(1) {
+        this(OUT) := this(IN) + 1
+      }
+      val output = new pip.Area(2) {
+        arbitrateTo(sink)
+        sink.payload := this(OUT)
+      }
+      pip.build()
+      def testIt(onPush: (Int, mutable.Queue[Int]) => Unit): Unit = simpleTest(clockDomain, source, sink)(onPush)
+    }).doSimUntilVoid { dut =>
+      dut.testIt { (value, queue) =>
+        queue += (value + 1) & 0xFFFF
+      }
+    }
+  }
+
+  test("defaultKeyCtrl") {
+    SimConfig.compile(new Component {
+      val pip = new StageCtrlPipeline("lane")
+      val IN = Payload(UInt(16 bits))
+      val TMP = Payload(UInt(16 bits))
+      val OUT = Payload(UInt(16 bits))
+      val source = slave Stream(IN)
+      val sink = master Stream(OUT)
+      val inserter = new pip.Ctrl(0) {
+        up.driveFrom(source)((self, payload) => self(IN) := payload)
+      }
+      pip.ctrl(1)(TMP) := pip.ctrl(1)(IN) + 1
+      val calc = new pip.Ctrl(2) {
+        this(OUT) := this(TMP) + 1
+      }
+      val output = new pip.Ctrl(3) {
+        down.driveTo(sink)((payload, self) => payload := self(OUT))
+      }
+      pip.build()
+      def testIt(onPush: (Int, mutable.Queue[Int]) => Unit): Unit = simpleTest(clockDomain, source, sink)(onPush)
+    }).doSimUntilVoid { dut =>
+      dut.testIt { (value, queue) =>
+        queue += (value + 2) & 0xFFFF
+      }
+    }
+  }
 
   // Remove C1 transactions which have the LSB set
   test("throw") {
@@ -374,6 +427,46 @@ class PipelineTester extends SpinalAnyFunSuite{
       when(c2.down.isFiring) {
         state := c2(IN)
       }
+    }).doSimUntilVoid { dut =>
+      var state = 0
+      dut.testIt { (value, queue) =>
+        queue += state
+        state = value
+      }
+    }
+  }
+
+
+  test("bypassDefaultKey") {
+    SimConfig.compile(new Component {
+      val pip = new StageCtrlPipeline("lane")
+      val IN = Payload(UInt(16 bits))
+      val OUT = Payload(UInt(16 bits))
+      val source = slave Stream(IN)
+      val sink = master Stream(OUT)
+      val state = Reg(UInt(16 bits)) init(0)
+      val inserter = new pip.Ctrl(0) {
+        up.driveFrom(source)((self, payload) => self(IN) := payload)
+        up(OUT) := state
+      }
+      val bypass0 = new pip.Ctrl(0) {
+        when(pip.ctrl(2).down.valid) {
+          bypass(OUT) := pip.ctrl(2).down(IN)
+        }
+      }
+      val bypass1 = new pip.Ctrl(1) {
+        when(pip.ctrl(2).down.valid) {
+          bypass(OUT) := pip.ctrl(2).down(IN)
+        }
+      }
+      val output = new pip.Ctrl(2) {
+        down.driveTo(sink)((payload, self) => payload := self(OUT))
+        when(down.isFiring) {
+          state := down(IN)
+        }
+      }
+      pip.build()
+      def testIt(onPush: (Int, mutable.Queue[Int]) => Unit): Unit = simpleTest(clockDomain, source, sink)(onPush)
     }).doSimUntilVoid { dut =>
       var state = 0
       dut.testIt { (value, queue) =>


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #1943

# Context, Motivation & Description

Currently, the `defaultKey` of the `CtrlLink` does not respect the `defaultKey` of the node `up`/`down`, instead, it use a internal `defaultKey` defined in the `CtrlApi`. This means the `defaultKey` in the node does not take effect, it makes some necessary code for complex pipeline.

Introduce a flexible control for the `CtrlLink` and Node so it can control the `defaultKey` in a more easier way. Also, add the `defaultKey` to the `StagePipeline` and `StageCtrlPipeline`, so it can be used as internal component of the complex pipeline.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

Note: the current `defaultKey` API is marked as deprecated since the newly introduced `upDefaultKey`/`downDefaultKey` can provide fine-grant control

**The `CtrlLinkMirror.defaultKey` is meaningless as it always uses `upDefaultKey`/`downDefaultKey`. This may introduce a break to some code that overrides the `defaultKey` of `CtrlLinkMirror`.** Since this Area is more like a internal thing and the `defaultKey` should not be overrided, so I think it is fine to change this.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
