### PR TITLE
axis: support independently sized TUSER fields

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4Stream.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4Stream.scala
@@ -8,13 +8,14 @@ import spinal.lib._
  * @param dataWidth Width of the bus in BYTES
  * @param idWidth Width of the ID field in bits
  * @param destWidth Width of the Destination field in bits
- * @param userWidth Width of the User field in bits
+ * @param userWidth Width of the User field in bits per byte lane
  * @param useStrb Use byte strobe bits
  * @param useKeep Use byte keep bits
  * @param useLast Use last bit
  * @param useId Use ID field, must specify idWidth
  * @param useDest Use Destination field, must specify destWidth
- * @param useUser Use User field, must specify userWidth
+ * @param useUser Use User field, must specify userWidth or beatUserWidth
+ * @param beatUserWidth Total width of the User field in bits for each beat, independent of the number of byte lanes
  */
 case class Axi4StreamConfig(dataWidth: Int,
                             idWidth:   Int = -1,
@@ -25,7 +26,16 @@ case class Axi4StreamConfig(dataWidth: Int,
                             useLast:   Boolean = false,
                             useId:     Boolean = false,
                             useDest:   Boolean = false,
-                            useUser:   Boolean = false)
+                            useUser:   Boolean = false,
+                            beatUserWidth: Int = -1) {
+  require(beatUserWidth == -1 || beatUserWidth > 0,
+    "Axi4Stream beatUserWidth must be -1 (unused) or positive")
+  require(userWidth <= 0 || beatUserWidth <= 0,
+    "Axi4Stream userWidth (bits per byte lane) and beatUserWidth (total bits per beat) are mutually exclusive")
+
+  def isUserPerByte: Boolean = beatUserWidth <= 0
+  def userBitsWidth: Int = if (isUserPerByte) userWidth * dataWidth else beatUserWidth
+}
 
 object Axi4Stream {
 
@@ -36,7 +46,7 @@ object Axi4Stream {
     val keep = (config.useKeep) generate Bits(config.dataWidth bit)
     val last = (config.useLast) generate Bool()
     val dest = (config.useDest) generate UInt(config.destWidth bit)
-    val user = (config.useUser) generate Bits(config.userWidth*config.dataWidth bit)
+    val user = (config.useUser) generate Bits(config.userBitsWidth bit)
 
     def isLast = if (this.last != null) this.last else False
 
@@ -50,8 +60,14 @@ object Axi4Stream {
             assert(that.config.idWidth <= this.config.idWidth, s"Axi4Stream $that directly drives stream $this with smaller ID width! (${that.config.idWidth} > ${this.config.idWidth})")
           if (that.config.useDest)
             assert(that.config.destWidth <= this.config.destWidth, s"Axi4Stream $that directly drives stream $this with smaller destination width! (${that.config.destWidth} > ${this.config.destWidth})")
-          if (that.config.useUser)
-            assert(that.config.userWidth <= this.config.userWidth, s"Axi4Stream $that directly drives stream $this with smaller user width! (${that.config.userWidth} > ${this.config.userWidth})")
+          if (that.config.useUser && this.config.useUser) {
+            assert(that.config.isUserPerByte == this.config.isUserPerByte,
+              s"Axi4Stream $that can't directly drive stream $this with a different TUSER association")
+            if (that.config.isUserPerByte)
+              assert(that.config.userWidth <= this.config.userWidth, s"Axi4Stream $that directly drives stream $this with smaller user width! (${that.config.userWidth} > ${this.config.userWidth})")
+            else
+              assert(that.config.userBitsWidth <= this.config.userBitsWidth, s"Axi4Stream $that directly drives stream $this with smaller user width! (${that.config.userBitsWidth} > ${this.config.userBitsWidth})")
+          }
 
           this.data := that.data.resized
           Axi4StreamBundlePriv.driveWeak(that,this,that.id,this.id, () => U(this.id.bitsRange -> false), allowResize = true, allowDrop = false)
@@ -65,16 +81,20 @@ object Axi4Stream {
             case (true, false) => B(this.user.bitsRange -> false)
             case (false, true) => LocatedPendingError(s"${that.user} can't drive $this because the corresponding sink signal does not exist")
             case (true, true) => {
-              val sourceSlices = that.user.subdivideIn(that.config.dataWidth slices)
-              val sinkSlices = this.user.subdivideIn(this.config.dataWidth slices)
-              val sourceSlicesPad = sourceSlices.padTo(sinkSlices.length, null)
-              sourceSlicesPad.zip(sinkSlices).foreach(pair => {
-                val (sourceSlice, sinkSlice) = pair
-                if (sourceSlice != null) {
-                  sinkSlice := sourceSlice.resized
-                } else
-                  sinkSlice := B(sinkSlice.bitsRange -> false)
-              })
+              if (that.config.isUserPerByte) {
+                val sourceSlices = that.user.subdivideIn(that.config.dataWidth slices)
+                val sinkSlices = this.user.subdivideIn(this.config.dataWidth slices)
+                val sourceSlicesPad = sourceSlices.padTo(sinkSlices.length, null)
+                sourceSlicesPad.zip(sinkSlices).foreach(pair => {
+                  val (sourceSlice, sinkSlice) = pair
+                  if (sourceSlice != null) {
+                    sinkSlice := sourceSlice.resized
+                  } else
+                    sinkSlice := B(sinkSlice.bitsRange -> false)
+                })
+              } else {
+                this.user := that.user.resized
+              }
             }
           }
         }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamSimpleWidthAdapter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamSimpleWidthAdapter.scala
@@ -40,7 +40,10 @@ class Axi4StreamSimpleWidthAdapter(inConfig: Axi4StreamConfig, outWidth: Int) ex
     io.axis_m.data := (B((0 until padBytes*8) -> False) ## io.axis_s.data)(counter*outWidth*8, outWidth*8 bit)
     inConfig.useKeep generate { io.axis_m.keep := (B((0 until padBytes) -> False) ## io.axis_s.keep)(counter*outWidth, outWidth bit) }
     inConfig.useStrb generate { io.axis_m.strb := (B((0 until padBytes) -> False) ## io.axis_s.strb)(counter*outWidth, outWidth bit) }
-    inConfig.useUser generate { io.axis_m.user := (B((0 until padBytes*inConfig.userWidth) -> False) ## io.axis_s.user)(counter*outWidth*inConfig.userWidth, outWidth*inConfig.userWidth bit) }
+    (inConfig.useUser && inConfig.isUserPerByte) generate {
+      io.axis_m.user := (B((0 until padBytes*inConfig.userWidth) -> False) ## io.axis_s.user)(counter*outWidth*inConfig.userWidth, outWidth*inConfig.userWidth bit)
+    }
+    (inConfig.useUser && !inConfig.isUserPerByte) generate { io.axis_m.user := io.axis_s.user }
     inConfig.useDest generate { io.axis_m.dest := io.axis_s.dest }
     inConfig.useId   generate { io.axis_m.id := io.axis_s.id }
     inConfig.useLast generate { io.axis_m.last := io.axis_s.last && counter.willOverflowIfInc }
@@ -76,7 +79,14 @@ class Axi4StreamSimpleWidthAdapter(inConfig: Axi4StreamConfig, outWidth: Int) ex
         buffer.data(counter*inWidth*8, inWidth*8 bit) := io.axis_s.data
         inConfig.useKeep generate { buffer.keep(counter*inWidth, inWidth bit) := io.axis_s.keep }
         inConfig.useStrb generate { buffer.strb(counter*inWidth, inWidth bit) := io.axis_s.strb }
-        inConfig.useUser generate { buffer.user(counter*inWidth*inConfig.userWidth, inWidth*inConfig.userWidth bit) := io.axis_s.user }
+        (inConfig.useUser && inConfig.isUserPerByte) generate {
+          buffer.user(counter*inWidth*inConfig.userWidth, inWidth*inConfig.userWidth bit) := io.axis_s.user
+        }
+        (inConfig.useUser && !inConfig.isUserPerByte) generate {
+          when(start) {
+            buffer.user := io.axis_s.user
+          }
+        }
       }
 
       inConfig.useLast generate {

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamSparseCompactor.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamSparseCompactor.scala
@@ -23,7 +23,7 @@ class Axi4StreamSparseCompactor(config: Axi4StreamConfig) extends Component {
   val invalidByte_data = B(0, 8 bit)
   val invalidByte_keep = False
   val invalidByte_strb = config.useStrb generate False
-  val invalidByte_user = config.useUser generate B(0, config.userWidth bit)
+  val invalidByte_user = (config.useUser && config.isUserPerByte) generate B(0, config.userWidth bit)
 
   val outStage = inStage.map(compactAxisBundle(_)).pipelined(m2s = true, s2m = true, halfRate = false)
 
@@ -86,13 +86,15 @@ class Axi4StreamSparseCompactor(config: Axi4StreamConfig) extends Component {
       val mux_data = invalidByte_data ## bundle.data
       val mux_keep = invalidByte_keep ## bundle.keep
       val mux_strb = bundle.config.useStrb generate { invalidByte_strb ## bundle.strb }
-      val mux_user = bundle.config.useUser generate { invalidByte_user ## bundle.user }
+      val mux_user = (bundle.config.useUser && bundle.config.isUserPerByte) generate { invalidByte_user ## bundle.user }
 
       outBundle.data.subdivideIn(dataWidth slices)(idx) := mux_data.subdivideIn(dataWidth+1 slices)(index)
       outBundle.keep.subdivideIn(dataWidth slices)(idx) := mux_keep.subdivideIn(dataWidth+1 slices)(index)
       bundle.config.useStrb generate { outBundle.strb.subdivideIn(dataWidth slices)(idx) := mux_strb.subdivideIn(dataWidth+1 slices)(index) }
-      bundle.config.useUser generate { outBundle.user.subdivideIn(dataWidth slices)(idx) := mux_user.subdivideIn(dataWidth+1 slices)(index) }
+      (bundle.config.useUser && bundle.config.isUserPerByte) generate { outBundle.user.subdivideIn(dataWidth slices)(idx) := mux_user.subdivideIn(dataWidth+1 slices)(index) }
     }
+
+    (bundle.config.useUser && !bundle.config.isUserPerByte) generate { outBundle.user := bundle.user }
 
     bundle.config.useId generate { outBundle.id := bundle.id }
     bundle.config.useDest generate { outBundle.dest := bundle.dest }

--- a/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamWidthAdapter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/amba4/axis/Axi4StreamWidthAdapter.scala
@@ -21,6 +21,9 @@ object Axi4StreamWidthAdapter {
  */
 class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamConfig, compact: Boolean = false) extends Component {
 
+  require(!inConfig.useUser || !outConfig.useUser || inConfig.isUserPerByte == outConfig.isUserPerByte,
+    "Axi4StreamWidthAdapter input and output TUSER associations must match")
+
   val needsValid = !inConfig.useKeep || !compact
 
   /*
@@ -38,13 +41,22 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
 
   val MAX_SIZE = Math.max(inConfig.dataWidth*2, outConfig.dataWidth*2)
 
-  val buffer     = Reg(Axi4StreamBundle(inConfig.copy(dataWidth = MAX_SIZE, useLast = false, useId = false, useDest = false)))
+  val bufferConfig = inConfig.copy(
+    dataWidth = MAX_SIZE,
+    useLast = false,
+    useId = false,
+    useDest = false,
+    useUser = inConfig.useUser && inConfig.isUserPerByte
+  )
+  val buffer     = Reg(Axi4StreamBundle(bufferConfig))
   if (inConfig.useKeep) { buffer.keep.init(B(buffer.keep.bitsRange -> False)) }
   // Store valid byte bits OR wire in keep as it's functionally the same
   val bufferValid = if (needsValid) { Reg(Bits(MAX_SIZE bit)) init(0) } else buffer.keep
   val bufferLast = RegInit(False)
   val bufferId   = inConfig.useId   generate Reg(io.axis_s.id)
   val bufferDest = inConfig.useDest generate Reg(io.axis_s.dest)
+  // Beat-associated TUSER is transaction metadata, stored independently from the byte buffer.
+  val bufferUser = (inConfig.useUser && !inConfig.isUserPerByte) generate Reg(io.axis_s.user)
   val start = Reg(Bool()) init(True)
 
   // Maps inputs into buffer slices given the current fill level
@@ -58,13 +70,13 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
     val bufferExt_valid = needsValid generate { Bits(bufExtDataWidth bit) }
     val bufferExt_keep = inConfig.useKeep generate Bits(bufExtDataWidth bit)
     val bufferExt_strb = inConfig.useStrb generate Bits(bufExtDataWidth bit)
-    val bufferExt_user = inConfig.useUser generate Bits(bufExtDataWidth*bufUserWidth bit)
+    val bufferExt_user = (inConfig.useUser && inConfig.isUserPerByte) generate Bits(bufExtDataWidth*bufUserWidth bit)
 
     val invalidByte_data = B(0, 8 bit)
     val invalidByte_valid = False
     val invalidByte_keep = False
     val invalidByte_strb = inConfig.useStrb generate False
-    val invalidByte_user = inConfig.useUser generate B(0, bufUserWidth bit)
+    val invalidByte_user = (inConfig.useUser && inConfig.isUserPerByte) generate B(0, bufUserWidth bit)
 
 
     for (bufIdx <- 0 until bufExtDataWidth) {
@@ -73,7 +85,7 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
       val thisByte_valid = if (bufIdx < bufDataWidth) bufValid.subdivideIn(bufDataWidth slices)(bufIdx) else invalidByte_valid
       val thisByte_keep = inConfig.useKeep generate { if (bufIdx < bufDataWidth) bufBundle.keep.subdivideIn(bufDataWidth slices)(bufIdx) else invalidByte_keep }
       val thisByte_strb = inConfig.useStrb generate { if (bufIdx < bufDataWidth) bufBundle.strb.subdivideIn(bufDataWidth slices)(bufIdx) else invalidByte_strb }
-      val thisByte_user = inConfig.useUser generate { if (bufIdx < bufDataWidth) bufBundle.user.subdivideIn(bufDataWidth slices)(bufIdx) else invalidByte_user }
+      val thisByte_user = (inConfig.useUser && inConfig.isUserPerByte) generate { if (bufIdx < bufDataWidth) bufBundle.user.subdivideIn(bufDataWidth slices)(bufIdx) else invalidByte_user }
 
       val mapping = for(i <- 0 until bufExtDataWidth) yield {
         if (bufIdx-i >= inDataWidth) {
@@ -93,7 +105,7 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
       val muxInput_valid = needsValid generate { invalidByte_valid ## thisByte_valid ## B((0 until inDataWidth) -> True) }
       val muxInput_keep = inConfig.useKeep generate { invalidByte_keep ## thisByte_keep ## inBundle.keep }
       val muxInput_strb = inConfig.useStrb generate { invalidByte_strb ## thisByte_strb ## inBundle.strb }
-      val muxInput_user = inConfig.useUser generate { invalidByte_user ## thisByte_user ## inBundle.user }
+      val muxInput_user = (inConfig.useUser && inConfig.isUserPerByte) generate { invalidByte_user ## thisByte_user ## inBundle.user }
 
       val muxSelect = UInt(log2Up(inDataWidth+2) bit)
       when(doWrite) {
@@ -105,13 +117,13 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
       needsValid generate { bufferExt_valid.subdivideIn(bufExtDataWidth slices)(bufIdx) := muxInput_valid.subdivideIn(inDataWidth+2 slices)(muxSelect) }
       inConfig.useKeep generate { bufferExt_keep.subdivideIn(bufExtDataWidth slices)(bufIdx) := muxInput_keep.subdivideIn(inDataWidth+2 slices)(muxSelect) }
       inConfig.useStrb generate { bufferExt_strb.subdivideIn(bufExtDataWidth slices)(bufIdx) := muxInput_strb.subdivideIn(inDataWidth+2 slices)(muxSelect) }
-      inConfig.useUser generate { bufferExt_user.subdivideIn(bufExtDataWidth slices)(bufIdx) := muxInput_user.subdivideIn(inDataWidth+2 slices)(muxSelect) }
+      (inConfig.useUser && inConfig.isUserPerByte) generate { bufferExt_user.subdivideIn(bufExtDataWidth slices)(bufIdx) := muxInput_user.subdivideIn(inDataWidth+2 slices)(muxSelect) }
     }
-    val bundle = Axi4StreamBundle(inConfig.copy(dataWidth = bufExtDataWidth, useLast = false, useId = false, useDest = false))
+    val bundle = Axi4StreamBundle(bufBundle.config.copy(dataWidth = bufExtDataWidth))
     bundle.data := bufferExt_data
     inConfig.useKeep generate { bundle.keep := bufferExt_keep }
     inConfig.useStrb generate { bundle.strb := bufferExt_strb }
-    inConfig.useUser generate { bundle.user := bufferExt_user }
+    (inConfig.useUser && inConfig.isUserPerByte) generate { bundle.user := bufferExt_user }
 
     (bundle, bufferExt_valid)
   }
@@ -126,7 +138,7 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
     val buffer_valid = needsValid generate { Bits(outBufDataWidth bit) }
     val buffer_keep = inConfig.useKeep generate Bits(outBufDataWidth bit)
     val buffer_strb = inConfig.useStrb generate Bits(outBufDataWidth bit)
-    val buffer_user = inConfig.useUser generate Bits(outBufDataWidth*bufUserWidth bit)
+    val buffer_user = (inConfig.useUser && inConfig.isUserPerByte) generate Bits(outBufDataWidth*bufUserWidth bit)
 
     for (idx <- 0 until outBufDataWidth) {
       val readIdx = UInt(log2Up(bufDataWidth) bit)
@@ -140,14 +152,14 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
       needsValid generate { buffer_valid.subdivideIn(outBufDataWidth slices)(idx) := bufValid.subdivideIn(bufDataWidth slices)(readIdx) }
       inConfig.useKeep generate { buffer_keep.subdivideIn(outBufDataWidth slices)(idx) := bufBundle.keep.subdivideIn(bufDataWidth slices)(readIdx) }
       inConfig.useStrb generate { buffer_strb.subdivideIn(outBufDataWidth slices)(idx) := bufBundle.strb.subdivideIn(bufDataWidth slices)(readIdx) }
-      inConfig.useUser generate { buffer_user.subdivideIn(outBufDataWidth slices)(idx) := bufBundle.user.subdivideIn(bufDataWidth slices)(readIdx) }
+      (inConfig.useUser && inConfig.isUserPerByte) generate { buffer_user.subdivideIn(outBufDataWidth slices)(idx) := bufBundle.user.subdivideIn(bufDataWidth slices)(readIdx) }
     }
 
     val bundle = Axi4StreamBundle(bufBundle.config.copy(dataWidth = outBufDataWidth, useLast = false, useId = false, useDest = false))
     bundle.data := buffer_data
     inConfig.useKeep generate { bundle.keep := buffer_keep }
     inConfig.useStrb generate { bundle.strb := buffer_strb }
-    inConfig.useUser generate { bundle.user := buffer_user }
+    (inConfig.useUser && inConfig.isUserPerByte) generate { bundle.user := buffer_user }
 
     (bundle, buffer_valid)
   }
@@ -178,7 +190,10 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
   outStream.data  := buffer.data(outConfig.dataWidth*8-1 downto 0)
   outStream.config.useKeep generate { outStream.keep := buffer.keep(outConfig.dataWidth-1 downto 0) }
   outStream.config.useStrb generate { outStream.strb := buffer.strb(outConfig.dataWidth-1 downto 0) }
-  outStream.config.useUser generate { outStream.user := buffer.user(outConfig.dataWidth*outConfig.userWidth-1 downto 0) }
+  (outStream.config.useUser && outStream.config.isUserPerByte) generate {
+    outStream.user := buffer.user(outConfig.dataWidth*outConfig.userWidth-1 downto 0)
+  }
+  (outStream.config.useUser && !outStream.config.isUserPerByte) generate { outStream.user := bufferUser }
   inConfig.useId   generate { outStream.id := bufferId }
   inConfig.useDest generate { outStream.dest := bufferDest }
   outStream.config.useLast generate { outStream.last := bufferLast && !bufferValid(outConfig.dataWidth) }
@@ -210,6 +225,7 @@ class Axi4StreamWidthAdapter(inConfig: Axi4StreamConfig, outConfig: Axi4StreamCo
   when(start && inStage.fire) {
     inConfig.useId generate { bufferId := inStage.id }
     inConfig.useDest generate { bufferDest := inStage.dest }
+    (inConfig.useUser && !inConfig.isUserPerByte) generate { bufferUser := inStage.user }
   }
 
   val readWriteBuffer = doReadStage(writeBuffer, writeBufferValid, outConfig.dataWidth, outStream.fire)

--- a/tester/src/test/scala/spinal/lib/bus/amba4/axis/Axi4StreamTester.scala
+++ b/tester/src/test/scala/spinal/lib/bus/amba4/axis/Axi4StreamTester.scala
@@ -36,6 +36,69 @@ case class Axi4StreamFragmentFixture[T <: Data](config: Axi4StreamConfig, outTyp
 
 class Axi4StreamTester extends SpinalAnyFunSuite {
 
+  test("user width association") {
+    assert(Axi4StreamConfig(dataWidth = 4, useUser = true, userWidth = 2).userBitsWidth == 8)
+    assert(Axi4StreamConfig(dataWidth = 4, useUser = true, beatUserWidth = 3).userBitsWidth == 3)
+
+    val legacyPositionalConfig = Axi4StreamConfig(4, 5, 6, 2, true, true, true, true, true, true)
+    assert(legacyPositionalConfig.userBitsWidth == 8)
+
+    SpinalVerilog(new Component {
+      val laneSource = slave(Axi4Stream(Axi4StreamConfig(dataWidth = 4, useUser = true, userWidth = 2)))
+      val laneSink = master(Axi4Stream(Axi4StreamConfig(dataWidth = 4, useUser = true, userWidth = 2)))
+      val beatSource = slave(Axi4Stream(Axi4StreamConfig(dataWidth = 2, useUser = true, beatUserWidth = 2)))
+      val beatSink = master(Axi4Stream(Axi4StreamConfig(dataWidth = 4, useUser = true, beatUserWidth = 3)))
+      val compactSource = slave(Axi4Stream(Axi4StreamConfig(dataWidth = 4, useKeep = true, useUser = true, beatUserWidth = 3)))
+      val compactSink = master(Axi4Stream(compactSource.config))
+
+      laneSink << laneSource
+      beatSink << beatSource
+      compactSink << Axi4StreamSparseCompactor(compactSource)
+
+      assert(laneSource.user.getBitsWidth == 8)
+      assert(beatSource.user.getBitsWidth == 2)
+      assert(beatSink.user.getBitsWidth == 3)
+    })
+  }
+
+  test("user width configuration validation") {
+    assertThrows[IllegalArgumentException](
+      Axi4StreamConfig(dataWidth = 4, userWidth = 1, beatUserWidth = 1)
+    )
+    assertThrows[IllegalArgumentException](
+      Axi4StreamConfig(dataWidth = 4, beatUserWidth = 0)
+    )
+    assertThrows[IllegalArgumentException](
+      Axi4StreamConfig(dataWidth = 4, beatUserWidth = -2)
+    )
+  }
+
+  test("beat user width adapter support") {
+    val beatConfig = Axi4StreamConfig(dataWidth = 4, useUser = true, beatUserWidth = 3)
+
+    SpinalVerilog(new Axi4StreamSimpleWidthAdapter(beatConfig, outWidth = 4))
+    SpinalVerilog(new Axi4StreamSimpleWidthAdapter(beatConfig, outWidth = 2))
+    SpinalVerilog(new Axi4StreamSimpleWidthAdapter(beatConfig, outWidth = 8))
+    SpinalVerilog(new Axi4StreamWidthAdapter(beatConfig, beatConfig.copy(dataWidth = 2)))
+    SpinalVerilog(new Axi4StreamWidthAdapter(beatConfig, beatConfig.copy(dataWidth = 8)))
+    SpinalVerilog(new Axi4StreamWidthAdapter(
+      beatConfig.copy(useKeep = true, useLast = true),
+      beatConfig.copy(dataWidth = 8, useKeep = true, useLast = true),
+      compact = true
+    ))
+
+    val laneConfig = Axi4StreamConfig(dataWidth = 4, useUser = true, userWidth = 2)
+    SpinalVerilog(new Axi4StreamSimpleWidthAdapter(laneConfig, outWidth = 2))
+    SpinalVerilog(new Axi4StreamWidthAdapter(laneConfig, laneConfig.copy(dataWidth = 8)))
+
+    assertThrows[IllegalArgumentException](
+      SpinalVerilog(new Axi4StreamWidthAdapter(
+        Axi4StreamConfig(dataWidth = 4, useUser = true, userWidth = 1),
+        Axi4StreamConfig(dataWidth = 2, useUser = true, beatUserWidth = 3)
+      ))
+    )
+  }
+
   def duplexTest(dut: Axi4StreamEndianFixture[Bits]): Unit = {
     dut.clockDomain.forkStimulus(10)
 


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

Related to #1294 and #1252.

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

`Axi4StreamConfig.userWidth` currently defines TUSER bits per byte lane, so the generated width is `dataWidth * userWidth`. This does not support AXI4-Stream interfaces whose TUSER width is independent of `dataWidth`.

This PR adds the mutually exclusive `beatUserWidth` parameter:

```scala
Axi4StreamConfig(
  dataWidth = 8,
  useUser = true,
  beatUserWidth = 4
)
```

This generates a 4-bit TUSER signal. Existing `userWidth` configurations keep their current byte-associated behavior.

The implementation distinguishes the two modes:

- `userWidth`: TUSER is sliced and adapted with its corresponding byte lanes.
- `beatUserWidth`: TUSER is handled as one complete field.
- Direct connections require matching TUSER association modes.
- `Axi4StreamSparseCompactor` propagates beat-associated TUSER without lane reordering.
- Both width adapters support beat-associated TUSER.
- Downsizing propagates the value to the generated output beats.
- Upsizing retains the first value of the assembled transaction.
- `Axi4StreamWidthAdapter` stores it independently from the byte buffer, similarly to `TID` and `TDEST`.

When several input beats are merged, `beatUserWidth` is treated as transaction metadata and is expected to remain stable for that transaction.

Tests cover width calculation, configuration validation, direct assignment, sparse compaction, adapter downsizing, upsizing, compact mode, association mismatches, and regression elaboration for the existing byte-associated path.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

Existing `userWidth` configurations retain the same generated TUSER width and byte-lane adaptation logic.

When `beatUserWidth` is used:

- TUSER width is independent of `dataWidth`.
- Direct connections and sparse compaction propagate TUSER as one field.
- `Axi4StreamSimpleWidthAdapter` directly propagates or registers TUSER.
- `Axi4StreamWidthAdapter` generates an additional `beatUserWidth`-wide register for TUSER.

No RTL changes are expected when TUSER is disabled or the existing byte-associated mode is used.

# Checklist

- [x] Unit tests were added
- [x] API changes are or will be documented:
  - using Scaladoc comments: `/** */`
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD):  not required
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged): not required
