### PR TITLE
Fix wrong IMSIC guest file check in mapping calibrate

### DIFF
--- a/lib/src/main/scala/spinal/lib/misc/aia/ImsicTrigger.scala
+++ b/lib/src/main/scala/spinal/lib/misc/aia/ImsicTrigger.scala
@@ -111,7 +111,7 @@ object ImsicTrigger {
     require(interruptFileGroupSize == 0 || isPow2(interruptFileGroupSize), "interruptFileGroupSize should be power of 2")
     require(!(interruptFileHartOffset != 0 && interruptFileGroupSize == 0), "Can not auto calculate interruptFileGroupSize when interruptFileHartOffset != 0")
 
-    require(maxGuestId < 63, "Per hart can only have max 63 guest interrupt files.")
+    require(maxGuestId <= 63, "Per hart can only have max 63 guest interrupt files.")
 
     val intFileNumber = 1 << log2Up(maxGuestId + 1)
     val minIntFileHartSize = interruptFileSize * intFileNumber


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

Fix IMSIC guest file check in the ImsicTrigger.mappingCalibrate

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

No impact
<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
