### PR TITLE
Release assert for spelling deprecation

### DIFF
--- a/core/src/main/scala/spinal/core/BaseType.scala
+++ b/core/src/main/scala/spinal/core/BaseType.scala
@@ -131,7 +131,7 @@ abstract class BaseType extends Data with DeclarationStatement with StatementDou
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.15.0")
+  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.16.0")
   def hasAssignement : Boolean = hasAssignment
 
   def hasAssignment : Boolean = !this.dlcIsEmpty

--- a/core/src/main/scala/spinal/core/Data.scala
+++ b/core/src/main/scala/spinal/core/Data.scala
@@ -663,7 +663,7 @@ trait Data extends ContextUser with NameableByComponent with Assignable with Spi
 
 
   // TODO enable deprecation
-  //@deprecated("use randBoot() instead", since = "1.15.0")
+  //@deprecated("use randBoot() instead", since = "1.16.0")
   def randBoot(u : Unit): this.type = randBoot()
   
   /**

--- a/core/src/main/scala/spinal/core/Trait.scala
+++ b/core/src/main/scala/spinal/core/Trait.scala
@@ -114,7 +114,7 @@ class GlobalData(val config : SpinalConfig) {
 
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.15.0")
+  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.16.0")
   def allocateAlgoIncrementale(): Int = {
     allocateAlgoIncremental()
   }

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitter.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitter.scala
@@ -93,7 +93,7 @@ abstract class ComponentEmitter {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.15.0")
+  //@deprecated("Use correctly spelled 'allocateAlgoIncremental' instead", since = "1.16.0")
   def allocateAlgoIncrementale(): Int = {
     allocateAlgoIncremental()
   }
@@ -105,7 +105,7 @@ abstract class ComponentEmitter {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'isSubComponentInputBound' instead", since = "1.15.0")
+  //@deprecated("Use correctly spelled 'isSubComponentInputBound' instead", since = "1.16.0")
   def isSubComponentInputBinded(data: BaseType) = {
     isSubComponentInputBound(data)
   }

--- a/core/src/main/scala/spinal/core/sim/package.scala
+++ b/core/src/main/scala/spinal/core/sim/package.scala
@@ -313,7 +313,7 @@ package object sim {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.15.0")
+  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.16.0")
   def periodicaly(delay: Long)(body: => Unit): Unit = {
     periodically(delay)(body)
   }
@@ -327,7 +327,7 @@ package object sim {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.15.0")
+  //@deprecated("Use correctly spelled 'periodically' instead", since = "1.16.0")
   def periodicaly(delay : TimeNumber)(body: => Unit): Unit = {
     periodically(delay)(body)
   }

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
@@ -37,7 +37,7 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
     def acquire(param : Int, getter : M2sTransfers => SizeRange): Unit = acquireImpl(param, getter(ipEmits), getter(st))
 
     // TODO enable deprecation
-    //@deprecated("Use correctly spelled 'acquire' instead", since = "1.15.0")
+    //@deprecated("Use correctly spelled 'acquire' instead", since = "1.16.0")
     def aquire(param : Int, getter : M2sTransfers => SizeRange): Unit = acquire(param, getter)
 
     def acquireImpl(param : Int, is: SizeRange, os: SizeRange): Unit ={
@@ -49,7 +49,7 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
     }
 
     // TODO enable deprecation
-    //@deprecated("Use correctly spelled 'acquireImpl' instead", since = "1.15.0")
+    //@deprecated("Use correctly spelled 'acquireImpl' instead", since = "1.16.0")
     def aquireImpl(param : Int, is: SizeRange, os: SizeRange): Unit = acquireImpl(param, is, os)
 
     simple(0, _.putFull)

--- a/lib/src/main/scala/spinal/lib/dsptool/FixData.scala
+++ b/lib/src/main/scala/spinal/lib/dsptool/FixData.scala
@@ -95,7 +95,7 @@ case class FixData(raw: Double,
   def asLongPositive: Long = if(value < 0) q.capcity.toLong + this.asLong else this.asLong
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.15.0")
+  //@deprecated("Use correctly spelled 'hasAssignment' instead", since = "1.16.0")
   def asLongPostive: Long = asLongPositive
 
   def hex: String = s"%${q.alignHex}s".format(this.asLongPostive.toHexString).replace(' ','0')

--- a/lib/src/main/scala/spinal/lib/sim/Misc.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Misc.scala
@@ -131,7 +131,7 @@ case class SparseMemory(val seed : Long = simRandom.nextLong(), var randOffset :
   val content = mutable.HashMap[Long, Array[Byte]]()
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'getElseAllocate' instead", since = "1.15.0")
+  //@deprecated("Use correctly spelled 'getElseAllocate' instead", since = "1.16.0")
   def getElseAlocate(idx : Long) = getElseAllocate(idx)
 
   def getElseAllocate(idx : Long) = {

--- a/lib/src/main/scala/spinal/lib/sim/Scoreboard.scala
+++ b/lib/src/main/scala/spinal/lib/sim/Scoreboard.scala
@@ -60,7 +60,7 @@ class ScoreboardInOrder[T]() {
   }
 
   // TODO enable deprecation
-  //@deprecated("Use correctly spelled 'checkEmptiness' instead", since = "1.15.0")
+  //@deprecated("Use correctly spelled 'checkEmptiness' instead", since = "1.16.0")
   def checkEmptyness(): Unit = checkEmptiness
 
   def checkEmptiness(): Unit ={

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -3,6 +3,7 @@ import sourcecode.File
 import sbt.io.Path
 import scala.collection.JavaConverters._
 
+/** Version configuration for sbt builds.*/
 object SpinalVersion {  
   val currentFile = new java.io.File(sourcecode.File())
   val configFilePath = currentFile.getParent + Path.sep + "version.conf"
@@ -23,4 +24,7 @@ object SpinalVersion {
   val debugger    = all
   val demo        = all
   val tester      = all
+
+  assert(major != "1.16.0", "when releasing 1.16.0, uncomment all '//@deprecated'"+
+        " spelling deprecation and remove this test")
 }

--- a/project/version.conf
+++ b/project/version.conf
@@ -1,3 +1,5 @@
+// Shared version configuration for sbt and mill
+
 compilers = ["2.12.18", "2.13.12"]
 compilerIsRC = false
 


### PR DESCRIPTION
Last release the uncommenting of spelling deprecation slip through the process.

So this PR add a assert to remind of this.

# Impact on code generation

None

