### PR TITLE
Fix fragment locking in stream fragment arbiters

### DIFF
--- a/lib/src/main/scala/spinal/lib/Fragment.scala
+++ b/lib/src/main/scala/spinal/lib/Fragment.scala
@@ -578,7 +578,7 @@ object StreamFragmentGenerator {
 
 object StreamFragmentArbiter {
    def apply[T <: Data](dataType: T)(inputs: Seq[Stream[Fragment[T]]]): Stream[Fragment[T]] = {
-    val arbiter = new StreamArbiter(Fragment(dataType), inputs.size, StreamArbiter.LowerFirst, StreamArbiter.TransactionLock)
+    val arbiter = new StreamArbiter(Fragment(dataType), inputs.size, StreamArbiter.LowerFirst, StreamArbiter.FragmentLock)
     (inputs, arbiter.io.inputs).zipped.foreach(_ >> _)
     arbiter.io.output
   }
@@ -586,7 +586,7 @@ object StreamFragmentArbiter {
 
 object StreamFragmentArbiterAndHeaderAdder {
   def apply[T <: Data](dataType: T)(inputs: Seq[Tuple2[Stream[Fragment[T]], T]]): Stream[Fragment[T]] = {
-    val arbiter = new StreamArbiter(Fragment(dataType), inputs.size, StreamArbiter.LowerFirst, StreamArbiter.TransactionLock)
+    val arbiter = new StreamArbiter(Fragment(dataType), inputs.size, StreamArbiter.LowerFirst, StreamArbiter.FragmentLock)
     (inputs, arbiter.io.inputs).zipped.foreach(_._1 >> _)
 
     val ret = Stream Fragment (dataType)

--- a/tester/src/test/scala/spinal/lib/SpinalSimStreamFragmentArbiterTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimStreamFragmentArbiterTester.scala
@@ -1,0 +1,112 @@
+package spinal.lib
+
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib.sim._
+import spinal.tester.SpinalSimFunSuite
+
+class SpinalSimStreamFragmentArbiterTester extends SpinalSimFunSuite {
+  test("arbiter") {
+    SimConfig
+      .compile {
+        new Component {
+          val inputs = Vec(slave(Stream(Fragment(UInt(10 bits)))), 2)
+          val output = master(Stream(Fragment(UInt(10 bits))))
+
+          output << StreamFragmentArbiter(UInt(10 bits))(inputs)
+        }
+      }
+      .doSimUntilVoid { dut =>
+        SimTimeout(100000)
+        dut.clockDomain.forkStimulus(10)
+
+        val scoreboards = Array.fill(2)(ScoreboardInOrder[(Int, Boolean)]())
+        dut.inputs.indices.foreach { source =>
+          val driver = StreamDriver(dut.inputs(source), dut.clockDomain) { p =>
+            val fragment = (source << 8) | simRandom.nextInt(256)
+            val last = simRandom.nextInt(5) == 0
+            p.fragment #= fragment
+            p.last #= last
+            scoreboards(source).pushRef((fragment, last))
+            true
+          }
+          driver.setFactor(if (source == 0) 0.5f else 1.0f)
+        }
+
+        val completedPackets = Array.fill(2)(0)
+        var activeSource = -1
+        StreamReadyRandomizer(dut.output, dut.clockDomain)
+        StreamMonitor(dut.output, dut.clockDomain) { p =>
+          val fragment = p.fragment.toInt
+          val last = p.last.toBoolean
+          val source = fragment >> 8
+          if (activeSource == -1) activeSource = source
+          assert(source == activeSource, s"Input $source interrupted a packet from input $activeSource")
+          scoreboards(source).pushDut((fragment, last))
+          if (last) {
+            completedPackets(source) += 1
+            activeSource = -1
+          }
+        }
+        dut.clockDomain.onSamplings {
+          if (completedPackets.forall(_ >= 50)) simSuccess()
+        }
+      }
+  }
+
+  test("arbiterAndHeaderAdder") {
+    SimConfig
+      .compile {
+        new Component {
+          val inputs = Vec(slave(Stream(Fragment(UInt(10 bits)))), 2)
+          val output = master(Stream(Fragment(UInt(10 bits))))
+
+          output << StreamFragmentArbiterAndHeaderAdder(UInt(10 bits))(
+            Seq(inputs(0) -> U(0x200, 10 bits), inputs(1) -> U(0x201, 10 bits))
+          )
+        }
+      }
+      .doSimUntilVoid { dut =>
+        SimTimeout(100000)
+        dut.clockDomain.forkStimulus(10)
+
+        val scoreboards = Array.fill(2)(ScoreboardInOrder[(Int, Boolean)]())
+        dut.inputs.indices.foreach { source =>
+          val driver = StreamDriver(dut.inputs(source), dut.clockDomain) { p =>
+            val fragment = (source << 8) | simRandom.nextInt(256)
+            val last = simRandom.nextInt(5) == 0
+            p.fragment #= fragment
+            p.last #= last
+            scoreboards(source).pushRef((fragment, last))
+            true
+          }
+          driver.setFactor(if (source == 0) 0.5f else 1.0f)
+        }
+
+        val completedPackets = Array.fill(2)(0)
+        var activeSource = -1
+        StreamReadyRandomizer(dut.output, dut.clockDomain)
+        StreamMonitor(dut.output, dut.clockDomain) { p =>
+          val fragment = p.fragment.toInt
+          val last = p.last.toBoolean
+          if (activeSource == -1) {
+            assert((fragment & 0x3fe) == 0x200, f"Expected a header, got 0x$fragment%03x")
+            assert(!last, "A header must not terminate a packet")
+            activeSource = fragment & 1
+          } else {
+            val source = fragment >> 8
+            assert(fragment < 0x200, f"Unexpected header 0x$fragment%03x inside a packet")
+            assert(source == activeSource, s"Input $source interrupted a packet from input $activeSource")
+            scoreboards(source).pushDut((fragment, last))
+            if (last) {
+              completedPackets(source) += 1
+              activeSource = -1
+            }
+          }
+        }
+        dut.clockDomain.onSamplings {
+          if (completedPackets.forall(_ >= 50)) simSuccess()
+        }
+      }
+  }
+}

--- a/tester/src/test/scala/spinal/lib/SpinalSimStreamFragmentArbiterTester.scala
+++ b/tester/src/test/scala/spinal/lib/SpinalSimStreamFragmentArbiterTester.scala
@@ -13,7 +13,7 @@ class SpinalSimStreamFragmentArbiterTester extends SpinalSimFunSuite {
           val inputs = Vec(slave(Stream(Fragment(UInt(10 bits)))), 2)
           val output = master(Stream(Fragment(UInt(10 bits))))
 
-          output << StreamFragmentArbiter(UInt(10 bits))(inputs)
+          output << StreamFragmentArbiter(UInt(10 bits))(inputs.toList)
         }
       }
       .doSimUntilVoid { dut =>


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->
`StreamFragmentArbiter` and `StreamFragmentArbiterAndHeaderAdder` currently use `StreamArbiter.TransactionLock`, which is not the correct locking policy for Fragment Streams.

This regression was introduced by the lock-policy API refactoring in #1856 (commit `de194930`). The previous `StreamArbiter.Lock.fragmentLock` was incorrectly migrated to `StreamArbiter.TransactionLock`. The corresponding policy in the new API is `StreamArbiter.FragmentLock`.

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->
- Changes `StreamFragmentArbiter` and `StreamFragmentArbiterAndHeaderAdder` to use `StreamArbiter.FragmentLock`.
- Adds randomized regression tests for both the regular fragment arbiter and the header-adder variant.

# Checklist

- [x] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
