### PR TITLE
Add scaladoc for advanced features

### DIFF
--- a/core/src/main/scala/spinal/core/BitVector.scala
+++ b/core/src/main/scala/spinal/core/BitVector.scala
@@ -505,9 +505,10 @@ abstract class BitVector extends BaseType with Widthable {
     this
   }
 
-  /** Set all bits */
+  /** Hardware assignment of all bits to `True` */
   override def setAll(): this.type
-  /** Clear all bits */
+  
+  /** Hardware assignment of all bits to `False` */
   override def clearAll(): this.type = {
     this := this.getZeroUnconstrained
     this

--- a/core/src/main/scala/spinal/core/Bits.scala
+++ b/core/src/main/scala/spinal/core/Bits.scala
@@ -251,6 +251,11 @@ class Bits extends BitVector with DataPrimitives[Bits] with BaseTypePrimitives[B
     * non-assignment, but  unlike those it is explicit. If a signal is unassigned
     * (e.g., no "don't care" or value) in any control path, an error will be raised.
     *
+    * At generation, `'x` in Verilog and `'-'` in VHDL will be generated, unless
+    * SpinalConfig.dontCareGenAsZero is explicitly set as `true`. Note that some
+    * simulators like Verilator use only 0 and 1 for performance reason and will
+    * use random or fixed 0 and 1 values depending on their config.
+    *
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
     * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
     */

--- a/core/src/main/scala/spinal/core/Bits.scala
+++ b/core/src/main/scala/spinal/core/Bits.scala
@@ -238,7 +238,7 @@ class Bits extends BitVector with DataPrimitives[Bits] with BaseTypePrimitives[B
   override def getZero: this.type = B(0, this.getWidth bits).asInstanceOf[this.type]
   override def getZeroUnconstrained: this.type = B(0).asInstanceOf[this.type]
   override def getAllTrue: this.type = B((BigInt(1) << this.getWidth) - 1, this.getWidth bits).asInstanceOf[this.type]
-  
+
   /** Hardware assignment of all bits to `True` */
   override def setAll(): this.type = {
     this := (BigInt(1) << this.getWidth) - 1
@@ -246,11 +246,11 @@ class Bits extends BitVector with DataPrimitives[Bits] with BaseTypePrimitives[B
   }
 
   /** Explicitly mark that this hardware signal can take any value in the current context.
-    * 
+    *
     * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
-    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned
     * (e.g., no "don't care" or value) in any control path, an error will be raised.
-    * 
+    *
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
     * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
     */

--- a/core/src/main/scala/spinal/core/Bits.scala
+++ b/core/src/main/scala/spinal/core/Bits.scala
@@ -238,11 +238,22 @@ class Bits extends BitVector with DataPrimitives[Bits] with BaseTypePrimitives[B
   override def getZero: this.type = B(0, this.getWidth bits).asInstanceOf[this.type]
   override def getZeroUnconstrained: this.type = B(0).asInstanceOf[this.type]
   override def getAllTrue: this.type = B((BigInt(1) << this.getWidth) - 1, this.getWidth bits).asInstanceOf[this.type]
+  
+  /** Hardware assignment of all bits to `True` */
   override def setAll(): this.type = {
     this := (BigInt(1) << this.getWidth) - 1
     this.asInstanceOf[this.type]
   }
 
+  /** Explicitly mark that this hardware signal can take any value in the current context.
+    * 
+    * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * (e.g., no "don't care" or value) in any control path, an error will be raised.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
+    * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
+    */
   override def assignDontCare(): this.type = {
     this.assignFrom(BitsLiteral(BigInt(0), (BigInt(1) << this.getWidth) - 1, widthOf(this)))
     this

--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -322,11 +322,16 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
   def ?[T <: SpinalEnum](whenTrue: SpinalEnumCraft[T]) = MuxBuilderEnum(whenTrue)
 
   /** Explicitly mark that this hardware signal can take any value in the current context.
-    * 
+    *
     * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
-    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned
     * (e.g., no "don't care" or value) in any control path, an error will be raised.
-    * 
+    *
+    * At generation, `'x` in Verilog and `'-'` in VHDL will be generated, unless
+    * SpinalConfig.dontCareGenAsZero is explicitly set as `true`. Note that some
+    * simulators like Verilator use only 0 and 1 for performance reason and will
+    * use random or fixed 0 and 1 values depending on their config.
+    *
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
     * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
     */

--- a/core/src/main/scala/spinal/core/Bool.scala
+++ b/core/src/main/scala/spinal/core/Bool.scala
@@ -117,26 +117,22 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
   /** this is assigned to `False` */
   def clear(): Unit = this := False
 
-  /** Set to True.
-    *
-    * Direct call to `set()` to reduce the number of nodes in the netlist.
-    */
+  /** Hardware assignment of all bits to `True` */
   override def setAll(): this.type = {
+    // Direct call to `set()` to reduce the number of nodes in the netlist.
     this.set()
     this
   }
 
-  /** Set to False.
-    *
-    * Direct call to `clear()` to reduce the number of nodes in the netlist.
-    */
+  /** Hardware assignment of all bits to `False` */
   override def clearAll(): this.type = {
+    // Direct call to `clear()` to reduce the number of nodes in the netlist.
     this.clear()
     this
   }
 
-  /**
-    * this is assigned to True when cond is True
+  /** This is assigned to `True` when `cond` is `True`
+    * 
     * @example{{{ myBool.setWhen(cond) }}}
     * @param cond a Bool condition
     * @return this is assigned to True when cond is True
@@ -325,6 +321,15 @@ class Bool extends BaseType with DataPrimitives[Bool]  with BaseTypePrimitives[B
   /** Conditional operation for Enumeration value */
   def ?[T <: SpinalEnum](whenTrue: SpinalEnumCraft[T]) = MuxBuilderEnum(whenTrue)
 
+  /** Explicitly mark that this hardware signal can take any value in the current context.
+    * 
+    * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * (e.g., no "don't care" or value) in any control path, an error will be raised.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
+    * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
+    */
   override def assignDontCare(): this.type = {
     this.assignFrom(new BoolPoison())
     this

--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -454,13 +454,13 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
   def assignFromBits(bits: Bits, hi: Int, low: Int): Unit
   def assignFromBits(bits: Bits, offset: Int, bitCount: BitCount): Unit = this.assignFromBits(bits, offset + bitCount.value - 1, offset)
 
-  /** Clear all bits to ``False`` and return itself */
+  /** Hardware assignment of all bits to `False` and return itself */
   def clearAll(): this.type = {
     assignFromBits(Bits(asBits.getBitsWidth bits).clearAll())
     this
   }
 
-  /** Set all bits to ``True`` and return itself */
+  /** Hardware assignment of all bits to `True` and return itself */
   def setAll(): this.type = {
     assignFromBits(Bits(asBits.getBitsWidth bits).setAll())
     this
@@ -472,10 +472,14 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
     ret
   }
 
-  /** Assign the default 'x' value to all signals composing this type.
+  /** Explicitly mark that this hardware signal can take any value in the current context.
+    * 
+    * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * (e.g., no "don't care" or value) in any control path, an error will be raised.
     * 
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
-    * @see [[https://en.wikipedia.org/wiki/Don't-care_term#X_value "Don't care term" wikipedia article]]
+    * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
     */
   def assignDontCare(): this.type = {
     flatten.foreach(_.assignDontCare())

--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -173,14 +173,17 @@ class BaseTypePimper[T <: BaseType](val _data: T) {
 
 object Data {
 
-  /** Creates a signal path through the component hierarchy to finalComponent to read the srcData signal
+  /** Internal API method to creates a signal path through the component hierarchy
+    * to `finalComponent` to read the `srcData` signal.
     *
-    * @param srcData Data that you want to read
-    * @param finalComponent Location where you want to read the srcData signal
-    * @param useCache If multiple doPull are done on the same signal, allow to reuse the previously created paths
-    * @param propagateName The signals created through the hierarchy will get the same name as srcData
-    * @tparam T Type of the srcData
-    * @return Readable signal in the finalComponent which is driven by srcData
+    * @param srcData [[Data]] that you want to read
+    * @param finalComponent Location where you want to read the `srcData` signal
+    * @param useCache If multiple `doPull` are done on the same signal, allow to reuse the previously created paths
+    * @param propagateName The signals created through the hierarchy will get the same name as `srcData`
+    * @tparam T Type of `srcData`
+    * @return Readable signal in the `finalComponent` which is driven by `srcData`
+    * 
+    * @see [[pull()]]
     */
   def doPull[T <: Data](srcData: T, finalComponent: Component, useCache: Boolean = false, propagateName: Boolean = false): T = {
 
@@ -440,14 +443,34 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
   def flatten: Seq[BaseType]
   def flattenLocalName: Seq[String]
   def flattenForeach(body : BaseType => Unit) : Unit = flatten.foreach(body(_))
-  /** Pull a signal to the top level (use for debugging) */
+
+  /** Make a signal accessible to the current component level (to be used for debugging).
+    * 
+    * Because of [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/hierarchy_violation.html hierarchy violation checks]],
+    * accesses to signal that break hierarchical abstraction generate errors.
+    * This method allows to bypass this check. It should be used with care as
+    * it violates the hierarchy abstraction paradigm. This is useful for debugging
+    * or temporary fixes, for example.
+    */
   def pull(): this.type = Data.doPull(this, Component.current, useCache = true, propagateName = false)
+
+  /** Make a signal accessible to the current component level (to be used for debugging).
+    * 
+    * Because of [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Design%20errors/hierarchy_violation.html hierarchy violation checks]],
+    * accesses to signal that break hierarchical abstraction generate errors.
+    * This method allows to bypass this check. It should be used with care as
+    * it violates the hierarchy abstraction paradigm. This is useful for debugging
+    * or temporary fixes, for example.
+    * 
+    * @param propagateName If true, signals created through the hierarchy will get the same name as
+    *                      the pulled signal           
+    */
   def pull(propagateName : Boolean): this.type = Data.doPull(this, Component.current, useCache = true, propagateName = propagateName)
 
   /** Concatenation between two signals */
   def ##(right: Data): Bits = this.asBits ## right.asBits
 
-  /** Cast signal to Bits */
+  /** Cast signal to [[Bits]] */
   def asBits: Bits
 
   def assignFromBits(bits: Bits): Unit

--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -496,11 +496,16 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
   }
 
   /** Explicitly mark that this hardware signal can take any value in the current context.
-    * 
+    *
     * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
-    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned
     * (e.g., no "don't care" or value) in any control path, an error will be raised.
-    * 
+    *
+    * At generation, `'x` in Verilog and `'-'` in VHDL will be generated, unless
+    * SpinalConfig.dontCareGenAsZero is explicitly set as `true`. Note that some
+    * simulators like Verilator use only 0 and 1 for performance reason and will
+    * use random or fixed 0 and 1 values depending on their config.
+    *
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
     * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
     */

--- a/core/src/main/scala/spinal/core/Enum.scala
+++ b/core/src/main/scala/spinal/core/Enum.scala
@@ -246,11 +246,16 @@ class SpinalEnumCraft[T <: SpinalEnum](var spinalEnum: SpinalEnum) extends BaseT
   }
 
   /** Explicitly mark that this hardware signal can take any value in the current context.
-    * 
+    *
     * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
-    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned
     * (e.g., no "don't care" or value) in any control path, an error will be raised.
-    * 
+    *
+    * At generation, `'x` in Verilog and `'-'` in VHDL will be generated, unless
+    * SpinalConfig.dontCareGenAsZero is explicitly set as `true`. Note that some
+    * simulators like Verilator use only 0 and 1 for performance reason and will
+    * use random or fixed 0 and 1 values depending on their config.
+    *
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
     * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
     */

--- a/core/src/main/scala/spinal/core/Enum.scala
+++ b/core/src/main/scala/spinal/core/Enum.scala
@@ -245,6 +245,15 @@ class SpinalEnumCraft[T <: SpinalEnum](var spinalEnum: SpinalEnum) extends BaseT
     InputNormalize.enumImpl(this)
   }
 
+  /** Explicitly mark that this hardware signal can take any value in the current context.
+    * 
+    * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * (e.g., no "don't care" or value) in any control path, an error will be raised.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
+    * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
+    */
   override def assignDontCare(): this.type = {
     this.assignFrom(new EnumPoison(spinalEnum))
     this

--- a/core/src/main/scala/spinal/core/SInt.scala
+++ b/core/src/main/scala/spinal/core/SInt.scala
@@ -576,11 +576,22 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
 
   override def getZeroUnconstrained: this.type = S(0).asInstanceOf[this.type]
   override def getAllTrue: this.type = S(if(getWidth != 0) -1 else 0, this.getWidth bits).asInstanceOf[this.type]
+  
+  /** Hardware assignment of all bits to `True` */
   override def setAll(): this.type = {
     this := (if(getWidth != 0) -1 else 0)
     this
   }
 
+  /** Explicitly mark that this hardware signal can take any value in the current context.
+    * 
+    * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * (e.g., no "don't care" or value) in any control path, an error will be raised.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
+    * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
+    */
   override def assignDontCare(): this.type = {
     this.assignFrom(SIntLiteral(BigInt(0), (BigInt(1) << this.getWidth) - 1, widthOf(this)))
     this

--- a/core/src/main/scala/spinal/core/SInt.scala
+++ b/core/src/main/scala/spinal/core/SInt.scala
@@ -584,11 +584,16 @@ class SInt extends BitVector with Num[SInt] with MinMaxProvider with DataPrimiti
   }
 
   /** Explicitly mark that this hardware signal can take any value in the current context.
-    * 
+    *
     * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
-    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned
     * (e.g., no "don't care" or value) in any control path, an error will be raised.
-    * 
+    *
+    * At generation, `'x` in Verilog and `'-'` in VHDL will be generated, unless
+    * SpinalConfig.dontCareGenAsZero is explicitly set as `true`. Note that some
+    * simulators like Verilator use only 0 and 1 for performance reason and will
+    * use random or fixed 0 and 1 values depending on their config.
+    *
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
     * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
     */

--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -159,9 +159,12 @@ object blackboxByteEnables extends MemBlackboxingPolicy {
 }
 
 
-/**
-  * Spinal configuration for the generation of the RTL
-  *
+/** Spinal configuration for the generation of the RTL.
+  * 
+  * @param memBlackBoxers list of phases that decide to blackbox memories, see
+  *        [[addStandardMemBlackboxing()]] doc on how to modify the default
+  *        [[blackboxOnlyIfRequested]] policy.
+  * 
   * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Other%20language%20features/vhdl_generation.html#vhdl-and-verilog-generation VHDL and Verilog generation doc]]
   */
 case class SpinalConfig(mode                           : SpinalMode = null,
@@ -207,7 +210,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         var devicePhaseHandler         : PhaseDeviceHandler = PhaseDeviceDefault,
                         phasesInserters                : ArrayBuffer[(ArrayBuffer[Phase]) => Unit] = ArrayBuffer[(ArrayBuffer[Phase]) => Unit](),
                         transformationPhases           : ArrayBuffer[Phase] = ArrayBuffer[Phase](),
-                        memBlackBoxers                 : ArrayBuffer[Phase] = ArrayBuffer[Phase] (/*new PhaseMemBlackBoxerDefault(blackboxNothing)*/),
+                        memBlackBoxers                 : ArrayBuffer[Phase] = ArrayBuffer[Phase](),
                         rtlHeader                      : String = null,
                         scopeProperties                : mutable.LinkedHashMap[ScopeProperty[_], Any] = mutable.LinkedHashMap[ScopeProperty[_], Any](),
                         private [core] var _withEnumString : Boolean = true,
@@ -253,6 +256,19 @@ case class SpinalConfig(mode                           : SpinalMode = null,
 
   def withPrivateNamespace : this.type = { privateNamespace = true; this }
 
+  /** Append a phase to flag memories for blackboxing based on a blackboxing policy.
+    *
+    * During elaboration, a list of blackboxing detection phases are applied sequentially.
+    * Each one decides whether to blackbox each memory, and if blackboxed,
+    * removes it from the memories for the next blackboxing phases. The remaining
+    * memories are inferred.
+    * 
+    * If no blackbox phases are defined (either with `memBlackBoxers` of 
+    * [[SpinalConfig]] constructor or by calling this method), 
+    * [[blackboxOnlyIfRequested]] is used.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Sequential%20logic/memory.html#blackboxing-policy RAM/ROM Blackboxing policy documentation]]
+    */  
   def addStandardMemBlackboxing(policy: MemBlackboxingPolicy): this.type = {
     memBlackBoxers += new PhaseMemBlackBoxingDefault(policy)
     this
@@ -444,6 +460,7 @@ class SpinalReport[T <: Component]() {
 object Spinal {
   val version = (if(Character.isDigit(spinal.core.Info.version(0))) "v" else "") + spinal.core.Info.version
 
+  // Used internally both by simulation and generation to elaborate the RTL
   def apply[T <: Component](config: SpinalConfig)(gen: => T): SpinalReport[T] = {
 
     if(config.memBlackBoxers.isEmpty)

--- a/core/src/main/scala/spinal/core/UInt.scala
+++ b/core/src/main/scala/spinal/core/UInt.scala
@@ -487,11 +487,16 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
   }
 
   /** Explicitly mark that this hardware signal can take any value in the current context.
-    * 
+    *
     * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
-    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned
     * (e.g., no "don't care" or value) in any control path, an error will be raised.
-    * 
+    *
+    * At generation, `'x` in Verilog and `'-'` in VHDL will be generated, unless
+    * SpinalConfig.dontCareGenAsZero is explicitly set as `true`. Note that some
+    * simulators like Verilator use only 0 and 1 for performance reason and will
+    * use random or fixed 0 and 1 values depending on their config.
+    *
     * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
     * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
     */

--- a/core/src/main/scala/spinal/core/UInt.scala
+++ b/core/src/main/scala/spinal/core/UInt.scala
@@ -479,11 +479,22 @@ class UInt extends BitVector with Num[UInt] with MinMaxProvider with DataPrimiti
 
   override def getZeroUnconstrained: this.type = U(0).asInstanceOf[this.type]
   override def getAllTrue: this.type = U(maxValue, this.getWidth bits).asInstanceOf[this.type]
+  
+  /** Hardware assignment of all bits to `True` */
   override def setAll(): this.type = {
     this := maxValue
     this
   }
 
+  /** Explicitly mark that this hardware signal can take any value in the current context.
+    * 
+    * This is analogous to Verilog `'x`  or VHDL `'-'` assignment or implicit
+    * non-assignment, but  unlike those it is explicit. If a signal is unassigned 
+    * (e.g., no "don't care" or value) in any control path, an error will be raised.
+    * 
+    * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Data%20types/index.html#data-types Data type documentation]] 
+    * @see [[https://en.wikipedia.org/wiki/Don%27t-care_term#X_value "Don't care term" wikipedia article]]
+    */
   override def assignDontCare(): this.type = {
     this.assignFrom(UIntLiteral(BigInt(0), (BigInt(1) << this.getWidth) - 1, widthOf(this)))
     this

--- a/core/src/main/scala/spinal/core/Vec.scala
+++ b/core/src/main/scala/spinal/core/Vec.scala
@@ -46,11 +46,25 @@ trait VecFactory {
   def Vec[T <: Data](gen: HardType[T], size: Int): Vec[T] = Vec.fill(size)(gen())
   def Vec[T <: Data](firstElement: T, followingElements: T*): Vec[T] = Vec(List(firstElement) ++ followingElements)
 
-  class VecBuilder{
+  class VecBuilder {
+
+   /** Produces a Vec containing the `Data` of a given function over a range of integer values starting from 0.
+    *  @param  n   The number of elements in the `Vec`
+    *  @param  f   The function instantiating element values
+    *  @return A `Vec` consisting of elements `f(0), ..., f(n -1)`
+    */    
     def tabulate[T <: Data](size: Int)(gen: (Int) => T): Vec[T] = {
       Vec((0 until size).map(gen(_))).setElementsParents()
     }
 
+
+   /** Produces a Vec of Vec containing the `Data` of a given function over ranges of integer values starting from 0.
+    *  @param   n1  the number of elements in the 1st dimension
+    *  @param   n2  the number of elements in the 2nd dimension
+    *  @param   f   The function instantiating element values
+    *  @return A Vec of Vec consisting of elements `f(i1, i2)`
+    *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
+    */
     def tabulate[T <: Data](n1: Int, n2: Int)(f: (Int, Int) => T): Vec[Vec[T]] =
       tabulate(n1)(i => tabulate(n2)(f(i, _)))
 

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -705,7 +705,19 @@ case class SpinalSimConfig(
   ){
 
 
-  def  withVerilator : this.type = {
+  /** Use C++ compiled Verilator simulation engine
+    * 
+    * The `'x'` and `'z'` unknown state behavior is configured to have maximal
+    * randomization. 
+    * 
+    * More specifically, the it is equivalent to using [[https://verilator.org/guide/latest/exe_verilator.html#cmdoption-x-assign --x-assign unique]]
+    * at compilation and [[https://verilator.org/guide/latest/exe_sim.html#cmdoption-arg-verilator-rand-reset-value +verilator+rand+reset+2]]
+    * [[https://verilator.org/guide/latest/exe_sim.html#cmdoption-arg-verilator-seed-value +verilator+seed+value]]
+    * invocation with `value` being the `seed` of [[SimConfig.doSim()]].
+    * 
+    * @see [[https://verilator.org/guide/latest/languages.html#unknown-states Verilator unknown states handling]]
+    */
+  def withVerilator : this.type = {
     _backend = SpinalSimBackendSel.VERILATOR
     this
   }

--- a/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
+++ b/core/src/main/scala/spinal/core/sim/SimBootstraps.scala
@@ -705,16 +705,16 @@ case class SpinalSimConfig(
   ){
 
 
-  /** Use C++ compiled Verilator simulation engine
-    * 
+  /** Use C++ compiled Verilator simulation engine.
+    *
     * The `'x'` and `'z'` unknown state behavior is configured to have maximal
     * randomization. 
-    * 
+    *
     * More specifically, the it is equivalent to using [[https://verilator.org/guide/latest/exe_verilator.html#cmdoption-x-assign --x-assign unique]]
     * at compilation and [[https://verilator.org/guide/latest/exe_sim.html#cmdoption-arg-verilator-rand-reset-value +verilator+rand+reset+2]]
     * [[https://verilator.org/guide/latest/exe_sim.html#cmdoption-arg-verilator-seed-value +verilator+seed+value]]
     * invocation with `value` being the `seed` of [[SimConfig.doSim()]].
-    * 
+    *
     * @see [[https://verilator.org/guide/latest/languages.html#unknown-states Verilator unknown states handling]]
     */
   def withVerilator : this.type = {

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -1025,13 +1025,22 @@ package object sim {
       }
     }
 
+    /** Wait one rising edge on the clock
+      * 
+      * Note that the function is not sensitive to reset/softReset/clockEnable.
+      */
     def waitRisingEdge(): Unit = waitRisingEdge(1)
+
+    /** Wait `count` rising edges on the clock
+      * 
+      * Note that count = 0 is legal, and the function is not sensitive to reset/softReset/clockEnable.
+      */
     def waitRisingEdge(count: Int): Unit ={
       val manager = SimManagerContext.current.manager
       val signal = getSignal(manager, cd.clock)
       var last = manager.getLong(signal)
       var counter = 0
-      waitUntil{
+      waitUntil {
         val current = manager.getLong(signal)
         if(last == 0l && current == 1l)
           counter += 1
@@ -1045,7 +1054,7 @@ package object sim {
       val signal  = getSignal(manager, cd.clock)
       var last    = manager.getLong(signal)
 
-      waitUntil{
+      waitUntil {
         val current = manager.getLong(signal)
         val cond = last == 0l && current == 1l && condAnd
         last = current
@@ -1053,14 +1062,23 @@ package object sim {
       }
     }
 
+    /** Wait one falling edge on the clock
+      * 
+      * Note that the function is not sensitive to reset/softReset/clockEnable.
+      */
     def waitFallingEdge(): Unit = waitFallingEdge(1)
+
+    /** Wait `count` falling edges on the clock
+      * 
+      * Note that count = 0 is legal, and the function is not sensitive to reset/softReset/clockEnable.
+      */
     def waitFallingEdge(count: Int = 1): Unit = {
       val manager = SimManagerContext.current.manager
       val signal  = getSignal(manager, cd.clock)
       var last    = manager.getLong(signal)
       var counter = 0
 
-      waitUntil{
+      waitUntil {
         val current = manager.getLong(signal)
         if(last == 1l && current == 0l)
           counter += 1
@@ -1074,7 +1092,7 @@ package object sim {
       val signal  = getSignal(manager, cd.clock)
       var last    = manager.getLong(signal)
 
-      waitUntil{
+      waitUntil {
         val current = manager.getLong(signal)
         val cond = last == 1l && current == 0l && condAnd
         last = current
@@ -1082,7 +1100,16 @@ package object sim {
       }
     }
 
+    /** Wait one edge on the clock specified by the ClockDomainConfig
+      * 
+      * Note that the function is not sensitive to reset/softReset/clockEnable.
+      */
     def waitActiveEdge(): Unit = waitActiveEdge(1)
+
+    /** Wait `count` edges on the clock specified by the ClockDomainConfig
+      * 
+      * Note that count = 0 is legal, and the function is not sensitive to reset/softReset/clockEnable.
+      */    
     def waitActiveEdge(count: Int = 1): Unit = {
       if (cd.config.clockEdge == spinal.core.RISING) {
         waitRisingEdge(count)
@@ -1159,6 +1186,12 @@ package object sim {
       }
     }
 
+    /* Fork a simulation process to generate the `ClockDomain` stimulus (clock, reset, softReset, clockEnable signals)
+     * 
+     * The reset duration is 16 clock periods. The period is computed from
+     * `ClockDomain.frequency`. An odd period will be truncated by one to have
+     * a symmetrical clock.
+     */
     def forkStimulus() : Unit = {
       val hz = cd.frequency match {
         case ClockDomain.FixedFrequency(value) => value.toBigDecimal
@@ -1177,58 +1210,77 @@ package object sim {
       if(cd.hasSoftResetSignalSim) cd.deassertSoftReset()
       if(cd.hasClockEnableSignalSim) cd.deassertClockEnable()
       fork(doStimulus(period, resetCycles))
-      if(sleepDuration >= 0) sleep(sleepDuration) //This allows the doStimulus to give initial value to clock/reset before going further
+      if(sleepDuration >= 0) sleep(sleepDuration) // This allows the doStimulus to give initial value to clock/reset before going further
     }
 
+    /* Fork a simulation process to generate the `ClockDomain` stimulus (clock, reset, softReset, clockEnable signals).
+     * 
+     * The reset duration is 16 clock periods. The period is given as a number 
+     * of simulation time units. An odd period will be truncated by one to have
+     * a symmetrical clock.
+     */
     def forkStimulus(period: TimeNumber): Unit = {
       forkStimulus(timeToLong(period))
     }
 
+    /* Fork a simulation process to generate the `ClockDomain` stimulus (clock, reset, softReset, clockEnable signals).
+     * 
+     * The reset duration is 16 clock periods. The period is computed from `frequency.toTime`.
+     * An odd period will be truncated by one to have a symmetrical clock.
+     */
     def forkStimulus(frequency: HertzNumber): Unit = forkStimulus(frequency.toTime)
 
+    /* Fork a simulation process which will periodically print the simulation speed in kilo-cycles per real time second
+     * `printPeriod`` is in realtime seconds.
+     */
     def forkSimSpeedPrinter(printPeriod: Double = 1.0) : Unit = SimSpeedPrinter(cd, printPeriod)
 
-    def onRisingEdges(block : => Unit): Unit ={
+    /** During simulation, execute the callback when the clock generates a edge */
+    def onRisingEdges(block : => Unit): Unit = {
       val manager = SimManagerContext.current.manager
       val signal = getSignal(manager, cd.clock)
       var last = manager.getInt(signal)
-      forkSensitive{
+      forkSensitive {
         val current = manager.getInt(signal)
         if(last == 0 && current == 1) block
         last = current
       }
     }
 
-    def onFallingEdges(block : => Unit): Unit ={
+    /** During simulation, execute the callback when the clock generates a falling edge */
+    def onFallingEdges(block : => Unit): Unit = {
       val manager = SimManagerContext.current.manager
       val signal = getSignal(manager, cd.clock)
       var last = manager.getInt(signal)
-      forkSensitive{
+      forkSensitive {
         val current = manager.getInt(signal)
         if(last == 1 && current == 0) block
         last = current
       }
     }
 
+    /** During simulation, execute the callback when the clock generates its configured edge */
     def onActiveEdges(block : => Unit): Unit = {
       if (cd.config.clockEdge == spinal.core.RISING) {
         onRisingEdges(block)
-      }else{
+      }else {
         onFallingEdges(block)
       }
     }
 
+    /** During simulation, execute the callback when the clock generates a rising or falling edge */
     def onEdges(block : => Unit): Unit ={
       val manager = SimManagerContext.current.manager
       val signal = getSignal(manager, cd.clock)
       var last = manager.getInt(signal)
-      forkSensitive{
+      forkSensitive {
         val current = manager.getInt(signal)
         if(last != current) block
         last = current
       }
     }
 
+    /** During simulation, execute the callback each time the ClockDomain sample (active edge + reset off + clock enable on) */
     def onSamplings(body: => Unit): Unit = {
       val key = (SimStatics.onSamplings, cd)
       val context = SimManagerContext.current
@@ -1249,6 +1301,7 @@ package object sim {
       context.get[ArrayBuffer[() => Unit]](key) += (() => body)
     }
 
+    /** During simulation, execute the callback only once on the next ClockDomain sample (active edge + reset off + clock enable on) */
     def onNextSampling(body: => Unit): Unit = {
       val edgeValue = if(cd.config.clockEdge == spinal.core.RISING) 1 else 0
       val manager = SimManagerContext.current.manager
@@ -1267,6 +1320,10 @@ package object sim {
       }
     }
 
+    /** During simulation, execute the callback each time the ClockDomain sample (active edge + reset off + clock enable on) and you
+      * you can stop it (forever) by letting the callback returning false.
+      * @see onSampling()
+      */
     def onSamplingWhile(body : => Boolean) : Unit = {
       val context = SimManagerContext.current
       val edgeValue = if (cd.config.clockEdge == spinal.core.RISING) 1 else 0

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -46,12 +46,12 @@ package object sim {
     field.set(r, null)
   }
 
-  /** Return the scala.util.Random for the current simulation
-    * 
-    * If only thread-less simulation API is used (`clockDomain.waitActiveEdge()`, 
+  /** Return the scala.util.Random for the current simulation.
+    *
+    * If only thread-less simulation API is used (`clockDomain.waitActiveEdge()`,
     * `cd.onActiveEdges{}`, `delayed(delay){}`, `forkSensitive{}`, etc.), the number returned
     * should be deterministic, even with multiple concurrent simulations.
-    * 
+    *
     * The seed is set as an argument of `doSim()`. The default value is to take
     * `.toInt` from the `SPINAL_SIM_SEED` environment variable, and if not
     * present to use a random value as seed each time.
@@ -1036,13 +1036,13 @@ package object sim {
       }
     }
 
-    /** Wait one rising edge on the clock
+    /** Wait one rising edge on the clock.
       * 
       * Note that the function is not sensitive to reset/softReset/clockEnable.
       */
     def waitRisingEdge(): Unit = waitRisingEdge(1)
 
-    /** Wait `count` rising edges on the clock
+    /** Wait `count` rising edges on the clock.
       * 
       * Note that count = 0 is legal, and the function is not sensitive to reset/softReset/clockEnable.
       */
@@ -1073,14 +1073,14 @@ package object sim {
       }
     }
 
-    /** Wait one falling edge on the clock
-      * 
+    /** Wait one falling edge on the clock.
+      *
       * Note that the function is not sensitive to reset/softReset/clockEnable.
       */
     def waitFallingEdge(): Unit = waitFallingEdge(1)
 
-    /** Wait `count` falling edges on the clock
-      * 
+    /** Wait `count` falling edges on the clock.
+      *
       * Note that count = 0 is legal, and the function is not sensitive to reset/softReset/clockEnable.
       */
     def waitFallingEdge(count: Int = 1): Unit = {
@@ -1111,16 +1111,16 @@ package object sim {
       }
     }
 
-    /** Wait one edge on the clock specified by the ClockDomainConfig
-      * 
+    /** Wait one edge on the clock specified by the ClockDomainConfig.
+      *
       * Note that the function is not sensitive to reset/softReset/clockEnable.
       */
     def waitActiveEdge(): Unit = waitActiveEdge(1)
 
-    /** Wait `count` edges on the clock specified by the ClockDomainConfig
-      * 
+    /** Wait `count` edges on the clock specified by the ClockDomainConfig.
+      *
       * Note that count = 0 is legal, and the function is not sensitive to reset/softReset/clockEnable.
-      */    
+      */
     def waitActiveEdge(count: Int = 1): Unit = {
       if (cd.config.clockEdge == spinal.core.RISING) {
         waitRisingEdge(count)
@@ -1197,7 +1197,7 @@ package object sim {
       }
     }
 
-    /* Fork a simulation process to generate the `ClockDomain` stimulus (clock, reset, softReset, clockEnable signals)
+    /* Fork a simulation process to generate the `ClockDomain` stimulus (clock, reset, softReset, clockEnable signals).
      * 
      * The reset duration is 16 clock periods. The period is computed from
      * `ClockDomain.frequency`. An odd period will be truncated by one to have

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -46,7 +46,7 @@ package object sim {
     field.set(r, null)
   }
 
-  /** Return the scala.util.Random for the current simulation.
+  /** Return a dedicated instance scala.util.Random for the current simulation.
     *
     * If only thread-less simulation API is used (`clockDomain.waitActiveEdge()`,
     * `cd.onActiveEdges{}`, `delayed(delay){}`, `forkSensitive{}`, etc.), the number returned

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -45,6 +45,17 @@ package object sim {
     field.setAccessible(true)
     field.set(r, null)
   }
+
+  /** Return the scala.util.Random for the current simulation
+    * 
+    * If only thread-less simulation API is used (`clockDomain.waitActiveEdge()`, 
+    * `cd.onActiveEdges{}`, `delayed(delay){}`, `forkSensitive{}`, etc.), the number returned
+    * should be deterministic, even with multiple concurrent simulations.
+    * 
+    * The seed is set as an argument of `doSim()`. The default value is to take
+    * `.toInt` from the `SPINAL_SIM_SEED` environment variable, and if not
+    * present to use a random value as seed each time.
+    */
   def simRandom(implicit simManager: SimManager = sm) = simManager.random
   def sm = SimManagerContext.current.manager
 

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -46,15 +46,23 @@ package object sim {
     field.set(r, null)
   }
 
-  /** Return a dedicated instance scala.util.Random for the current simulation.
+  /** Returns a dedicated instance of scala.util.Random for the current simulation.
     *
-    * If only thread-less simulation API is used (`clockDomain.waitActiveEdge()`,
-    * `cd.onActiveEdges{}`, `delayed(delay){}`, `forkSensitive{}`, etc.), the number returned
-    * should be deterministic, even with multiple concurrent simulations.
+    * There is one instance per simulation and its usage is deterministic with any 
+    * combination of sensitive, thread-full and thread-less API. 
+    * 
+    * This is because the simulation engine executes only one sim thread created
+    * by functions like [[sim.fork()]] at a time. The engine blocks/resumes them
+    * so there is never concurrent execution of test code.
+    * 
+    * Each simulation maintains its own `Random`, making it safe for concurrent
+    * simulations.
     *
     * The seed is set as an argument of `doSim()`. The default value is to take
     * `.toInt` from the `SPINAL_SIM_SEED` environment variable, and if not
     * present to use a random value as seed each time.
+    * 
+    * @see https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Simulation/engine.html
     */
   def simRandom(implicit simManager: SimManager = sm) = simManager.random
   def sm = SimManagerContext.current.manager

--- a/lib/src/main/scala/spinal/lib/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/Stream.scala
@@ -446,7 +446,7 @@ class Stream[T <: Data](val payloadType :  HardType[T]) extends Bundle with IMas
     * The cost is `(payload width + 1)` flip-flops and the latency is 1.
     * 
     * The name "m2s" comes from from the fact that the signals that flow
-    * from Master-to-Slave are pipelined  (namely `ready` and `payload`).
+    * from Master-to-Slave are pipelined  (namely `valid` and `payload`).
     * 
     * @param collapsBubble When `true`(the default), add the logic to allow to store an incoming payload when there is 
     *                      no stored payload and the slave is not ready.

--- a/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
+++ b/lib/src/main/scala/spinal/lib/bus/misc/BusSlaveFactory.scala
@@ -42,8 +42,9 @@ case class BusSlaveFactoryConfig(wordEndianness: Endianness = LITTLE){
 }
 
 
-/**
-  * Bus slave factory is a tool that provide an abstract and smooth way to define register bank
+/** Bus slave factory is a tool that provide an abstract and smooth way to define register bank
+  *
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/bus_slave_factory.html Bus Slave Factory documentation]] 
   */
 trait BusSlaveFactory extends Area{
 
@@ -58,10 +59,10 @@ trait BusSlaveFactory extends Area{
   /** Return the data width of the bus */
   def busDataWidth: Int
 
-  /** Address incrementation used by the read and write multi words registers */
+  /** Address increment used by the read and write multi words registers */
   def wordAddressInc: Int = busDataWidth / 8
 
-  /** Set the endianness during write/read multiword */
+  /** Set the endianness during write/read multi-word */
   def setWordEndianness(value : Endianness) = setConfig(getConfig.copy(wordEndianness = value))
 
   def withOffset(offset : BigInt) = new BusSlaveFactoryAddressWrapper(this, offset)

--- a/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
+++ b/lib/src/main/scala/spinal/lib/com/uart/UartCtrl.scala
@@ -46,7 +46,16 @@ class UartCtrlIo(g : UartCtrlGenerics) extends Bundle {
   val readBreak = out Bool()
 }
 
-
+/** An UART controller with control through registers
+  * 
+  * `this.io` of type [[UartCtrlIo]] gives access to signals to control the UART.
+  * 
+  * See `Tilelink/Apb3/Wishbone/AvalonMM/Bmb/UartCtrl` that implement memory mapping
+  * for various buses.
+  * 
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Examples/Intermediates%20ones/uart.html spinal doc using it as example]]
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Examples/Advanced%20ones/memory_mapped_uart.html APB3 memory mapping example]]
+  */
 class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
   val io = new UartCtrlIo(g)
   val tx = new UartCtrlTx(g)

--- a/lib/src/main/scala/spinal/lib/sim/Stream.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Stream.scala
@@ -57,7 +57,25 @@ class StreamMonitor[T <: Data](stream : Stream[T], clockDomain: ClockDomain){
   }
 }
 
-object StreamDriver{
+object StreamDriver {
+  
+/** Drive a [[Stream]] with a callback, by default randomly.
+  * 
+  * Call the lambda when new data should be presented to the [[Stream]], the
+  * return value indicating if the data is valid. For example:
+  * 
+  * {{{
+  * val payloads = Queue(0xff, 0xab, 0x11)
+  * StreamDriver(dut.io.push, dut.clockDomain) { payload =>
+  *   if (payloads.nonEmpty) { payload.address #= payloads.dequeue(); true }
+  *   else false
+  * }
+  * }}}
+  * 
+  * See [[setFactor]] for the random behavior and how to change it.
+  * 
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/stream.html#simulation-support  Simulation support documentation]]
+  */
   def apply[T <: Data](stream : Stream[T], clockDomain: ClockDomain)(driver : (T) => Boolean) = new StreamDriver(stream,clockDomain,driver)
 //  def apply[T <: Data](stream : Stream[T], clockDomain: ClockDomain)(driver : (T) => Unit) = new StreamDriver(stream,clockDomain,(x) => {driver(x); true})
 
@@ -72,6 +90,10 @@ object StreamDriver{
     (driver, cmdQueue)
   }
 
+  /** Create StreamDriver that iterate over the [[Iterable]] `els`.
+   * 
+   *  The type `E` of `els` should be `#=` assignable to `payload`
+   */
   def fromIterable[T <: Data, E](flow: Stream[T], clockDomain: ClockDomain, els: Iterable[E])
     (implicit ev: T => SimEquiv { type SimEquivT = E }): StreamDriver[T] = {
     val iter = els.iterator
@@ -86,7 +108,25 @@ object StreamDriver{
   }
 }
 
-class StreamDriver[T <: Data](stream : Stream[T], clockDomain: ClockDomain, var driver : (T) => Boolean){
+
+/** Drive a [[Stream]] with a callback, by default randomly.
+  * 
+  * Call the lambda when new data should be presented to the [[Stream]], the
+  * return value indicating if the data is valid. For example:
+  * 
+  * {{{
+  * val payloads = Queue(0xff, 0xab, 0x11)
+  * StreamDriver(dut.io.push, dut.clockDomain) { payload =>
+  *   if (payloads.nonEmpty) { payload.address #= payloads.dequeue(); true }
+  *   else false
+  * }
+  * }}}
+  * 
+  * See [[setFactor]] for the random behavior and how to change it.
+  * 
+  * @see [[https://spinalhdl.github.io/SpinalDoc-RTD/master/SpinalHDL/Libraries/stream.html#simulation-support  Simulation support documentation]]
+  */
+class StreamDriver[T <: Data](stream : Stream[T], clockDomain: ClockDomain, var driver : (T) => Boolean) {
   implicit val _ = sm
   var transactionDelay : () => Int = () => {
     val x = simRandom.nextDouble()
@@ -94,7 +134,23 @@ class StreamDriver[T <: Data](stream : Stream[T], clockDomain: ClockDomain, var 
   }
 
   var factor = Option.empty[Float]
+
+  /** Set a fixed probability of executing the driver callback.
+    * 
+    * If not set, there is a new delay of `(x*x*10).toInt` clock cycles 
+    * (with `x = simRandom.nextDouble()`) between each callback. When set, 
+    * the callback is executed clock where `simRandom.nextFloat() < value`.
+    * This means that the callback is always executed with `value >= 1.0f`
+    * and never with `<= 0.0f`.
+    */
   def setFactor(value : Float) = factor = Some(value)
+
+  /** Set a periodic simulation step change of setFactor.
+    * 
+    * Each `period` simulation steps, execute `setFactor(simRandom.nextFloat())`,
+    * i.e. a new uniform probability that the driver callback is executed each
+    * clock sample.
+    */
   def setFactorPeriodically(period : Long) = periodically(period)(setFactor(simRandom.nextFloat()))
 
   //The  following commented threaded code is the equivalent to the following uncommented thread-less code (nearly)

--- a/tester/src/test/scala/spinal/lib/bus/tilelink/RamTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/tilelink/RamTester.scala
@@ -18,7 +18,7 @@ import spinal.sim.SimThread
 
 import scala.collection.mutable.ArrayBuffer
 
-class RamTester extends AnyFunSuite{
+class RamTester extends AnyFunSuite {
   def doTest(): Unit = {
     val tester = new TilelinkTester(
       simConfig = SimConfig,
@@ -41,9 +41,9 @@ class RamTester extends AnyFunSuite{
           )
         )
 
-        // Note that the testbench automaticaly use val ordering = Flow(OrderingCmd(p.sizeBytes))
-        // from the spinal.lib.bus.tilelink.Ram component to figure out the global memory ordering
-        // If you want to test your memory component, you also need to implement that val ordering thing
+        // Note that the testbench automatically use val ordering = Flow(OrderingCmd(p.sizeBytes))
+        // from the spinal.lib.bus.tilelink.Ram component to figure out the global memory ordering.
+        // If you want to test your memory component, you also need to implement that val ordering thing.
         val ram = new RamFiber(4096)
         ram.up at 0x0 of m0.node
         ram.up.setUpConnection(a = StreamPipe.FULL)
@@ -69,7 +69,7 @@ class RamTester extends AnyFunSuite{
     )
 
     tester.doSim("manual") { tb =>
-      periodicaly(1000) {
+      periodically(1000) {
         tb.mastersStuff.foreach(_.agent.driver.driver.randomizeStallRate())
         tb.slavesStuff.foreach(_.model.driver.driver.randomizeStallRate())
       }
@@ -89,10 +89,8 @@ class RamTester extends AnyFunSuite{
     tester.checkErrors()
   }
 
-
   test("default"){
     doTest()
   }
-
 
 }


### PR DESCRIPTION
This PR add scaladoc to various advanced features of SpinalHDL.

The goal is to first write in-depth doc of individual method behaviors and then, based on these precise descriptions, add more accessible documentation in [SpinalDoc-RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/). As the code is the "single source of truth" and contributors and advanced users navigate the lib much more that they look at SpinalDoc, I think it make more sense.

It is based on SpinalDoc-RTD, my experience of the behavior when using SpinalHDL, currently mainly with verilator and yosys+nextpnr. I also did some analysis of the code with and without LLM (mistral). I entirely wrote the text myself though.

It would be great if people with more experience could review it before merging, for example:

-  @briansune for verilator stuff in b831140
-  @Dolu1990 for data model stuff in 97987c6951, a15cf16516026 and 4b0203258
-  @inochisa for StreamDriver behavior in 3dacc00930