### PR TITLE
Adding support for Atomic op-codes.

### DIFF
--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Bus.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Bus.scala
@@ -14,18 +14,25 @@ import scala.collection.mutable.ArrayBuffer
 object Opcode extends AreaRoot{
   val A = new SpinalEnum{
     // If you extends that list, don't forget to update the tilelink Decoder
-    val PUT_FULL_DATA, PUT_PARTIAL_DATA, GET, ACQUIRE_BLOCK, ACQUIRE_PERM = newElement()
+    val PUT_FULL_DATA, PUT_PARTIAL_DATA, ARITHMETIC_DATA, LOGICAL_DATA, GET, ACQUIRE_BLOCK, ACQUIRE_PERM = newElement()
     defaultEncoding = SpinalEnumEncoding("enc")(
       GET -> 4,
       PUT_FULL_DATA -> 0,
       PUT_PARTIAL_DATA -> 1,
+      ARITHMETIC_DATA -> 2,
+      LOGICAL_DATA -> 3,
       ACQUIRE_BLOCK -> 6,
       ACQUIRE_PERM -> 7
     )
     def isGetPut(c : C) = List(GET, PUT_FULL_DATA, PUT_PARTIAL_DATA).map(c === _).orR
     def isPut(c : C) = List(PUT_FULL_DATA, PUT_PARTIAL_DATA).map(c === _).orR
     def isGet(c : C) = List(GET).map(c === _).orR
+    def isArithmetic(c : C) = c === ARITHMETIC_DATA
+    def isLogical(c : C) = c === LOGICAL_DATA
+    def isAtomic(c : C) = List(ARITHMETIC_DATA, LOGICAL_DATA).map(c === _).orR
     def isAcquire(c : C) = List(ACQUIRE_BLOCK, ACQUIRE_PERM).map(c === _).orR
+    def withData(c : C) = List(PUT_FULL_DATA, PUT_PARTIAL_DATA, ARITHMETIC_DATA, LOGICAL_DATA).map(c === _).orR
+    def returnsData(c : C) = List(GET, ARITHMETIC_DATA, LOGICAL_DATA, ACQUIRE_BLOCK).map(c === _).orR
   }
 
   val B = new SpinalEnum{
@@ -66,6 +73,21 @@ object Opcode extends AreaRoot{
 }
 
 object Param{
+  val Arithmetic = new Area {
+    val MIN  = 0
+    val MAX  = 1
+    val MINU = 2
+    val MAXU = 3
+    val ADD  = 4
+  }
+
+  val Logical = new Area {
+    val XOR  = 0
+    val OR   = 1
+    val AND  = 2
+    val SWAP = 3
+  }
+
   val Hint = new Area{
     val NONE = 0
     val NO_ALLOCATE_ON_MISS = 2
@@ -241,7 +263,7 @@ case class ChannelA(override val p : BusParameter) extends BusFragment(p) {
   val corrupt = p.withDataA generate Bool()
   val debugId = DebugId()
 
-  override def withBeats = p.withDataA.mux(List(Opcode.A.PUT_FULL_DATA(), Opcode.A.PUT_PARTIAL_DATA()).sContains(opcode), False)
+  override def withBeats = p.withDataA.mux(Opcode.A.withData(opcode), False)
   def asNoData() : this.type = p.withDataA match {
     case false => CombInit(this)
     case true => {
@@ -263,7 +285,7 @@ case class ChannelA(override val p : BusParameter) extends BusFragment(p) {
     val spec = for(i <- 0 until 1 << p.sizeWidth) yield i -> B((BigInt(1) << (1 << i))-1 & ((BigInt(1) << p.dataBytes)-1), p.dataBytes bits)
     val fromSize = size.muxList(spec)
     val shifted = fromSize |<< address(0, p.dataBytesLog2Up bits)
-    shifted & this.mask.orMask(!Opcode.A.isPut(opcode))
+    shifted & this.mask.orMask(!Opcode.A.withData(opcode))
   }
 
   def weakAssignFrom(m : ChannelA): Unit ={

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Decoder.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Decoder.scala
@@ -58,6 +58,8 @@ case class Decoder(upNode : NodeParameters,
     op(_.get.some, 4)
     op(_.putFull.some, 0)
     op(_.putPartial.some, 1)
+    op(_.arithmetic.some, 2)
+    op(_.logical.some, 3)
     op(e => e.acquireB.some || e.acquireT.some, 6)
     op(e => e.acquireB.some || e.acquireT.some, 7)
     val terms = ArrayBuffer[Masked]()

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/ErrorSlave.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/ErrorSlave.scala
@@ -15,6 +15,8 @@ class ErrorSlave(bp : BusParameter) extends Component{
     io.bus.d.opcode := buffer.opcode mux(
       Opcode.A.PUT_FULL_DATA    -> Opcode.D.ACCESS_ACK(),
       Opcode.A.PUT_PARTIAL_DATA -> Opcode.D.ACCESS_ACK(),
+      Opcode.A.ARITHMETIC_DATA  -> Opcode.D.ACCESS_ACK_DATA(),
+      Opcode.A.LOGICAL_DATA     -> Opcode.D.ACCESS_ACK_DATA(),
       Opcode.A.GET              -> Opcode.D.ACCESS_ACK_DATA(),
       Opcode.A.ACQUIRE_BLOCK    -> Opcode.D.GRANT_DATA(),
       Opcode.A.ACQUIRE_PERM     -> Opcode.D.GRANT()

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/Master.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/Master.scala
@@ -21,6 +21,8 @@ case class M2sTransfers(acquireT     : SizeRange = SizeRange.none,
   def allowA(opcode : Opcode.A.E)  : Boolean = opcode match {
     case Opcode.A.PUT_FULL_DATA => putFull.some
     case Opcode.A.PUT_PARTIAL_DATA => putPartial.some
+    case Opcode.A.ARITHMETIC_DATA => arithmetic.some
+    case Opcode.A.LOGICAL_DATA => logical.some
     case Opcode.A.GET => get.some
     case Opcode.A.ACQUIRE_BLOCK => withBCE
     case Opcode.A.ACQUIRE_PERM  => withBCE
@@ -29,6 +31,8 @@ case class M2sTransfers(acquireT     : SizeRange = SizeRange.none,
   def allow(opcode : Any) : Boolean = opcode match{
     case Opcode.A.PUT_FULL_DATA => putFull.some
     case Opcode.A.PUT_PARTIAL_DATA => putPartial.some
+    case Opcode.A.ARITHMETIC_DATA => arithmetic.some
+    case Opcode.A.LOGICAL_DATA => logical.some
     case Opcode.A.GET => get.some
     case Opcode.A.ACQUIRE_BLOCK => withBCE
     case Opcode.A.ACQUIRE_PERM  => withBCE
@@ -122,6 +126,8 @@ case class M2sTransfers(acquireT     : SizeRange = SizeRange.none,
       Opcode.A.GET              -> Bool(get.some),
       Opcode.A.PUT_FULL_DATA    -> Bool(putFull.some),
       Opcode.A.PUT_PARTIAL_DATA -> Bool(putPartial.some),
+      Opcode.A.ARITHMETIC_DATA  -> Bool(arithmetic.some),
+      Opcode.A.LOGICAL_DATA     -> Bool(logical.some),
       Opcode.A.ACQUIRE_BLOCK    -> Bool(acquireB.some || acquireT.some),
       Opcode.A.ACQUIRE_PERM     -> Bool(acquireB.some || acquireT.some)
     )
@@ -274,5 +280,4 @@ case class M2sSupport(transfers : M2sTransfers,
   def withAddressWidth(w: Int): M2sSupport = copy(addressWidth = w)
   def dataBytes = dataWidth/8
 }
-
 

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/TransferFilter.scala
@@ -85,6 +85,8 @@ class TransferFilter(unp : NodeParameters, dnp : NodeParameters, spec : Seq[Mapp
     io.up.d.opcode := opcode.mux(
       Opcode.A.PUT_FULL_DATA -> Opcode.D.ACCESS_ACK(),
       Opcode.A.PUT_PARTIAL_DATA -> Opcode.D.ACCESS_ACK(),
+      Opcode.A.ARITHMETIC_DATA -> Opcode.D.ACCESS_ACK_DATA(),
+      Opcode.A.LOGICAL_DATA -> Opcode.D.ACCESS_ACK_DATA(),
       Opcode.A.GET -> Opcode.D.ACCESS_ACK_DATA(),
       Opcode.A.ACQUIRE_BLOCK -> Opcode.D.GRANT_DATA(),
       Opcode.A.ACQUIRE_PERM -> Opcode.D.GRANT()

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Checker.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Checker.scala
@@ -95,12 +95,51 @@ class Checker(p : BusParameter, mappings : Seq[Endpoint], checkMapping : Boolean
     }
   }
 
+  private def unsignedFromLittleEndian(bytes: Array[Byte]): BigInt = BigInt(1, bytes.reverse)
+  private def signedFromLittleEndian(bytes: Array[Byte]): BigInt = {
+    val unsigned = unsignedFromLittleEndian(bytes)
+    val bits = bytes.length*8
+    if(unsigned.testBit(bits-1)) unsigned - (BigInt(1) << bits) else unsigned
+  }
+  private def littleEndianFrom(value: BigInt, byteCount: Int): Array[Byte] = {
+    val mask = (BigInt(1) << (byteCount*8)) - 1
+    val clipped = value & mask
+    Array.tabulate(byteCount)(i => ((clipped >> (i*8)) & 0xFF).toByte)
+  }
+  private def atomicOperand(a: TransactionA): Array[Byte] = {
+    val offset = (a.address.toLong & (a.data.length-1)).toInt
+    Array.tabulate(a.bytes)(i => a.data(offset + i))
+  }
+  private def atomicResult(a: TransactionA, oldBytes: Array[Byte]): Array[Byte] = {
+    val operandBytes = atomicOperand(a)
+    val bits = a.bytes*8
+    val mask = (BigInt(1) << bits) - 1
+    val oldU = unsignedFromLittleEndian(oldBytes)
+    val rhsU = unsignedFromLittleEndian(operandBytes)
+    val next = a.opcode match {
+      case Opcode.A.ARITHMETIC_DATA => a.param match {
+        case Param.Arithmetic.MIN  => if(signedFromLittleEndian(oldBytes) < signedFromLittleEndian(operandBytes)) oldU else rhsU
+        case Param.Arithmetic.MAX  => if(signedFromLittleEndian(oldBytes) > signedFromLittleEndian(operandBytes)) oldU else rhsU
+        case Param.Arithmetic.MINU => oldU min rhsU
+        case Param.Arithmetic.MAXU => oldU max rhsU
+        case Param.Arithmetic.ADD  => oldU + rhsU
+      }
+      case Opcode.A.LOGICAL_DATA => a.param match {
+        case Param.Logical.XOR  => oldU ^ rhsU
+        case Param.Logical.OR   => oldU | rhsU
+        case Param.Logical.AND  => oldU & rhsU
+        case Param.Logical.SWAP => rhsU
+      }
+    }
+    littleEndianFrom(next & mask, a.bytes)
+  }
+
   override def onA(a: TransactionA) = {
     assert(inflightA(a.source) == null)
     assert((a.address & (a.bytes-1)) == 0, "Unaligned address :(")
 
     a.opcode match {
-      case Opcode.A.PUT_FULL_DATA | Opcode.A.PUT_PARTIAL_DATA | Opcode.A.GET=>
+      case Opcode.A.PUT_FULL_DATA | Opcode.A.PUT_PARTIAL_DATA | Opcode.A.ARITHMETIC_DATA | Opcode.A.LOGICAL_DATA | Opcode.A.GET=>
       case Opcode.A.ACQUIRE_BLOCK | Opcode.A.ACQUIRE_PERM =>
     }
 
@@ -130,6 +169,10 @@ class Checker(p : BusParameter, mappings : Seq[Endpoint], checkMapping : Boolean
             case Opcode.A.PUT_FULL_DATA=> {
               assert(a.mask.forall(v => v))
               mem.write(address, a.data, a.mask)
+            }
+            case Opcode.A.ARITHMETIC_DATA | Opcode.A.LOGICAL_DATA => {
+              ctx.ref = mem.readBytes(address, o.bytes)
+              mem.write(address, atomicResult(a, ctx.ref))
             }
             case Opcode.A.ACQUIRE_BLOCK => {
               ctx.ref = mem.readBytes(address, o.bytes)

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MasterAgent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MasterAgent.scala
@@ -198,6 +198,35 @@ class MasterAgent (val bus : Bus, val cd : ClockDomain)(implicit idAllocator: Id
     d
   }
 
+  private def atomic(source : Int, address : Long, opcode : Opcode.A.E, param : Int, data : Seq[Byte]) : TransactionD = {
+    val bytes = data.size
+    val debugId = allocateDebugId()
+    val a = TransactionA()
+    a.opcode  = opcode
+    a.param   = param
+    a.size    = log2Up(bytes)
+    a.source  = source
+    a.address = address
+    a.debugId = debugId
+    a.data = data.toArray
+    a.mask = Array.fill(data.size)(true)
+    driver.scheduleA(a)
+
+    val d = waitAtoD(source)
+    assert(d.opcode == Opcode.D.ACCESS_ACK_DATA, s"Unexpected transaction on $bus")
+    assert(d.bytes == bytes, s"Unexpected transaction on $bus")
+    freeDebugId(debugId)
+    d
+  }
+
+  def arithmeticData(source : Int, address : Long, param : Int, data : Seq[Byte]) : TransactionD = {
+    atomic(source, address, Opcode.A.ARITHMETIC_DATA, param, data)
+  }
+
+  def logicalData(source : Int, address : Long, param : Int, data : Seq[Byte]) : TransactionD = {
+    atomic(source, address, Opcode.A.LOGICAL_DATA, param, data)
+  }
+
 
 
   def probeAck(source : Int,

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MemoryAgent.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/MemoryAgent.scala
@@ -79,6 +79,45 @@ class MemoryAgent(bus: Bus,
   }
   def checkAddress(address : Long) = true
 
+  private def unsignedFromLittleEndian(bytes: Array[Byte]): BigInt = BigInt(1, bytes.reverse)
+  private def signedFromLittleEndian(bytes: Array[Byte]): BigInt = {
+    val unsigned = unsignedFromLittleEndian(bytes)
+    val bits = bytes.length*8
+    if(unsigned.testBit(bits-1)) unsigned - (BigInt(1) << bits) else unsigned
+  }
+  private def littleEndianFrom(value: BigInt, byteCount: Int): Array[Byte] = {
+    val mask = (BigInt(1) << (byteCount*8)) - 1
+    val clipped = value & mask
+    Array.tabulate(byteCount)(i => ((clipped >> (i*8)) & 0xFF).toByte)
+  }
+  private def atomicOperand(a: TransactionA): Array[Byte] = {
+    val offset = (a.address.toLong & (a.data.length-1)).toInt
+    Array.tabulate(a.bytes)(i => a.data(offset + i))
+  }
+  private def atomicResult(a: TransactionA, oldBytes: Array[Byte]): Array[Byte] = {
+    val operandBytes = atomicOperand(a)
+    val bits = a.bytes*8
+    val mask = (BigInt(1) << bits) - 1
+    val oldU = unsignedFromLittleEndian(oldBytes)
+    val rhsU = unsignedFromLittleEndian(operandBytes)
+    val next = a.opcode match {
+      case Opcode.A.ARITHMETIC_DATA => a.param match {
+        case Param.Arithmetic.MIN  => if(signedFromLittleEndian(oldBytes) < signedFromLittleEndian(operandBytes)) oldU else rhsU
+        case Param.Arithmetic.MAX  => if(signedFromLittleEndian(oldBytes) > signedFromLittleEndian(operandBytes)) oldU else rhsU
+        case Param.Arithmetic.MINU => oldU min rhsU
+        case Param.Arithmetic.MAXU => oldU max rhsU
+        case Param.Arithmetic.ADD  => oldU + rhsU
+      }
+      case Opcode.A.LOGICAL_DATA => a.param match {
+        case Param.Logical.XOR  => oldU ^ rhsU
+        case Param.Logical.OR   => oldU | rhsU
+        case Param.Logical.AND  => oldU & rhsU
+        case Param.Logical.SWAP => rhsU
+      }
+    }
+    littleEndianFrom(next & mask, a.bytes)
+  }
+
   override def onA(a: TransactionA) = {
     if(bus.p.withBCE && simRandom.nextFloat() < randomProberFactor) fork {
       cd.waitSampling(simRandom.nextInt(randomProberDelayMax))
@@ -117,6 +156,21 @@ class MemoryAgent(bus: Bus,
           val d = TransactionD(a)
           d.opcode = Opcode.D.ACCESS_ACK
           d.denied = !ok
+          driver.scheduleD(d)
+        }
+        case Opcode.A.ARITHMETIC_DATA | Opcode.A.LOGICAL_DATA => {
+          handleCoherency(a, Param.Cap.toN)
+          if(idCallback != null) idCallback.call(a.debugId)(new OrderingArgs(0, a.bytes))
+          val d = TransactionD(a)
+          d.opcode = Opcode.D.ACCESS_ACK_DATA
+          d.denied = !ok
+          if(ok) {
+            val old = mem.readBytes(a.address.toLong, a.bytes)
+            mem.write(a.address.toLong, atomicResult(a, old))
+            d.data = old
+          } else {
+            d.data = Array.fill(a.bytes)(simRandom.nextInt().toByte)
+          }
           driver.scheduleD(d)
         }
         case Opcode.A.ACQUIRE_BLOCK => {

--- a/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Transactions.scala
+++ b/lib/src/main/scala/spinal/lib/bus/tilelink/sim/Transactions.scala
@@ -148,7 +148,7 @@ class TransactionA extends TransactionABCD{
   }
 
   override def withData = opcode match {
-    case Opcode.A.PUT_FULL_DATA | Opcode.A.PUT_PARTIAL_DATA => true
+    case Opcode.A.PUT_FULL_DATA | Opcode.A.PUT_PARTIAL_DATA | Opcode.A.ARITHMETIC_DATA | Opcode.A.LOGICAL_DATA => true
     case _ => false
   }
   override def withMask = withData
@@ -377,6 +377,9 @@ class TransactionD extends TransactionABCD{
           }
           case Opcode.A.PUT_FULL_DATA | Opcode.A.PUT_PARTIAL_DATA => {
             opcode == Opcode.D.ACCESS_ACK
+          }
+          case Opcode.A.ARITHMETIC_DATA | Opcode.A.LOGICAL_DATA => {
+            opcode == Opcode.D.ACCESS_ACK_DATA
           }
           case Opcode.A.ACQUIRE_BLOCK => {
             opcode == Opcode.D.GRANT || opcode == Opcode.D.GRANT_DATA


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

This patch adds support for the TileLink Atomic operations to the channelA definitions so that they can be used with custom TileLink slave components. This should be transparent to existing SpinalHDL tilelink components.

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

This should have minimal effect on code generation as it is mostly extending enums.

# Checklist
<!--
- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been20merged)?
--> 

No new unit tests have been added, however this code has been used with a new component which supports these new operations and integrates the original tilelink.Cache as an LLC and several other tilelink/AXI bridge components. 