### PR TITLE
Add tilelink channel D corrupt line check

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/bmb/TilelinkToBmb.scala
+++ b/lib/src/main/scala/spinal/lib/bus/bmb/TilelinkToBmb.scala
@@ -49,14 +49,14 @@ case class TilelinkToBmb(p : tilelink.M2sParameters) extends Component{
   io.down.cmd.context   := io.up.a.size ## io.down.cmd.opcode
 
   io.up.d.arbitrationFrom(io.down.rsp)
-  io.up.d.opcode  := io.down.rsp.context(0).mux(tilelink.Opcode.D.ACCESS_ACK, tilelink.Opcode.D.ACCESS_ACK_DATA)
+  val ackOpcode = io.down.rsp.context(0).mux(tilelink.Opcode.D.ACCESS_ACK, tilelink.Opcode.D.ACCESS_ACK_DATA)
+  io.up.d.opcode  := ackOpcode
   io.up.d.param   := 0
   io.up.d.source  := io.down.rsp.source
   io.up.d.size    := io.down.rsp.context.dropLow(1).asUInt
   io.up.d.denied  := io.down.rsp.isError
   io.up.d.data    := io.down.rsp.data
-  io.up.d.corrupt := False
+  io.up.d.corrupt := io.down.rsp.isError && tilelink.Opcode.D.isData(ackOpcode)
 }
-
 
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Apb3Bridge.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Apb3Bridge.scala
@@ -53,15 +53,16 @@ class Apb3Bridge(p : NodeParameters) extends Component{
   io.down.PWDATA := buffered.data
 
   val rsp = cloneOf(io.up.d)
+  val rspOpcode = isGet.mux(Opcode.D.ACCESS_ACK_DATA, Opcode.D.ACCESS_ACK)
   rsp.valid := forked.fire
-  rsp.opcode := isGet.mux(Opcode.D.ACCESS_ACK_DATA, Opcode.D.ACCESS_ACK)
+  rsp.opcode := rspOpcode
   rsp.param := 0
   rsp.source := buffered.source
   rsp.sink := 0
   rsp.size := buffered.size
   rsp.data := io.down.PRDATA
   rsp.denied := io.down.PSLVERROR
-  rsp.corrupt := False
+  rsp.corrupt := io.down.PSLVERROR && Opcode.D.isData(rspOpcode)
 
   io.up.d << rsp.halfPipe()
   io.down.PSEL(0) clearWhen(io.up.d.valid)

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Axi4Bridge.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Axi4Bridge.scala
@@ -98,13 +98,14 @@ class Axi4Bridge(p : NodeParameters, withAxi3 : Boolean = false, forceAxi4Len : 
 
     a.ctx.io.query.id := io.up.d.source
     io.up.d.arbitrationFrom(arbiter.io.output)
-    io.up.d.opcode := arbiter.io.chosen(0).mux(Opcode.D.ACCESS_ACK_DATA(), Opcode.D.ACCESS_ACK())
+    val ackOpcode = arbiter.io.chosen(0).mux(Opcode.D.ACCESS_ACK_DATA(), Opcode.D.ACCESS_ACK())
+    io.up.d.opcode := ackOpcode
     io.up.d.param := 0
     io.up.d.source := arbiter.io.output.source
     io.up.d.sink := 0
     io.up.d.denied := arbiter.io.output.denied
     io.up.d.data := io.down.r.data
-    io.up.d.corrupt := False
+    io.up.d.corrupt := arbiter.io.output.denied && Opcode.D.isData(ackOpcode)
     io.up.d.size := a.ctx.io.query.context
   }
 }

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/AxiLite4Bridge.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/AxiLite4Bridge.scala
@@ -86,13 +86,15 @@ class AxiLite4Bridge(p : NodeParameters) extends Component{
     io.down.r.ready := io.up.d.ready
     io.down.b.ready := io.up.d.ready || !lastB
     io.up.d.valid := io.down.r.valid || io.down.b.valid && lastB
-    io.up.d.opcode := pending.get.mux(Opcode.D.ACCESS_ACK_DATA(), Opcode.D.ACCESS_ACK())
+    val ackOpcode = pending.get.mux(Opcode.D.ACCESS_ACK_DATA(), Opcode.D.ACCESS_ACK())
+    val denied = !pending.get.mux(io.down.r.isOKAY(), io.down.b.isOKAY())
+    io.up.d.opcode := ackOpcode
     io.up.d.param := 0
     io.up.d.source := pending.source
     io.up.d.sink := 0
-    io.up.d.denied := !pending.get.mux(io.down.r.isOKAY(), io.down.b.isOKAY())
+    io.up.d.denied := denied
     io.up.d.data := io.down.r.data
-    io.up.d.corrupt := False
+    io.up.d.corrupt := denied && Opcode.D.isData(ackOpcode)
     io.up.d.size := pending.size
   }
 }

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Bus.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Bus.scala
@@ -62,6 +62,7 @@ object Opcode extends AreaRoot{
     )
     def fromA(opcode : C) : Bool = List(ACCESS_ACK, ACCESS_ACK_DATA, GRANT, GRANT_DATA).map(opcode === _).orR
     def isFinal(opcode : C) : Bool = List(ACCESS_ACK, ACCESS_ACK_DATA, RELEASE_ACK).map(opcode === _).orR
+    def isData(opcode : C) : Bool = List(ACCESS_ACK_DATA, GRANT_DATA).map(opcode === _).orR
   }
 }
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/ErrorSlave.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/ErrorSlave.scala
@@ -12,13 +12,14 @@ class ErrorSlave(bp : BusParameter) extends Component{
     val buffer = io.bus.a.halfPipe()
     buffer.ready := io.bus.d.fire && io.bus.d.isLast()
     io.bus.d.valid := buffer.valid && buffer.isLast()
-    io.bus.d.opcode := buffer.opcode mux(
+    val ackOpcode = buffer.opcode mux(
       Opcode.A.PUT_FULL_DATA    -> Opcode.D.ACCESS_ACK(),
       Opcode.A.PUT_PARTIAL_DATA -> Opcode.D.ACCESS_ACK(),
       Opcode.A.GET              -> Opcode.D.ACCESS_ACK_DATA(),
       Opcode.A.ACQUIRE_BLOCK    -> Opcode.D.GRANT_DATA(),
       Opcode.A.ACQUIRE_PERM     -> Opcode.D.GRANT()
     )
+    io.bus.d.opcode := ackOpcode
     io.bus.d.param := 0
     io.bus.d.source := buffer.source
     io.bus.d.sink := 0
@@ -26,7 +27,7 @@ class ErrorSlave(bp : BusParameter) extends Component{
     io.bus.d.denied := True
     if(bp.withDataD) {
       io.bus.d.data.assignDontCare()
-      io.bus.d.corrupt.assignDontCare()
+      io.bus.d.corrupt := Opcode.D.isData(ackOpcode)
     }
   }
   assert(!bp.withBCE)

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
@@ -82,17 +82,18 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
   io.up.d.sink.removeAssignments() := io.down.d.sink.resized
   when(doIt){
     io.up.d.valid := True
-    io.up.d.opcode := opcode.mux(
+    val ackOpcode = opcode.mux(
       Opcode.A.PUT_FULL_DATA -> Opcode.D.ACCESS_ACK(),
       Opcode.A.PUT_PARTIAL_DATA -> Opcode.D.ACCESS_ACK(),
       Opcode.A.GET -> Opcode.D.ACCESS_ACK_DATA(),
       Opcode.A.ACQUIRE_BLOCK -> Opcode.D.GRANT_DATA(),
       Opcode.A.ACQUIRE_PERM -> Opcode.D.GRANT()
     )
+    io.up.d.opcode := ackOpcode
     io.up.d.size := size
     io.up.d.source := source
     io.up.d.denied := True
-    io.up.d.corrupt := False
+    io.up.d.corrupt := Opcode.D.isData(ackOpcode)
     io.up.d.param := 0
     if(unp.withBCE) io.up.d.sink.msb := True
     when(io.up.d.ready) {

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Checker.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Checker.scala
@@ -199,6 +199,9 @@ class Checker(p : BusParameter, mappings : Seq[Endpoint], checkMapping : Boolean
   }
 
   override def onD(d: TransactionD) = {
+    if(d.withData) assert(!d.denied || d.corrupt, "Denied is also corrupt")
+    if(!d.withData) assert(!d.corrupt)
+
     d.opcode match{
       case Opcode.D.ACCESS_ACK | Opcode.D.ACCESS_ACK_DATA | Opcode.D.GRANT | Opcode.D.GRANT_DATA  =>  {
         val ctx = inflightA(d.source)
@@ -206,12 +209,11 @@ class Checker(p : BusParameter, mappings : Seq[Endpoint], checkMapping : Boolean
         d.assertRspOf(ctx.a)
         if(checkMapping) {
           assert(ctx.isSet, s"No reference was provided for :\n${ctx.a}to compare with :\n$d")
-          if (d.withData && !ctx.denied) {
+          if (d.withData && !ctx.denied && !d.corrupt) {
             assert(ctx.ref != null, s"No reference data was provided for :\n${ctx.a}to compare with :\n$d")
             assert((ctx.ref, d.data).zipped.forall(_ == _), s"Missmatch for :\n${ctx.a}\n$d\n!=${ctx.ref.map(v => f"${v}%02x").mkString(" ")}")
           }
           assert(d.denied == ctx.denied)
-          assert(!d.corrupt)
         }
         if(d.opcode == Opcode.D.GRANT || d.opcode == Opcode.D.GRANT_DATA){
           doGrow(d.source, d.address, d.param)

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Checker.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Checker.scala
@@ -54,7 +54,7 @@ class Checker(p : BusParameter, mappings : Seq[Endpoint], checkMapping : Boolean
 
   val inflightA = Array.fill[InflightA](1 << p.sourceWidth)(null)
   val inflightB = mutable.LinkedHashMap[(Int, BigInt), TransactionB]()
-  val inflightC = mutable.LinkedHashMap[(Int, BigInt), TransactionC]()
+  val inflightC = mutable.LinkedHashMap[Int, TransactionC]()
   val inflightD = mutable.LinkedHashMap[BigInt, TransactionD]()
 
   case class Cap(var current : Int, var probed : Boolean)
@@ -161,8 +161,8 @@ class Checker(p : BusParameter, mappings : Seq[Endpoint], checkMapping : Boolean
     import Opcode.C._
     c.opcode match {
       case RELEASE_DATA | RELEASE => {
-        val key = c.source -> c.address
-        assert(!inflightC.contains(key))
+        val key = c.source
+        assert(!inflightC.contains(key), s"C source $key already has an outstanding Release :\n${inflightC(key)}$c")
         inflightC(key) = c
       }
       case PROBE_ACK | PROBE_ACK_DATA => {
@@ -222,8 +222,9 @@ class Checker(p : BusParameter, mappings : Seq[Endpoint], checkMapping : Boolean
         if(checkMapping) idCallback.remove(ctx.a.debugId, ctx)
       }
       case Opcode.D.RELEASE_ACK => {
-        inflightC.remove(d.source -> d.address) match {
-          case Some(c) => doShrink(d.source, d.address, c.param)
+        inflightC.remove(d.source) match {
+          case Some(c) => doShrink(d.source, c.address, c.param)
+          case None => SimError(s"ReleaseAck without outstanding C source ${d.source}")
         }
       }
     }

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MasterTester.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MasterTester.scala
@@ -183,14 +183,17 @@ class MasterTester(val m : MasterSpec, val agent : MasterAgent){
               deniedOn(_.get){(address, bytes) =>
                 val d = agent.get(sourceId, address, bytes)
                 assert(d.denied)
+                assert(d.corrupt)
               }
               deniedOn(_.putPartial){(address, bytes) =>
                 val d = agent.putPartialData(sourceId, address, randomizedData(bytes), randomizedMask(bytes))
                 assert(d.denied)
+                assert(!d.corrupt)
               }
               deniedOn(_.putFull){(address, bytes) =>
                 val d = agent.putFullData(sourceId, address, randomizedData(bytes))
                 assert(d.denied)
+                assert(!d.corrupt)
               }
               deniedOn(_.acquireB){(address, bytes) =>
                 val b = agent.block.get(sourceId, address) match {

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MemoryAgent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MemoryAgent.scala
@@ -108,6 +108,7 @@ class MemoryAgent(bus: Bus,
           d.denied = !ok
           if(ok) d.data = mem.readBytes(a.address.toLong, a.bytes)
           if(!ok)  d.data = Array.fill(a.bytes)(simRandom.nextInt().toByte)
+          d.corrupt = d.denied
           driver.scheduleD(d)
         }
         case Opcode.A.PUT_PARTIAL_DATA | Opcode.A.PUT_FULL_DATA => { //TODO probePerm not tested

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Transactions.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Transactions.scala
@@ -361,6 +361,7 @@ class TransactionD extends TransactionABCD{
     val ret = new TransactionD()
     ret.copyNoDataFrom(this)
     ret.opcode = opcode
+    ret.corrupt = corrupt
     ret.denied = denied
     ret.sink = sink
     ret.asInstanceOf[this.type]


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

According to the latest tilelink spec 1.9.3. The corrupt line of the channel D should not be hard-wired to False. Make its behavior following the spec.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

The tilelink channel D now provides right corrupt line.

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
